### PR TITLE
feat(edge): configure local-ca TLS reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Local TLS materials for edge (generated per environment)
+infra/certs/*.crt
+infra/certs/*.key
+infra/certs/*.pem
+infra/certs/*.csr
+infra/certs/*.srl
+infra/certs/*.p12
+infra/certs/*.der
+
+# Keep repository placeholders/docs
+!infra/certs/.gitkeep
+!infra/certs/README.md

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,4 +1,11 @@
-# Placeholder reverse proxy for Issue #2 bootstrap.
+# Issue #3: edge HTTPS termination and reverse proxy.
+# `edge.crt` / `edge.key` must be issued by a local CA and mounted at /certs.
+
 :80 {
-    reverse_proxy codexbox:8080
+	redir https://{host}{uri} permanent
+}
+
+:443 {
+	tls /certs/edge.crt /certs/edge.key
+	reverse_proxy codexbox:8080
 }

--- a/infra/certs/README.md
+++ b/infra/certs/README.md
@@ -1,0 +1,23 @@
+# Local CA Certificate Files for `edge`
+
+## Operational assumptions
+- TLS terminates at the `edge` (Caddy) container.
+- Certificates are issued by a local CA that clients trust.
+- Only the server certificate and private key are mounted into the container.
+
+## Required files
+Place these files in this directory:
+- `edge.crt`: server certificate issued by your local CA
+- `edge.key`: private key for `edge.crt`
+
+`infra/Caddyfile` expects these files at `/certs/edge.crt` and `/certs/edge.key`.
+
+## Hostname and SAN guidance
+- Issue the server certificate for the LAN hostname users will open in browser
+  (for example `codexbox.home.arpa`).
+- Ensure the certificate SAN contains every hostname you intend to use.
+
+## Security notes
+- Do not place the CA private key in this repository.
+- Keep the CA key outside this directory and outside Docker mounts.
+- Treat `edge.key` as secret material.

--- a/tasks/archived/2026-03-05-issue-3-edge-tls-proxy/design.md
+++ b/tasks/archived/2026-03-05-issue-3-edge-tls-proxy/design.md
@@ -1,0 +1,19 @@
+# Issue 3 Design
+
+## Overview
+- Configure `edge` in Caddy to redirect HTTP to HTTPS and terminate TLS on `:443` using certificate/key files mounted from `infra/certs`.
+- Proxy all browser traffic from `edge` to internal `codexbox:8080`.
+
+## Main Decisions
+- Use explicit TLS file paths (`/certs/edge.crt` and `/certs/edge.key`) to enforce local certificate usage.
+- Keep site addressing host-agnostic (`:443`) so deployment hostname can vary as long as cert SAN matches the client hostname.
+- Keep `codexbox` reachable only through internal compose networking (`expose`, no `ports`).
+- Add cert operation guidance in-repo and ignore generated cert/key artifacts in Git.
+
+## Impact
+- Replaces the bootstrap HTTP-only edge config with TLS-enabled reverse proxy behavior.
+- Clarifies local CA certificate placement and reduces accidental key commit risk.
+
+## Risks
+- Certificate CN/SAN mismatch will cause browser trust warnings.
+  - Mitigation: document hostname/SAN requirements in cert README.

--- a/tasks/archived/2026-03-05-issue-3-edge-tls-proxy/plan.md
+++ b/tasks/archived/2026-03-05-issue-3-edge-tls-proxy/plan.md
@@ -1,0 +1,21 @@
+# Issue 3 Plan
+
+## TDD
+- TDD: no
+- Rationale: This issue is infrastructure/configuration work where validation is compose config resolution and Caddy config parsing rather than behavior-first unit tests.
+
+## Steps
+- [x] Write requirements and design notes for Issue #3.
+- [x] Update `infra/Caddyfile` for HTTP->HTTPS redirect and TLS reverse proxy.
+- [x] Add `infra/certs/README.md` with local-CA certificate placement guidance.
+- [x] Add `.gitignore` rules for generated cert/key materials under `infra/certs`.
+- [x] Validate with `docker compose config` and Caddy config parse (`caddy adapt`).
+- [x] Self-check against acceptance criteria and summarize closeout path.
+
+## Risks and Unknowns
+- Runtime TLS cannot be fully proven without an actual local-CA cert pair and trusted client.
+- Basic auth is recommended in architecture guidance but not explicitly required by Issue #3 acceptance criteria.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #3` in PR description.

--- a/tasks/archived/2026-03-05-issue-3-edge-tls-proxy/requirements.md
+++ b/tasks/archived/2026-03-05-issue-3-edge-tls-proxy/requirements.md
@@ -1,0 +1,27 @@
+# Issue 3 Requirements
+
+## Goal
+- Configure `edge` to terminate HTTPS with a local-CA-issued certificate and reverse proxy traffic to `codexbox`.
+
+## In Scope
+- Replace the placeholder Caddy config with HTTPS/TLS and reverse proxy behavior.
+- Keep `codexbox` non-public (internal-only service exposure).
+- Document expected certificate files for local CA operation.
+
+## Out of Scope
+- Final production authentication policy beyond this issue scope.
+- DNS/router setup and client trust-store distribution steps.
+- WebUI backend feature work.
+
+## Acceptance Criteria
+- Caddy config exists.
+- HTTPS is enabled with local-CA-issued certs.
+- `codexbox` is not directly published.
+
+## Constraints and Assumptions
+- Follow `docs/codex-webui-docker-lan-design.md`.
+- Use mounted cert files under `infra/certs`.
+- Keep changes minimal and focused on Issue #3.
+
+## Open Questions
+- None blocking for Issue #3.


### PR DESCRIPTION
## Summary
- Replace placeholder `infra/Caddyfile` with TLS termination + reverse proxy config
- Add HTTP to HTTPS redirect at edge (`:80` -> `:443`)
- Configure TLS to use local-CA-issued cert files at `/certs/edge.crt` and `/certs/edge.key`
- Add cert placement/security guidance in `infra/certs/README.md`
- Add `.gitignore` rules to prevent accidental commit of generated cert/key material
- Archive Issue #3 task artifacts under `tasks/archived/...`

## Validation
- `docker compose config`
- `cat infra/Caddyfile | docker run -i --rm caddy:2 caddy adapt --config /dev/stdin --adapter caddyfile`

## Acceptance Criteria Check
- Caddy config exists: yes (`infra/Caddyfile`)
- HTTPS enabled with local-CA-issued certs: yes (`tls /certs/edge.crt /certs/edge.key`)
- `codexbox` not directly published: yes (`expose` only, no `ports`)

Closes #3
