### PR TITLE
feat(codexbox): implement session rpc sse runtime core

### DIFF
--- a/codexbox/Dockerfile
+++ b/codexbox/Dockerfile
@@ -3,5 +3,6 @@ FROM node:22-bookworm-slim
 WORKDIR /app
 
 COPY webui-server.js /app/webui-server.js
+COPY public /app/public
 
 CMD ["node", "/app/webui-server.js"]

--- a/codexbox/public/app.js
+++ b/codexbox/public/app.js
@@ -1,0 +1,293 @@
+const state = {
+  sessionId: null,
+  threadId: null,
+  eventSource: null,
+  sending: false,
+  messageById: new Map(),
+  pendingApprovals: new Map(),
+};
+
+const els = {
+  status: document.getElementById("status"),
+  sessionId: document.getElementById("session-id"),
+  messages: document.getElementById("messages"),
+  approvals: document.getElementById("approvals"),
+  composer: document.getElementById("composer"),
+  prompt: document.getElementById("prompt"),
+  send: document.getElementById("send"),
+  approvalTemplate: document.getElementById("approval-template"),
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function appendMessage(kind, text, options = {}) {
+  const node = document.createElement("article");
+  node.className = `msg ${kind}`;
+  node.textContent = text;
+
+  if (options.itemId) {
+    node.dataset.itemId = options.itemId;
+    state.messageById.set(options.itemId, node);
+  }
+
+  els.messages.appendChild(node);
+  els.messages.scrollTop = els.messages.scrollHeight;
+  return node;
+}
+
+function updateComposerState() {
+  els.send.disabled = state.sending || !state.threadId;
+}
+
+async function api(path, payload, method = "POST") {
+  const options = { method, headers: {} };
+  if (method !== "GET") {
+    options.headers["content-type"] = "application/json";
+    options.body = JSON.stringify(payload || {});
+  }
+
+  const response = await fetch(path, options);
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || !body.ok) {
+    throw new Error(body.error || `HTTP ${response.status}`);
+  }
+  return body;
+}
+
+function extractThreadIdFromResult(result) {
+  if (result?.thread?.id) return result.thread.id;
+  return null;
+}
+
+function parseEventData(event) {
+  try {
+    return JSON.parse(event.data);
+  } catch {
+    return null;
+  }
+}
+
+function renderApprovals() {
+  const approvals = Array.from(state.pendingApprovals.values());
+  if (approvals.length === 0) {
+    els.approvals.classList.add("empty");
+    els.approvals.textContent = "No pending approvals.";
+    return;
+  }
+
+  els.approvals.classList.remove("empty");
+  els.approvals.textContent = "";
+
+  for (const approval of approvals) {
+    const fragment = els.approvalTemplate.content.cloneNode(true);
+    const card = fragment.querySelector(".approval-card");
+    const method = fragment.querySelector(".approval-method");
+    const body = fragment.querySelector(".approval-body");
+
+    method.textContent = approval.method;
+    body.textContent = JSON.stringify(approval.params || {}, null, 2);
+
+    for (const button of fragment.querySelectorAll("button[data-decision]")) {
+      button.addEventListener("click", async () => {
+        try {
+          await api("/api/approvals/respond", {
+            sessionId: state.sessionId,
+            requestId: approval.requestId,
+            decision: button.dataset.decision,
+          });
+          setStatus(`Approval resolved: ${approval.requestId}`);
+        } catch (err) {
+          setStatus(`Approval error: ${err.message}`);
+        }
+      });
+    }
+
+    card.dataset.requestId = approval.requestId;
+    els.approvals.appendChild(fragment);
+  }
+}
+
+function handleRpcNotification(message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+
+  if (message.method === "thread/started") {
+    const threadId = message.params?.thread?.id;
+    if (threadId) {
+      state.threadId = threadId;
+      setStatus(`Thread ready: ${threadId}`);
+      updateComposerState();
+    }
+    return;
+  }
+
+  if (message.method === "item/started" && message.params?.item?.type === "agentMessage") {
+    const itemId = message.params.item.id;
+    if (itemId && !state.messageById.has(itemId)) {
+      appendMessage("assistant", "", { itemId });
+    }
+    return;
+  }
+
+  if (message.method === "item/completed" && message.params?.item?.type === "agentMessage") {
+    const itemId = message.params.item.id;
+    const text = message.params.item.text || "";
+    const node = state.messageById.get(itemId);
+    if (node) {
+      node.textContent = text;
+    }
+    return;
+  }
+
+  if (message.method === "turn/completed") {
+    state.sending = false;
+    updateComposerState();
+    setStatus("Turn completed.");
+    return;
+  }
+}
+
+function handleDelta(params) {
+  const itemId = params?.itemId;
+  const delta = params?.delta || "";
+  if (!itemId || typeof delta !== "string") {
+    return;
+  }
+
+  let node = state.messageById.get(itemId);
+  if (!node) {
+    node = appendMessage("assistant", "", { itemId });
+  }
+  node.textContent += delta;
+  els.messages.scrollTop = els.messages.scrollHeight;
+}
+
+function connectSse() {
+  const url = `/api/session/events?sessionId=${encodeURIComponent(state.sessionId)}`;
+  const eventSource = new EventSource(url);
+  state.eventSource = eventSource;
+
+  eventSource.addEventListener("session/snapshot", (event) => {
+    const payload = parseEventData(event);
+    if (!payload) return;
+    state.threadId = payload.threadId || state.threadId;
+    state.pendingApprovals.clear();
+    for (const approval of payload.pendingApprovals || []) {
+      state.pendingApprovals.set(String(approval.requestId), approval);
+    }
+    renderApprovals();
+    updateComposerState();
+  });
+
+  eventSource.addEventListener("rpc/notification", (event) => {
+    const payload = parseEventData(event);
+    handleRpcNotification(payload?.message);
+  });
+
+  eventSource.addEventListener("chat/delta", (event) => {
+    const payload = parseEventData(event);
+    handleDelta(payload?.params || {});
+  });
+
+  eventSource.addEventListener("approval/pending", (event) => {
+    const payload = parseEventData(event);
+    const approval = payload?.approval;
+    if (!approval) return;
+    state.pendingApprovals.set(String(approval.requestId), approval);
+    renderApprovals();
+    setStatus(`Approval requested: ${approval.method}`);
+  });
+
+  eventSource.addEventListener("approval/resolved", (event) => {
+    const payload = parseEventData(event);
+    const requestId = String(payload?.approval?.requestId || "");
+    if (!requestId) return;
+    state.pendingApprovals.delete(requestId);
+    renderApprovals();
+  });
+
+  eventSource.addEventListener("approval/timed_out", (event) => {
+    const payload = parseEventData(event);
+    const requestId = String(payload?.approval?.requestId || "");
+    if (requestId) {
+      state.pendingApprovals.delete(requestId);
+      renderApprovals();
+    }
+    setStatus("An approval request timed out.");
+  });
+
+  eventSource.addEventListener("session/closed", (event) => {
+    const payload = parseEventData(event);
+    setStatus(`Session closed: ${payload?.reason || "unknown"}`);
+    state.sending = false;
+    state.threadId = null;
+    updateComposerState();
+  });
+
+  eventSource.onerror = () => {
+    setStatus("SSE disconnected. Refresh to reconnect.");
+  };
+}
+
+async function startSession() {
+  setStatus("Starting session...");
+  const session = await api("/api/session/start", {});
+  state.sessionId = session.sessionId;
+  els.sessionId.textContent = state.sessionId;
+
+  connectSse();
+
+  setStatus("Creating thread...");
+  const thread = await api("/api/thread/start", {
+    sessionId: state.sessionId,
+    params: {},
+  });
+
+  state.threadId = extractThreadIdFromResult(thread.result);
+  updateComposerState();
+
+  if (state.threadId) {
+    setStatus(`Ready. Thread: ${state.threadId}`);
+    appendMessage("system", "Session ready. Start chatting.");
+  } else {
+    setStatus("Ready, but thread ID is missing.");
+  }
+}
+
+async function sendTurn(text) {
+  state.sending = true;
+  updateComposerState();
+
+  appendMessage("user", text);
+  try {
+    await api("/api/turn/start", {
+      sessionId: state.sessionId,
+      threadId: state.threadId,
+      prompt: text,
+    });
+    setStatus("Turn started...");
+  } catch (err) {
+    state.sending = false;
+    updateComposerState();
+    setStatus(`Turn error: ${err.message}`);
+  }
+}
+
+els.composer.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const text = els.prompt.value.trim();
+  if (!text || state.sending || !state.threadId) {
+    return;
+  }
+  els.prompt.value = "";
+  await sendTurn(text);
+});
+
+updateComposerState();
+startSession().catch((err) => {
+  setStatus(`Startup failed: ${err.message}`);
+  appendMessage("system", `Startup failed: ${err.message}`);
+});

