### PR TITLE
feat(security): enforce edge auth and runtime safety defaults

### DIFF
--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -12,9 +12,13 @@ const SESSION_IDLE_TIMEOUT_MS = Number(process.env.SESSION_IDLE_TIMEOUT_MS || 15
 const SESSION_SWEEP_INTERVAL_MS = Number(process.env.SESSION_SWEEP_INTERVAL_MS || 30 * 1000);
 const APPROVAL_TIMEOUT_MS = Number(process.env.APPROVAL_TIMEOUT_MS || 2 * 60 * 1000);
 const RPC_TIMEOUT_MS = Number(process.env.RPC_TIMEOUT_MS || 60 * 1000);
+const CODEX_DEFAULT_APPROVAL_POLICY = process.env.CODEX_DEFAULT_APPROVAL_POLICY || "untrusted";
+const CODEX_DEFAULT_SANDBOX = process.env.CODEX_DEFAULT_SANDBOX || "read-only";
 const STATIC_DIR = path.join(__dirname, "public");
 
 const sessions = new Map();
+const VALID_APPROVAL_POLICIES = new Set(["untrusted", "on-failure", "on-request", "never"]);
+const VALID_SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 
 function nowMs() {
   return Date.now();
@@ -48,6 +52,31 @@ function normalizeError(err) {
     return err.message;
   }
   return JSON.stringify(err);
+}
+
+function assertValidServerSafetyDefaults() {
+  if (!VALID_APPROVAL_POLICIES.has(CODEX_DEFAULT_APPROVAL_POLICY)) {
+    throw new Error(
+      `Invalid CODEX_DEFAULT_APPROVAL_POLICY: ${CODEX_DEFAULT_APPROVAL_POLICY}`,
+    );
+  }
+  if (!VALID_SANDBOX_MODES.has(CODEX_DEFAULT_SANDBOX)) {
+    throw new Error(`Invalid CODEX_DEFAULT_SANDBOX: ${CODEX_DEFAULT_SANDBOX}`);
+  }
+}
+
+function assertNoUnsafeOverrides(source, blockedKeys, endpointPath) {
+  if (!source || typeof source !== "object") {
+    return;
+  }
+
+  for (const key of blockedKeys) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      throw new Error(
+        `${endpointPath} does not allow overriding '${key}'; server-side safety policy is enforced`,
+      );
+    }
+  }
 }
 
 function makeSession() {
@@ -573,7 +602,15 @@ async function handlePostApi(req, res, pathname) {
 
   if (pathname === "/api/thread/start") {
     const session = ensureSession(body.sessionId);
-    const params = body.params && typeof body.params === "object" ? body.params : {};
+    const rawParams = body.params && typeof body.params === "object" ? body.params : {};
+    assertNoUnsafeOverrides(rawParams, ["approvalPolicy", "sandbox", "cwd"], pathname);
+
+    const params = {
+      ...rawParams,
+      approvalPolicy: CODEX_DEFAULT_APPROVAL_POLICY,
+      sandbox: CODEX_DEFAULT_SANDBOX,
+    };
+
     const result = await rpcRequest(session, "thread/start", params);
     if (typeof result?.thread?.id === "string") {
       session.threadId = result.thread.id;
@@ -587,6 +624,7 @@ async function handlePostApi(req, res, pathname) {
     const session = ensureSession(body.sessionId);
 
     const params = body.params && typeof body.params === "object" ? { ...body.params } : {};
+    assertNoUnsafeOverrides(params, ["approvalPolicy", "sandboxPolicy", "cwd"], pathname);
 
     if (!params.threadId) {
       params.threadId = body.threadId || session.threadId;
@@ -705,6 +743,8 @@ function handleGetApi(req, res, pathname, searchParams) {
 
   sendJson(res, 404, { ok: false, error: "not found" });
 }
+
+assertValidServerSafetyDefaults();
 
 const server = http.createServer(async (req, res) => {
   const method = req.method || "GET";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      EDGE_BASIC_AUTH_USER: ${EDGE_BASIC_AUTH_USER:?EDGE_BASIC_AUTH_USER is required}
+      EDGE_BASIC_AUTH_PASSWORD_HASH: ${EDGE_BASIC_AUTH_PASSWORD_HASH:?EDGE_BASIC_AUTH_PASSWORD_HASH is required}
     depends_on:
       - codexbox
     networks:

--- a/docs/edge-authentication.md
+++ b/docs/edge-authentication.md
@@ -1,0 +1,35 @@
+# Edge Authentication Setup
+
+## Operational assumptions
+- `edge` is the only LAN-exposed service.
+- HTTPS is already configured with local-CA-issued certs.
+- Basic auth is required before proxying to `codexbox`.
+
+## Required environment variables
+Set these variables before running `docker compose up`:
+- `EDGE_BASIC_AUTH_USER`
+- `EDGE_BASIC_AUTH_PASSWORD_HASH`
+
+`EDGE_BASIC_AUTH_PASSWORD_HASH` must be a Caddy bcrypt hash.
+
+## Generate password hash
+Run this command on your host:
+
+```bash
+caddy hash-password --plaintext 'replace-with-strong-password'
+```
+
+Use the output string as `EDGE_BASIC_AUTH_PASSWORD_HASH`.
+
+## Example startup
+
+```bash
+export EDGE_BASIC_AUTH_USER='codex'
+export EDGE_BASIC_AUTH_PASSWORD_HASH='$2a$14$.................................................'
+docker compose up -d
+```
+
+## Security notes
+- Do not commit plaintext passwords.
+- Rotate credentials if they are shared accidentally.
+- Keep `codexbox` unexposed to host/LAN.

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,5 +1,6 @@
-# Issue #3: edge HTTPS termination and reverse proxy.
+# Issue #3 + #19: edge HTTPS termination, auth, and reverse proxy.
 # `edge.crt` / `edge.key` must be issued by a local CA and mounted at /certs.
+# Basic auth credentials are injected from env vars at startup.
 
 :80 {
 	redir https://{host}{uri} permanent
@@ -7,5 +8,10 @@
 
 :443 {
 	tls /certs/edge.crt /certs/edge.key
+
+	basic_auth {
+		{$EDGE_BASIC_AUTH_USER} {$EDGE_BASIC_AUTH_PASSWORD_HASH}
+	}
+
 	reverse_proxy codexbox:8080
 }

--- a/tasks/archived/2026-03-06-issues-19-20-security-hardening/design.md
+++ b/tasks/archived/2026-03-06-issues-19-20-security-hardening/design.md
@@ -1,0 +1,27 @@
+# Issues 19-20 Design
+
+## Overview
+- Add Caddy `basic_auth` to the `:443` site block using runtime-injected env vars.
+- Add server-side safety policy constants in `webui-server.js`, reject unsafe client overrides, and force thread-start policy to safe defaults.
+
+## Main Decisions
+- Caddy auth variables:
+  - `EDGE_BASIC_AUTH_USER`
+  - `EDGE_BASIC_AUTH_PASSWORD_HASH`
+- Compose will require these variables at startup (`${VAR:?error}` style) to avoid insecure silent defaults.
+- Thread safety policy fixed at server side via env-configurable defaults:
+  - `CODEX_DEFAULT_APPROVAL_POLICY` (default `untrusted`)
+  - `CODEX_DEFAULT_SANDBOX` (default `read-only`)
+- Reject request payload keys that attempt to override safety policy:
+  - `/api/thread/start`: `approvalPolicy`, `sandbox`
+  - `/api/turn/start`: `approvalPolicy`, `sandboxPolicy`
+
+## Validation Strategy
+- `docker compose config` should fail if required auth env vars are missing.
+- `caddy adapt` with auth env vars should parse successfully.
+- API negative test for unsafe override should return an error.
+- Positive smoke flow should still complete `session/start` and `thread/start`.
+
+## Risks
+- Users without env vars set will see compose startup failure.
+  - Mitigation: document credential generation/setup clearly.

--- a/tasks/archived/2026-03-06-issues-19-20-security-hardening/plan.md
+++ b/tasks/archived/2026-03-06-issues-19-20-security-hardening/plan.md
@@ -1,0 +1,23 @@
+# Issues 19-20 Plan
+
+## TDD
+- TDD: partial
+- Rationale: Config and integration changes are better validated via command-level and API smoke/negative tests.
+
+## Steps
+- [x] Create requirements/design/plan artifacts.
+- [x] Update `infra/Caddyfile` to require Basic auth using env vars.
+- [x] Update `docker-compose.yml` to require auth env vars for `edge`.
+- [x] Add credential setup documentation for local development.
+- [x] Harden backend API parameter handling in `codexbox/webui-server.js`.
+- [x] Run security boundary and negative tests.
+- [x] Self-check acceptance criteria and prepare closeout.
+
+## Security and Compatibility Checks
+- Boundary check: unauthenticated access blocked at `edge`.
+- Negative test: reject unsafe override payload for `thread/start`.
+- Design check: secure-by-default expectations remain satisfied.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #19` and `Closes #20` in PR body when validated.

--- a/tasks/archived/2026-03-06-issues-19-20-security-hardening/requirements.md
+++ b/tasks/archived/2026-03-06-issues-19-20-security-hardening/requirements.md
@@ -1,0 +1,37 @@
+# Issues 19-20 Requirements
+
+## Goal
+- Enforce authenticated access at `edge` and block client-driven safety override escalation in backend execution APIs.
+
+## In Scope
+- Issue #19
+  - Require Basic auth at `edge` before reverse proxying to `codexbox`.
+  - Configure auth credentials from environment variables.
+  - Document local setup for auth credentials.
+- Issue #20
+  - Prevent clients from overriding safety-critical runtime settings (`approvalPolicy`, `sandbox`, `sandboxPolicy`).
+  - Enforce server-side defaults for thread execution safety policy.
+  - Add negative validation for unsafe override attempts.
+
+## Out of Scope
+- Comprehensive protocol compatibility expansion (`#21`).
+- P1/P2 feature work (`#9` and later).
+- OIDC or production identity federation.
+
+## Acceptance Criteria Mapping
+- #19
+  - Caddy auth is required before proxying.
+  - Credentials are env/secret-driven.
+  - Unauthorized access is rejected.
+- #20
+  - Backend enforces safe approval/sandbox defaults.
+  - Unsafe client overrides are rejected.
+  - Negative test proves escalation attempt is blocked.
+
+## Constraints and Assumptions
+- Keep changes small and focused.
+- Preserve HTTPS termination behavior.
+- Keep WebUI startup path functional after hardening.
+
+## Open Questions
+- None blocking for #19/#20 implementation.


### PR DESCRIPTION
## Summary
- Require Basic auth at `edge` before proxying WebUI traffic
- Require `EDGE_BASIC_AUTH_USER` and `EDGE_BASIC_AUTH_PASSWORD_HASH` in compose config
- Add local setup guide for edge authentication and Caddy password hash generation
- Enforce backend safety defaults for thread execution (`approvalPolicy=untrusted`, `sandbox=read-only` by default)
- Reject unsafe client overrides in execution APIs (`approvalPolicy`, `sandbox`, `sandboxPolicy`, `cwd`)
- Archive task execution artifacts for Issues #19 and #20

## Validation
- `node --check codexbox/webui-server.js`
- `docker compose config` (fails when auth env vars are missing)
- `EDGE_BASIC_AUTH_USER=... EDGE_BASIC_AUTH_PASSWORD_HASH=... docker compose config` (passes)
- `caddy adapt` with auth env vars shows authentication handler present
- Negative API test: `/api/thread/start` override attempt returns HTTP 400
- Positive API test: normal `thread/start` returns server-enforced safe settings

Closes #19
Closes #20
