### PR TITLE
docs(skill): add PR and issue closeout guidance

### DIFF
--- a/.agents/skills/task-execution/SKILL.md
+++ b/.agents/skills/task-execution/SKILL.md
@@ -21,9 +21,10 @@ Follow a single repository-local execution workflow for coding tasks. Keep issue
 8. Implement.
 9. Self-evaluate against the reviewed requirements, design, and plan.
 10. Run tests or other validation and report any unverified items.
-11. Promote durable decisions back into GitHub Issues or `docs/`.
-12. Record any repeated friction, missing guidance, or repeated manual wording as a candidate improvement for this skill.
-13. Move completed task artifacts into `tasks/archived/`.
+11. Finalize delivery with a merge path and Issue closeout method.
+12. Promote durable decisions back into GitHub Issues or `docs/`.
+13. Record any repeated friction, missing guidance, or repeated manual wording as a candidate improvement for this skill.
+14. Move completed task artifacts into `tasks/archived/`.
 
 ## Task Artifacts
 
@@ -50,6 +51,12 @@ Follow a single repository-local execution workflow for coding tasks. Keep issue
 - Prefer updating the skill only when the same issue recurs or when the gap clearly affects execution quality.
 - Put workflow changes in `SKILL.md`.
 - Put detailed review criteria or decision rules in `references/`.
+
+## Delivery and Issue Closeout
+
+- Prefer PR-based delivery, including self-review cases.
+- Use `Closes #<issue-number>` in the PR description when applicable so Issue closeout is automated on merge.
+- If direct push to `main` is used, record that choice and close the Issue manually.
 
 ## References
 

--- a/.agents/skills/task-execution/references/planning-review.md
+++ b/.agents/skills/task-execution/references/planning-review.md
@@ -10,6 +10,7 @@ Review the implementation plan before starting execution.
 - Are risks, unknowns, and deferred items listed?
 - Is the task breakdown small enough to track progress?
 - Are prerequisites complete?
+- Is the merge path and Issue closeout method explicit?
 
 ## Passing Conditions
 
@@ -20,3 +21,4 @@ Do not move forward until all of these are true:
 - Risks, unknowns, and deferred items are listed.
 - The task breakdown is small enough to execute without losing track of progress.
 - No missing prerequisite remains that would stop implementation after work begins.
+- The merge path and Issue closeout method are explicit.


### PR DESCRIPTION
## Summary
- Add explicit delivery closeout step (merge path + issue closeout method)
- Prefer PR-based delivery and document direct-push fallback
- Extend planning review checklist/passing conditions with closeout explicitness