--- a/codexbox/public/index.html
+++ b/codexbox/public/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Codex WebUI</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="shell">
+      <header class="topbar">
+        <div>
+          <h1>Codex WebUI</h1>
+          <p id="status" class="status">Booting session...</p>
+        </div>
+        <div class="meta">
+          <span>Session</span>
+          <code id="session-id">-</code>
+        </div>
+      </header>
+
+      <main class="layout">
+        <section class="chat-panel">
+          <div id="messages" class="messages" aria-live="polite"></div>
+          <form id="composer" class="composer">
+            <textarea id="prompt" placeholder="Type your prompt..." rows="3"></textarea>
+            <button id="send" type="submit">Send</button>
+          </form>
+        </section>
+
+        <aside class="approval-panel">
+          <h2>Approvals</h2>
+          <div id="approvals" class="approvals empty">No pending approvals.</div>
+        </aside>
+      </main>
+    </div>
+
+    <template id="approval-template">
+      <article class="approval-card">
+        <p class="approval-method"></p>
+        <pre class="approval-body"></pre>
+        <div class="approval-actions">
+          <button data-decision="allow" type="button">Allow</button>
+          <button data-decision="deny" type="button">Deny</button>
+          <button data-decision="cancel" type="button">Cancel</button>
+        </div>
+      </article>
+    </template>
+
+    <script src="/static/app.js" defer></script>
+  </body>
+</html>

--- a/codexbox/public/styles.css
+++ b/codexbox/public/styles.css
@@ -1,0 +1,258 @@
+:root {
+  --bg-0: #f2eee8;
+  --bg-1: #fff9f2;
+  --ink-0: #1c1610;
+  --ink-1: #55473b;
+  --accent: #1f6d5f;
+  --accent-soft: #d6ece7;
+  --warn: #8b2f2f;
+  --line: #d7c9bb;
+  --panel: #fffefc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "IBM Plex Sans", "Segoe UI", "Hiragino Kaku Gothic ProN", sans-serif;
+  color: var(--ink-0);
+  background:
+    radial-gradient(circle at 20% 10%, #f9e8d9 0, transparent 32%),
+    radial-gradient(circle at 85% 0%, #ddeee8 0, transparent 26%),
+    linear-gradient(160deg, var(--bg-0), var(--bg-1));
+  min-height: 100vh;
+}
+
+.shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.topbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2vw, 2rem);
+  letter-spacing: 0.02em;
+}
+
+.status {
+  margin: 6px 0 0;
+  color: var(--ink-1);
+  font-size: 0.95rem;
+}
+
+.meta {
+  display: grid;
+  gap: 4px;
+  text-align: right;
+  color: var(--ink-1);
+  font-size: 0.82rem;
+}
+
+.meta code {
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  background: #f8f1e9;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 3px 7px;
+  color: var(--ink-0);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1.8fr 1fr;
+  gap: 14px;
+}
+
+.chat-panel,
+.approval-panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 6px 20px rgba(49, 37, 20, 0.07);
+}
+
+.chat-panel {
+  min-height: 70vh;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  overflow: hidden;
+}
+
+.messages {
+  padding: 16px;
+  overflow: auto;
+  display: grid;
+  gap: 10px;
+}
+
+.msg {
+  border-radius: 12px;
+  padding: 10px 12px;
+  max-width: 90%;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  animation: rise 0.2s ease-out;
+}
+
+.msg.user {
+  margin-left: auto;
+  background: #f3e0cf;
+  border: 1px solid #e4c8ad;
+}
+
+.msg.assistant {
+  margin-right: auto;
+  background: #ebf4f2;
+  border: 1px solid #d1e5df;
+}
+
+.msg.system {
+  margin: 0 auto;
+  color: var(--ink-1);
+  border: 1px dashed var(--line);
+  background: #fff7ed;
+  font-size: 0.9rem;
+}
+
+.composer {
+  border-top: 1px solid var(--line);
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+}
+
+.composer textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 50px;
+  max-height: 180px;
+  border: 1px solid #cbb8a5;
+  border-radius: 10px;
+  padding: 10px;
+  font: inherit;
+  background: #fffdfb;
+}
+
+.composer button {
+  border: none;
+  border-radius: 10px;
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+  padding: 0 16px;
+  cursor: pointer;
+}
+
+.composer button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.approval-panel {
+  padding: 12px;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 10px;
+}
+
+.approval-panel h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.approvals {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.approvals.empty {
+  color: var(--ink-1);
+  font-size: 0.92rem;
+}
+
+.approval-card {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 9px;
+  background: #fff;
+}
+
+.approval-method {
+  margin: 0 0 6px;
+  font-size: 0.86rem;
+  color: var(--ink-1);
+}
+
+.approval-body {
+  margin: 0;
+  max-height: 140px;
+  overflow: auto;
+  font-size: 0.78rem;
+  background: #f8f4ef;
+  border: 1px solid #e0d2c3;
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.approval-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.approval-actions button {
+  border: 1px solid #c7b39d;
+  background: #fff;
+  border-radius: 8px;
+  padding: 5px 8px;
+  cursor: pointer;
+}
+
+.approval-actions button[data-decision="allow"] {
+  background: var(--accent-soft);
+  border-color: #9dcabc;
+}
+
+.approval-actions button[data-decision="deny"],
+.approval-actions button[data-decision="cancel"] {
+  color: var(--warn);
+}
+
+@keyframes rise {
+  from {
+    transform: translateY(6px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 920px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-panel {
+    min-height: 60vh;
+  }
+
+  .approval-panel {
+    min-height: 220px;
+  }
+}

--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -1,20 +1,775 @@
 const http = require("node:http");
+const path = require("node:path");
+const fs = require("node:fs");
+const { spawn } = require("node:child_process");
+const { randomUUID } = require("node:crypto");
 
-const port = Number(process.env.PORT || 8080);
+const PORT = Number(process.env.PORT || 8080);
+const HOST = process.env.HOST || "0.0.0.0";
+const CODEX_BIN = process.env.CODEX_BIN || "codex";
+const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT || process.cwd();
+const SESSION_IDLE_TIMEOUT_MS = Number(process.env.SESSION_IDLE_TIMEOUT_MS || 15 * 60 * 1000);
+const SESSION_SWEEP_INTERVAL_MS = Number(process.env.SESSION_SWEEP_INTERVAL_MS || 30 * 1000);
+const APPROVAL_TIMEOUT_MS = Number(process.env.APPROVAL_TIMEOUT_MS || 2 * 60 * 1000);
+const RPC_TIMEOUT_MS = Number(process.env.RPC_TIMEOUT_MS || 60 * 1000);
+const STATIC_DIR = path.join(__dirname, "public");
 
-const server = http.createServer((req, res) => {
-  // Placeholder endpoint for compose bootstrap. Later P0 issues replace this.
-  res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
-  res.end(
-    JSON.stringify({
+const sessions = new Map();
+
+function nowMs() {
+  return Date.now();
+}
+
+function sendJson(res, statusCode, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function sendText(res, statusCode, text) {
+  res.writeHead(statusCode, {
+    "content-type": "text/plain; charset=utf-8",
+    "content-length": Buffer.byteLength(text),
+  });
+  res.end(text);
+}
+
+function normalizeError(err) {
+  if (!err) {
+    return "unknown error";
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  if (err && typeof err.message === "string") {
+    return err.message;
+  }
+  return JSON.stringify(err);
+}
+
+function makeSession() {
+  const sessionId = randomUUID();
+  const session = {
+    id: sessionId,
+    createdAt: nowMs(),
+    lastActivityAt: nowMs(),
+    nextRpcId: 1,
+    nextSseId: 1,
+    stdoutBuffer: "",
+    child: null,
+    closed: false,
+    pendingRequests: new Map(),
+    pendingApprovals: new Map(),
+    sseClients: new Set(),
+    threadId: null,
+  };
+  sessions.set(sessionId, session);
+  return session;
+}
+
+function touchSession(session) {
+  session.lastActivityAt = nowMs();
+}
+
+function writeSse(res, eventName, data, eventId) {
+  res.write(`id: ${eventId}\n`);
+  res.write(`event: ${eventName}\n`);
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function emitSessionEvent(session, eventName, payload) {
+  const eventId = session.nextSseId++;
+  const data = {
+    sessionId: session.id,
+    emittedAt: nowMs(),
+    ...payload,
+  };
+
+  for (const client of session.sseClients) {
+    if (client.writableEnded || client.destroyed) {
+      session.sseClients.delete(client);
+      continue;
+    }
+    try {
+      writeSse(client, eventName, data, eventId);
+    } catch {
+      session.sseClients.delete(client);
+    }
+  }
+}
+
+function rpcWrite(session, message) {
+  if (!session.child || session.closed) {
+    throw new Error("session is not running");
+  }
+  const line = JSON.stringify(message);
+  session.child.stdin.write(`${line}\n`);
+  touchSession(session);
+}
+
+function rpcNotify(session, method, params) {
+  const message = {
+    jsonrpc: "2.0",
+    method,
+  };
+  if (params !== undefined) {
+    message.params = params;
+  }
+  rpcWrite(session, message);
+}
+
+function rpcRespond(session, requestId, result) {
+  rpcWrite(session, {
+    jsonrpc: "2.0",
+    id: requestId,
+    result,
+  });
+}
+
+function rpcError(session, requestId, message, code = -32601, data = null) {
+  rpcWrite(session, {
+    jsonrpc: "2.0",
+    id: requestId,
+    error: {
+      code,
+      message,
+      data,
+    },
+  });
+}
+
+function rpcRequest(session, method, params) {
+  const requestId = session.nextRpcId++;
+  const key = String(requestId);
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      session.pendingRequests.delete(key);
+      reject(new Error(`RPC timeout for method ${method}`));
+    }, RPC_TIMEOUT_MS);
+
+    session.pendingRequests.set(key, {
+      method,
+      resolve,
+      reject,
+      timeout,
+    });
+
+    try {
+      rpcWrite(session, {
+        jsonrpc: "2.0",
+        id: requestId,
+        method,
+        params,
+      });
+    } catch (err) {
+      clearTimeout(timeout);
+      session.pendingRequests.delete(key);
+      reject(err);
+    }
+  });
+}
+
+function handleRpcResponse(session, message) {
+  const key = String(message.id);
+  const pending = session.pendingRequests.get(key);
+  if (!pending) {
+    return;
+  }
+
+  clearTimeout(pending.timeout);
+  session.pendingRequests.delete(key);
+
+  if (message.error) {
+    pending.reject(new Error(normalizeError(message.error)));
+    return;
+  }
+
+  pending.resolve(message.result);
+}
+
+function approvalDefaultResult(method, decision) {
+  const normalized = String(decision || "deny").toLowerCase();
+
+  if (method === "item/commandExecution/requestApproval") {
+    if (normalized === "allow") return { decision: "accept" };
+    if (normalized === "cancel") return { decision: "cancel" };
+    return { decision: "decline" };
+  }
+
+  if (method === "item/fileChange/requestApproval") {
+    if (normalized === "allow") return { decision: "accept" };
+    if (normalized === "cancel") return { decision: "cancel" };
+    return { decision: "decline" };
+  }
+
+  if (method === "execCommandApproval" || method === "applyPatchApproval") {
+    if (normalized === "allow") return { decision: "approved" };
+    if (normalized === "cancel") return { decision: "abort" };
+    return { decision: "denied" };
+  }
+
+  return null;
+}
+
+function serializeApproval(approval) {
+  return {
+    requestId: approval.requestId,
+    method: approval.method,
+    params: approval.params,
+    createdAt: approval.createdAt,
+    expiresAt: approval.expiresAt,
+  };
+}
+
+function listPendingApprovals(session) {
+  return Array.from(session.pendingApprovals.values())
+    .sort((a, b) => a.createdAt - b.createdAt)
+    .map(serializeApproval);
+}
+
+function resolveApproval(session, requestId, result, resolutionType) {
+  const key = String(requestId);
+  const approval = session.pendingApprovals.get(key);
+  if (!approval) {
+    throw new Error(`approval ${requestId} not found`);
+  }
+
+  clearTimeout(approval.timeoutHandle);
+  session.pendingApprovals.delete(key);
+
+  rpcRespond(session, approval.requestId, result);
+  emitSessionEvent(session, "approval/resolved", {
+    resolutionType,
+    approval: serializeApproval(approval),
+    result,
+  });
+  touchSession(session);
+
+  return {
+    requestId: approval.requestId,
+    resolutionType,
+    result,
+  };
+}
+
+function handleApprovalTimeout(session, requestId) {
+  const key = String(requestId);
+  const approval = session.pendingApprovals.get(key);
+  if (!approval) {
+    return;
+  }
+
+  const timeoutResult = approvalDefaultResult(approval.method, "cancel");
+  if (!timeoutResult) {
+    session.pendingApprovals.delete(key);
+    emitSessionEvent(session, "approval/timed_out", {
+      approval: serializeApproval(approval),
+      reason: "unsupported-approval-type",
+    });
+    return;
+  }
+
+  try {
+    resolveApproval(session, requestId, timeoutResult, "timeout");
+  } catch (err) {
+    emitSessionEvent(session, "approval/timed_out", {
+      approval: serializeApproval(approval),
+      reason: normalizeError(err),
+    });
+  }
+}
+
+function isApprovalRequestMethod(method) {
+  return (
+    method === "item/commandExecution/requestApproval" ||
+    method === "item/fileChange/requestApproval" ||
+    method === "execCommandApproval" ||
+    method === "applyPatchApproval"
+  );
+}
+
+function handleRpcRequestFromServer(session, message) {
+  const method = message.method;
+
+  if (isApprovalRequestMethod(method)) {
+    const requestId = String(message.id);
+    const createdAt = nowMs();
+    const approval = {
+      requestId,
+      method,
+      params: message.params || {},
+      createdAt,
+      expiresAt: createdAt + APPROVAL_TIMEOUT_MS,
+      timeoutHandle: null,
+    };
+
+    approval.timeoutHandle = setTimeout(() => {
+      handleApprovalTimeout(session, requestId);
+    }, APPROVAL_TIMEOUT_MS);
+
+    session.pendingApprovals.set(requestId, approval);
+    emitSessionEvent(session, "approval/pending", {
+      approval: serializeApproval(approval),
+    });
+    touchSession(session);
+    return;
+  }
+
+  rpcError(session, message.id, `Unsupported server request method: ${method}`);
+  emitSessionEvent(session, "rpc/server_request_unsupported", {
+    message,
+  });
+}
+
+function handleRpcNotification(session, message) {
+  emitSessionEvent(session, "rpc/notification", { message });
+
+  if (message.method === "thread/started") {
+    const threadId = message.params?.thread?.id;
+    if (typeof threadId === "string") {
+      session.threadId = threadId;
+    }
+  }
+
+  if (message.method === "item/agentMessage/delta") {
+    emitSessionEvent(session, "chat/delta", {
+      params: message.params || {},
+    });
+  }
+
+  touchSession(session);
+}
+
+function handleRpcMessage(session, message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(message, "id") && Object.prototype.hasOwnProperty.call(message, "method")) {
+    handleRpcRequestFromServer(session, message);
+    return;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(message, "id")) {
+    handleRpcResponse(session, message);
+    return;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(message, "method")) {
+    handleRpcNotification(session, message);
+  }
+}
+
+function handleChildStdout(session, chunk) {
+  session.stdoutBuffer += chunk;
+  const parts = session.stdoutBuffer.split(/\r?\n/);
+  session.stdoutBuffer = parts.pop() || "";
+
+  for (const part of parts) {
+    const line = part.trim();
+    if (!line) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(line);
+      handleRpcMessage(session, parsed);
+    } catch (err) {
+      emitSessionEvent(session, "rpc/parse_error", {
+        line,
+        error: normalizeError(err),
+      });
+    }
+  }
+}
+
+function shutdownSession(session, reason) {
+  if (!session || session.closed) {
+    return;
+  }
+
+  session.closed = true;
+
+  for (const pending of session.pendingRequests.values()) {
+    clearTimeout(pending.timeout);
+    pending.reject(new Error(`session closed: ${reason}`));
+  }
+  session.pendingRequests.clear();
+
+  for (const approval of session.pendingApprovals.values()) {
+    clearTimeout(approval.timeoutHandle);
+  }
+  session.pendingApprovals.clear();
+
+  if (session.child && !session.child.killed) {
+    session.child.kill("SIGTERM");
+    setTimeout(() => {
+      if (session.child && !session.child.killed) {
+        session.child.kill("SIGKILL");
+      }
+    }, 1000).unref();
+  }
+
+  emitSessionEvent(session, "session/closed", { reason });
+
+  for (const client of session.sseClients) {
+    try {
+      client.end();
+    } catch {
+      // no-op
+    }
+  }
+  session.sseClients.clear();
+
+  sessions.delete(session.id);
+}
+
+async function startSessionRuntime(session) {
+  const child = spawn(CODEX_BIN, ["app-server", "--listen", "stdio://"], {
+    cwd: WORKSPACE_ROOT,
+    env: process.env,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  session.child = child;
+
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    handleChildStdout(session, chunk);
+  });
+
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    emitSessionEvent(session, "rpc/stderr", { chunk: String(chunk) });
+  });
+
+  child.on("error", (err) => {
+    if (session.closed) {
+      return;
+    }
+    emitSessionEvent(session, "session/error", {
+      error: `app-server process error: ${normalizeError(err)}`,
+    });
+    shutdownSession(session, `app-server process error: ${normalizeError(err)}`);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (session.closed) {
+      return;
+    }
+    shutdownSession(session, `app-server exited (code=${code}, signal=${signal})`);
+  });
+
+  const initResult = await rpcRequest(session, "initialize", {
+    clientInfo: {
+      name: "codex-webui",
+      version: "0.1.0",
+    },
+    capabilities: {
+      experimentalApi: true,
+    },
+  });
+
+  rpcNotify(session, "initialized");
+  emitSessionEvent(session, "session/started", { initResult });
+  touchSession(session);
+
+  return initResult;
+}
+
+async function readRequestBody(req) {
+  const chunks = [];
+  let size = 0;
+
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > 1024 * 1024) {
+      throw new Error("request body too large");
+    }
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  const text = Buffer.concat(chunks).toString("utf8").trim();
+  if (!text) {
+    return {};
+  }
+
+  return JSON.parse(text);
+}
+
+function ensureSession(sessionId) {
+  const id = String(sessionId || "").trim();
+  if (!id) {
+    throw new Error("sessionId is required");
+  }
+
+  const session = sessions.get(id);
+  if (!session) {
+    throw new Error(`session not found: ${id}`);
+  }
+
+  if (session.closed) {
+    throw new Error(`session is closed: ${id}`);
+  }
+
+  return session;
+}
+
+function serveStaticFile(res, filePath, contentType) {
+  fs.readFile(filePath, (err, buf) => {
+    if (err) {
+      sendText(res, 404, "Not found");
+      return;
+    }
+
+    res.writeHead(200, {
+      "content-type": contentType,
+      "content-length": buf.length,
+      "cache-control": "no-store",
+    });
+    res.end(buf);
+  });
+}
+
+async function handlePostApi(req, res, pathname) {
+  const body = await readRequestBody(req);
+
+  if (pathname === "/api/session/start") {
+    const session = makeSession();
+    try {
+      const initResult = await startSessionRuntime(session);
+      sendJson(res, 200, {
+        ok: true,
+        sessionId: session.id,
+        initResult,
+        idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS,
+        approvalTimeoutMs: APPROVAL_TIMEOUT_MS,
+      });
+      return;
+    } catch (err) {
+      shutdownSession(session, `startup_failed: ${normalizeError(err)}`);
+      sendJson(res, 500, {
+        ok: false,
+        error: `failed to start session: ${normalizeError(err)}`,
+      });
+      return;
+    }
+  }
+
+  if (pathname === "/api/session/end") {
+    const session = ensureSession(body.sessionId);
+    shutdownSession(session, "session ended by client");
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  if (pathname === "/api/thread/start") {
+    const session = ensureSession(body.sessionId);
+    const params = body.params && typeof body.params === "object" ? body.params : {};
+    const result = await rpcRequest(session, "thread/start", params);
+    if (typeof result?.thread?.id === "string") {
+      session.threadId = result.thread.id;
+    }
+    touchSession(session);
+    sendJson(res, 200, { ok: true, result });
+    return;
+  }
+
+  if (pathname === "/api/turn/start") {
+    const session = ensureSession(body.sessionId);
+
+    const params = body.params && typeof body.params === "object" ? { ...body.params } : {};
+
+    if (!params.threadId) {
+      params.threadId = body.threadId || session.threadId;
+    }
+    if (!params.threadId) {
+      throw new Error("threadId is required (call /api/thread/start first)");
+    }
+
+    if (!Array.isArray(params.input)) {
+      if (Array.isArray(body.input)) {
+        params.input = body.input;
+      } else if (typeof body.prompt === "string") {
+        params.input = [{ type: "text", text: body.prompt }];
+      } else if (typeof body.text === "string") {
+        params.input = [{ type: "text", text: body.text }];
+      } else {
+        throw new Error("input is required (set params.input array or prompt/text string)");
+      }
+    }
+
+    const result = await rpcRequest(session, "turn/start", params);
+    touchSession(session);
+    sendJson(res, 200, { ok: true, result });
+    return;
+  }
+
+  if (pathname === "/api/approvals/respond") {
+    const session = ensureSession(body.sessionId);
+    const requestId = body.requestId;
+    if (requestId === undefined || requestId === null) {
+      throw new Error("requestId is required");
+    }
+
+    const approval = session.pendingApprovals.get(String(requestId));
+    if (!approval) {
+      throw new Error(`pending approval not found: ${requestId}`);
+    }
+
+    const result = body.result && typeof body.result === "object"
+      ? body.result
+      : approvalDefaultResult(approval.method, body.decision || "deny");
+
+    if (!result) {
+      throw new Error(`unsupported approval method: ${approval.method}`);
+    }
+
+    const resolved = resolveApproval(session, requestId, result, "manual");
+    sendJson(res, 200, {
+      ok: true,
+      resolved,
+    });
+    return;
+  }
+
+  sendJson(res, 404, { ok: false, error: "not found" });
+}
+
+function handleGetApi(req, res, pathname, searchParams) {
+  if (pathname === "/api/healthz") {
+    sendJson(res, 200, {
       ok: true,
       service: "codexbox",
-      message: "Placeholder server for compose bootstrap.",
-      path: req.url,
-    }),
-  );
+      sessions: sessions.size,
+      now: nowMs(),
+    });
+    return;
+  }
+
+  if (pathname === "/api/session/events") {
+    const session = ensureSession(searchParams.get("sessionId"));
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+      "x-accel-buffering": "no",
+    });
+    res.write("retry: 1500\n\n");
+
+    session.sseClients.add(res);
+    touchSession(session);
+
+    writeSse(
+      res,
+      "session/snapshot",
+      {
+        sessionId: session.id,
+        threadId: session.threadId,
+        pendingApprovals: listPendingApprovals(session),
+      },
+      session.nextSseId++,
+    );
+
+    const heartbeat = setInterval(() => {
+      if (!res.writableEnded) {
+        res.write(`: heartbeat ${Date.now()}\n\n`);
+      }
+    }, 15000);
+
+    req.on("close", () => {
+      clearInterval(heartbeat);
+      session.sseClients.delete(res);
+    });
+
+    return;
+  }
+
+  if (pathname === "/api/approvals") {
+    const session = ensureSession(searchParams.get("sessionId"));
+    sendJson(res, 200, {
+      ok: true,
+      pendingApprovals: listPendingApprovals(session),
+    });
+    return;
+  }
+
+  sendJson(res, 404, { ok: false, error: "not found" });
+}
+
+const server = http.createServer(async (req, res) => {
+  const method = req.method || "GET";
+  const requestUrl = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+  const pathname = requestUrl.pathname;
+
+  try {
+    if (method === "GET" && pathname === "/") {
+      serveStaticFile(res, path.join(STATIC_DIR, "index.html"), "text/html; charset=utf-8");
+      return;
+    }
+
+    if (method === "GET" && pathname === "/static/app.js") {
+      serveStaticFile(res, path.join(STATIC_DIR, "app.js"), "text/javascript; charset=utf-8");
+      return;
+    }
+
+    if (method === "GET" && pathname === "/static/styles.css") {
+      serveStaticFile(res, path.join(STATIC_DIR, "styles.css"), "text/css; charset=utf-8");
+      return;
+    }
+
+    if (pathname.startsWith("/api/")) {
+      if (method === "GET") {
+        handleGetApi(req, res, pathname, requestUrl.searchParams);
+        return;
+      }
+      if (method === "POST") {
+        await handlePostApi(req, res, pathname);
+        return;
+      }
+      sendJson(res, 405, { ok: false, error: "method not allowed" });
+      return;
+    }
+
+    sendText(res, 404, "Not found");
+  } catch (err) {
+    sendJson(res, 400, {
+      ok: false,
+      error: normalizeError(err),
+    });
+  }
 });
 
-server.listen(port, "0.0.0.0", () => {
-  console.log(`codexbox placeholder listening on ${port}`);
+const sessionSweep = setInterval(() => {
+  const threshold = nowMs() - SESSION_IDLE_TIMEOUT_MS;
+  for (const session of sessions.values()) {
+    if (session.lastActivityAt < threshold) {
+      shutdownSession(session, "idle timeout");
+    }
+  }
+}, SESSION_SWEEP_INTERVAL_MS);
+sessionSweep.unref();
+
+for (const signal of ["SIGTERM", "SIGINT"]) {
+  process.on(signal, () => {
+    for (const session of Array.from(sessions.values())) {
+      shutdownSession(session, `process signal ${signal}`);
+    }
+    server.close(() => {
+      process.exit(0);
+    });
+  });
+}
+
+server.listen(PORT, HOST, () => {
+  console.log(`codexbox webui server listening on ${HOST}:${PORT}`);
 });

--- a/tasks/archived/2026-03-06-issues-4-8-runtime-core/design.md
+++ b/tasks/archived/2026-03-06-issues-4-8-runtime-core/design.md
@@ -1,0 +1,55 @@
+# Issues 4-8 Design
+
+## Overview
+- Replace the placeholder HTTP server with a stateful WebUI server that manages browser sessions and a dedicated Codex app-server child per session.
+- Use SSE for one-way event streaming to the browser.
+- Use JSON HTTP endpoints for command initiation (`thread/start`, `turn/start`, approval responses).
+
+## Core Components
+- Session store (`Map<sessionId, SessionState>`) with:
+  - app-server child process
+  - pending JSON-RPC request map
+  - active SSE clients
+  - pending approvals
+  - event sequence counter and timestamps
+- JSON-RPC bridge:
+  - outbound request helper with promise resolution
+  - line-oriented stdout parser
+  - server request handler for approval requests
+- Idle reaper:
+  - periodic sweep that terminates stale sessions and children
+- Minimal static UI:
+  - create session
+  - open SSE stream
+  - start thread on demand
+  - send turns and render streamed deltas
+  - basic approval modal/actions
+
+## API Surface
+- `POST /api/session/start`
+- `GET /api/session/events?sessionId=...`
+- `POST /api/session/end`
+- `POST /api/thread/start`
+- `POST /api/turn/start`
+- `GET /api/approvals?sessionId=...`
+- `POST /api/approvals/respond`
+- `GET /api/healthz`
+- `GET /` and `/static/*`
+
+## Approval Handling
+- Detect server-initiated JSON-RPC requests with methods:
+  - `item/commandExecution/requestApproval`
+  - `item/fileChange/requestApproval`
+  - `execCommandApproval`
+  - `applyPatchApproval`
+- Persist as pending approval records keyed by JSON-RPC request id.
+- Emit SSE events on create/update.
+- Timeout strategy:
+  - auto-respond with cancel-style decision on timeout
+  - mark approval as timed out and emit an event
+
+## Risks
+- Upstream protocol changes may add new request/notification variants.
+  - Mitigation: forward unknown notifications as generic SSE events.
+- App-server startup or auth failures.
+  - Mitigation: return clear API errors and emit session error events.

--- a/tasks/archived/2026-03-06-issues-4-8-runtime-core/plan.md
+++ b/tasks/archived/2026-03-06-issues-4-8-runtime-core/plan.md
@@ -1,0 +1,32 @@
+# Issues 4-8 Plan
+
+## TDD
+- TDD: partial
+- Rationale: Core logic is integration-heavy (child process + SSE), so test-first unit coverage is limited in this iteration. Validation will combine static checks and end-to-end API smoke runs.
+
+## Steps
+- [x] Write requirements/design/plan for #4-#8 batch implementation.
+- [x] Implement session manager, SSE endpoint, and idle cleanup.
+- [x] Implement app-server JSON-RPC bridge and initialize handshake.
+- [x] Implement APIs for `thread/start` and `turn/start`.
+- [x] Implement approval storage, response API, and timeout handling.
+- [x] Implement minimal responsive WebUI with incremental streaming output.
+- [x] Run validation checks and smoke-test the flow.
+- [x] Self-check acceptance criteria and summarize unresolved items.
+
+## Validation Plan
+- `node --check codexbox/webui-server.js`
+- start server and call APIs with curl:
+  - `session/start`
+  - `thread/start`
+  - `turn/start`
+  - SSE event observation
+- Validate UI load and chat turn on localhost.
+
+## Risks and Unknowns
+- Approval flows may be hard to trigger deterministically in smoke tests.
+- Running server and app-server in this environment may differ from Docker runtime details.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #4`, `Closes #5`, `Closes #6`, `Closes #7`, `Closes #8` in PR body if acceptance criteria are met.

--- a/tasks/archived/2026-03-06-issues-4-8-runtime-core/requirements.md
+++ b/tasks/archived/2026-03-06-issues-4-8-runtime-core/requirements.md
@@ -1,0 +1,46 @@
+# Issues 4-8 Requirements
+
+## Goal
+- Deliver the P0 runtime core needed for browser-to-Codex conversation flow: session lifecycle, app-server bridge, streaming execution APIs, minimal chat UI, and approval handling.
+
+## In Scope
+- Issue #4: session creation, SSE stream endpoint, idle session cleanup.
+- Issue #5: one `codex app-server` child per session, stdio JSON-RPC bridge, initialize handshake.
+- Issue #6: backend APIs for `thread/start` and `turn/start`, forwarding streaming notifications to UI.
+- Issue #7: minimal WebUI with input box and incremental assistant streaming for desktop/mobile.
+- Issue #8: store pending approvals, send Allow/Deny decisions back, handle timeout/cancel.
+
+## Out of Scope
+- P1 and P2 issues (`#9` and later) such as file tree/diff APIs and reconnect recovery.
+- Production-grade auth and full UI polish.
+- Multi-user hard isolation.
+
+## Acceptance Criteria Mapping
+- #4
+  - session IDs are issued
+  - SSE endpoint exists
+  - idle sessions are cleaned up
+- #5
+  - one child per browser session
+  - stdio JSONL is bridged correctly
+  - initialize handshake is completed
+- #6
+  - `thread/start` is available
+  - `turn/start` is available
+  - streaming events are forwarded to the UI layer
+- #7
+  - input box exists
+  - streamed assistant output renders incrementally
+  - basic session view works in desktop and mobile layouts
+- #8
+  - pending approvals are stored
+  - Allow/Deny responses are sent back
+  - approval timeout or cancellation is handled
+
+## Constraints and Assumptions
+- `codex app-server` is launched via `codex app-server --listen stdio://`.
+- Web server remains dependency-light (Node.js built-ins) in this stage.
+- Keep repository changes focused on `codexbox/` and temporary task artifacts.
+
+## Open Questions
+- None blocking for implementing #4-#8.


### PR DESCRIPTION
## Summary
- Implement session lifecycle with server-side session IDs, SSE event stream endpoint, and idle cleanup reaper
- Bridge one `codex app-server` child process per session over stdio JSON-RPC with initialize/initialized handshake
- Add execution APIs for `thread/start` and `turn/start` and forward streaming notifications to SSE clients
- Implement pending approval storage and response handling with timeout-based auto resolution
- Add minimal responsive WebUI for chat input and incremental assistant stream rendering
- Archive task execution artifacts for this implementation batch

## Validation
- `node --check codexbox/webui-server.js`
- `node --check codexbox/public/app.js`
- `docker compose config`
- API smoke flow:
  - `POST /api/session/start`
  - `POST /api/thread/start`
  - `POST /api/turn/start`
  - `GET /api/session/events` (SSE stream observed)
- Idle cleanup smoke flow with short timeout env vars

## Notes
- Approval request events were implemented and wired, but deterministic generation depends on model behavior/policy at runtime.

Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
