### PR TITLE
feat(backend): add read-only git diff APIs

### DIFF
--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -117,9 +117,40 @@ function resolveWorkspacePath(requestedPath) {
   };
 }
 
+function normalizeRepoRelativePath(requestedPath) {
+  const rawPath = String(requestedPath || "").trim();
+  if (!rawPath) {
+    throw new Error("path is required");
+  }
+
+  const candidatePath = path.resolve(WORKSPACE_ROOT_REALPATH, rawPath);
+  if (!isPathInside(WORKSPACE_ROOT_REALPATH, candidatePath)) {
+    throw new Error(`path escapes workspace: ${rawPath}`);
+  }
+
+  const relativePath = path.relative(WORKSPACE_ROOT_REALPATH, candidatePath).split(path.sep).join("/");
+  if (!relativePath || relativePath === ".") {
+    throw new Error("path must point to a file");
+  }
+
+  return {
+    rawPath,
+    absolutePath: candidatePath,
+    relativePath,
+  };
+}
+
 async function runGit(args) {
   const { stdout } = await execFileAsync("git", ["-C", WORKSPACE_ROOT_REALPATH, ...args], {
     encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+async function runGitBuffer(args) {
+  const { stdout } = await execFileAsync("git", ["-C", WORKSPACE_ROOT_REALPATH, ...args], {
+    encoding: "buffer",
     maxBuffer: 8 * 1024 * 1024,
   });
   return stdout;
@@ -233,6 +264,31 @@ function ensureTextFile(buffer, requestedPath) {
   }
 }
 
+function toTextPayload(pathname, ref, exists, buffer) {
+  if (!exists) {
+    return {
+      path: pathname,
+      ref,
+      exists: false,
+      size: 0,
+      content: "",
+    };
+  }
+
+  if (buffer.length > MAX_FILE_BYTES) {
+    throw new Error(`file is too large: ${pathname}`);
+  }
+  ensureTextFile(buffer, pathname);
+
+  return {
+    path: pathname,
+    ref,
+    exists: true,
+    size: buffer.length,
+    content: buffer.toString("utf8"),
+  };
+}
+
 async function listWorkspaceFiles() {
   const [trackedOutput, statusOutput] = await Promise.all([
     runGit(["ls-files", "-z", "--cached"]),
@@ -317,6 +373,96 @@ async function readWorkspaceFile(requestedPath) {
     path: resolved.relativePath,
     size: buffer.length,
     content: buffer.toString("utf8"),
+  };
+}
+
+async function gitObjectExists(ref, relativePath) {
+  try {
+    await runGit(["cat-file", "-e", `${ref}:${relativePath}`]);
+    return true;
+  } catch (err) {
+    if (typeof err?.code === "number") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+async function gitObjectType(ref, relativePath) {
+  const output = await runGit(["cat-file", "-t", `${ref}:${relativePath}`]);
+  return output.trim();
+}
+
+async function readGitFile(requestedPath, ref = "HEAD") {
+  const normalized = normalizeRepoRelativePath(requestedPath);
+  const exists = await gitObjectExists(ref, normalized.relativePath);
+  if (!exists) {
+    return toTextPayload(normalized.relativePath, ref, false, Buffer.alloc(0));
+  }
+
+  const objectType = await gitObjectType(ref, normalized.relativePath);
+  if (objectType !== "blob") {
+    throw new Error(`path is not a file: ${requestedPath}`);
+  }
+
+  const buffer = await runGitBuffer(["show", `${ref}:${normalized.relativePath}`]);
+  return toTextPayload(normalized.relativePath, ref, true, buffer);
+}
+
+async function readWorkspaceFileVersion(requestedPath) {
+  const normalized = normalizeRepoRelativePath(requestedPath);
+  if (!fs.existsSync(normalized.absolutePath)) {
+    return toTextPayload(normalized.relativePath, "WORKTREE", false, Buffer.alloc(0));
+  }
+
+  const resolved = resolveWorkspacePath(normalized.relativePath);
+  const stat = await fs.promises.stat(resolved.absolutePath);
+  if (!stat.isFile()) {
+    throw new Error(`path is not a file: ${requestedPath}`);
+  }
+
+  const buffer = await fs.promises.readFile(resolved.absolutePath);
+  return toTextPayload(normalized.relativePath, "WORKTREE", true, buffer);
+}
+
+async function readGitStatus(requestedPath) {
+  const normalized = normalizeRepoRelativePath(requestedPath);
+  const output = await runGit([
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all",
+    "--",
+    normalized.relativePath,
+  ]);
+  const status = parseGitStatusPorcelain(output).get(normalized.relativePath);
+
+  return {
+    path: normalized.relativePath,
+    gitStatus: status?.code || "  ",
+    indexStatus: status?.indexStatus || " ",
+    worktreeStatus: status?.worktreeStatus || " ",
+  };
+}
+
+async function readGitDiff(requestedPath) {
+  const status = await readGitStatus(requestedPath);
+  const [left, right] = await Promise.all([
+    readGitFile(status.path, "HEAD"),
+    readWorkspaceFileVersion(status.path),
+  ]);
+
+  if (!left.exists && !right.exists) {
+    throw new Error(`path not found: ${status.path}`);
+  }
+
+  return {
+    path: status.path,
+    gitStatus: status.gitStatus,
+    indexStatus: status.indexStatus,
+    worktreeStatus: status.worktreeStatus,
+    left,
+    right,
   };
 }
 
@@ -1184,6 +1330,25 @@ async function handleGetApi(req, res, pathname, searchParams) {
     sendJson(res, 200, {
       ok: true,
       file,
+    });
+    return;
+  }
+
+  if (pathname === "/api/git/show") {
+    const ref = String(searchParams.get("ref") || "HEAD").trim() || "HEAD";
+    const file = await readGitFile(searchParams.get("path"), ref);
+    sendJson(res, 200, {
+      ok: true,
+      file,
+    });
+    return;
+  }
+
+  if (pathname === "/api/git/diff") {
+    const diff = await readGitDiff(searchParams.get("path"));
+    sendJson(res, 200, {
+      ok: true,
+      diff,
     });
     return;
   }

--- a/codexbox/webui-server.test.js
+++ b/codexbox/webui-server.test.js
@@ -4,11 +4,14 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs/promises");
 const net = require("node:net");
+const os = require("node:os");
 const path = require("node:path");
-const { spawn } = require("node:child_process");
+const { spawn, execFile } = require("node:child_process");
+const { promisify } = require("node:util");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const SERVER_PATH = path.join(__dirname, "webui-server.js");
+const execFileAsync = promisify(execFile);
 
 async function findFreePort() {
   return new Promise((resolve, reject) => {
@@ -46,7 +49,33 @@ async function waitForServer(port) {
   throw new Error("server did not become ready in time");
 }
 
-async function startServer(t) {
+async function git(repoDir, args) {
+  const result = await execFileAsync("git", ["-C", repoDir, ...args], {
+    encoding: "utf8",
+  });
+  return result.stdout;
+}
+
+async function createTempGitRepo(t) {
+  const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-webui-git-"));
+  t.after(async () => {
+    await fs.rm(repoDir, { recursive: true, force: true });
+  });
+
+  await git(repoDir, ["init", "-q"]);
+  await git(repoDir, ["config", "user.email", "test@example.com"]);
+  await git(repoDir, ["config", "user.name", "Test User"]);
+
+  await fs.writeFile(path.join(repoDir, "tracked.txt"), "tracked-v1\n");
+  await fs.mkdir(path.join(repoDir, "nested"), { recursive: true });
+  await fs.writeFile(path.join(repoDir, "nested", "keep.txt"), "nested-v1\n");
+  await git(repoDir, ["add", "."]);
+  await git(repoDir, ["commit", "-qm", "init"]);
+
+  return repoDir;
+}
+
+async function startServer(t, options = {}) {
   const port = await findFreePort();
   const child = spawn(process.execPath, [SERVER_PATH], {
     cwd: REPO_ROOT,
@@ -54,7 +83,8 @@ async function startServer(t) {
       ...process.env,
       HOST: "127.0.0.1",
       PORT: String(port),
-      MAX_FILE_BYTES: "128",
+      MAX_FILE_BYTES: options.maxFileBytes || "128",
+      WORKSPACE_ROOT: options.workspaceRoot || REPO_ROOT,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -151,4 +181,109 @@ test("GET /api/fs/file rejects oversized files", async (t) => {
   const body = await response.json();
   assert.equal(body.ok, false);
   assert.match(body.error, /file is too large/);
+});
+
+test("GET /api/git/show returns HEAD content for a tracked file", async (t) => {
+  const repoDir = await createTempGitRepo(t);
+  await fs.writeFile(path.join(repoDir, "tracked.txt"), "tracked-v2\n");
+
+  const { port } = await startServer(t, { workspaceRoot: repoDir });
+  const response = await fetch(
+    `http://127.0.0.1:${port}/api/git/show?path=${encodeURIComponent("tracked.txt")}`,
+  );
+  assert.equal(response.status, 200);
+
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.file.path, "tracked.txt");
+  assert.equal(body.file.ref, "HEAD");
+  assert.equal(body.file.exists, true);
+  assert.equal(body.file.content, "tracked-v1\n");
+});
+
+test("GET /api/git/show rejects directories", async (t) => {
+  const repoDir = await createTempGitRepo(t);
+
+  const { port } = await startServer(t, { workspaceRoot: repoDir });
+  const response = await fetch(
+    `http://127.0.0.1:${port}/api/git/show?path=${encodeURIComponent("nested")}`,
+  );
+  assert.equal(response.status, 400);
+
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.match(body.error, /path is not a file/);
+});
+
+test("GET /api/git/diff returns HEAD and worktree content for modified files", async (t) => {
+  const repoDir = await createTempGitRepo(t);
+  await fs.writeFile(path.join(repoDir, "tracked.txt"), "tracked-v2\n");
+
+  const { port } = await startServer(t, { workspaceRoot: repoDir });
+  const response = await fetch(
+    `http://127.0.0.1:${port}/api/git/diff?path=${encodeURIComponent("tracked.txt")}`,
+  );
+  assert.equal(response.status, 200);
+
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.diff.path, "tracked.txt");
+  assert.equal(body.diff.left.content, "tracked-v1\n");
+  assert.equal(body.diff.right.content, "tracked-v2\n");
+  assert.equal(body.diff.left.exists, true);
+  assert.equal(body.diff.right.exists, true);
+  assert.match(body.diff.gitStatus, /M/);
+});
+
+test("GET /api/git/diff uses an empty left side for new files", async (t) => {
+  const repoDir = await createTempGitRepo(t);
+  await fs.writeFile(path.join(repoDir, "new-file.txt"), "brand-new\n");
+
+  const { port } = await startServer(t, { workspaceRoot: repoDir });
+  const response = await fetch(
+    `http://127.0.0.1:${port}/api/git/diff?path=${encodeURIComponent("new-file.txt")}`,
+  );
+  assert.equal(response.status, 200);
+
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.diff.left.exists, false);
+  assert.equal(body.diff.left.content, "");
+  assert.equal(body.diff.right.exists, true);
+  assert.equal(body.diff.right.content, "brand-new\n");
+  assert.equal(body.diff.right.ref, "WORKTREE");
+  assert.equal(body.diff.gitStatus, "??");
+});
+
+test("GET /api/git/diff uses an empty right side for deleted files", async (t) => {
+  const repoDir = await createTempGitRepo(t);
+  await fs.rm(path.join(repoDir, "tracked.txt"));
+
+  const { port } = await startServer(t, { workspaceRoot: repoDir });
+  const response = await fetch(
+    `http://127.0.0.1:${port}/api/git/diff?path=${encodeURIComponent("tracked.txt")}`,
+  );
+  assert.equal(response.status, 200);
+
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.diff.left.exists, true);
+  assert.equal(body.diff.left.content, "tracked-v1\n");
+  assert.equal(body.diff.right.exists, false);
+  assert.equal(body.diff.right.content, "");
+  assert.match(body.diff.gitStatus, /D/);
+});
+
+test("GET /api/git/diff blocks path traversal", async (t) => {
+  const repoDir = await createTempGitRepo(t);
+
+  const { port } = await startServer(t, { workspaceRoot: repoDir });
+  const response = await fetch(
+    `http://127.0.0.1:${port}/api/git/diff?path=${encodeURIComponent("../etc/passwd")}`,
+  );
+  assert.equal(response.status, 400);
+
+  const body = await response.json();
+  assert.equal(body.ok, false);
+  assert.match(body.error, /path escapes workspace/);
 });

--- a/tasks/archived/2026-03-06-issue-10-git-diff-apis/design.md
+++ b/tasks/archived/2026-03-06-issue-10-git-diff-apis/design.md
@@ -1,0 +1,26 @@
+# Issue 10 Design
+
+## Overview
+- Extend the existing Node server with Git-specific read helpers.
+- Normalize repo-relative paths separately from filesystem-resolved paths so deleted files can still be shown from `HEAD`.
+
+## API Shape
+- `GET /api/git/show?path=...&ref=HEAD`
+  - Returns `{ ok, file }`
+  - `file` includes `path`, `ref`, `exists`, `size`, and `content`
+- `GET /api/git/diff?path=...`
+  - Returns `{ ok, diff }`
+  - `diff` includes `path`, Git status fields, and `left` / `right` text payloads
+  - `left` is the Git side (`HEAD`)
+  - `right` is the worktree side
+
+## Main Decisions
+- Require `path` for both endpoints.
+- Treat missing `HEAD` content as an empty left side for new files.
+- Treat missing worktree content as an empty right side for deleted files.
+- Reject binary or oversized text on both sides with the same safety checks used for `/api/fs/file`.
+- Use temporary Git repos in tests so modified/new/deleted states can be exercised safely.
+
+## Risks
+- Git path resolution differs from filesystem resolution for symlinks and deleted files.
+  - Mitigation: validate repo-relative paths for escape prevention, then resolve worktree paths separately when filesystem content is needed.

--- a/tasks/archived/2026-03-06-issue-10-git-diff-apis/plan.md
+++ b/tasks/archived/2026-03-06-issue-10-git-diff-apis/plan.md
@@ -1,0 +1,25 @@
+# Issue 10 Plan
+
+## TDD
+- TDD: partial
+- Rationale: endpoint behavior and edge cases are clear enough to pin with tests, but the server helper refactor is easier to shape while implementing.
+
+## Steps
+- [x] Add repo-relative path normalization and Git blob read helpers.
+- [x] Implement `GET /api/git/show`.
+- [x] Implement `GET /api/git/diff`.
+- [x] Add tests for modified, new, deleted, and path-escape cases using temporary Git repos.
+- [x] Run validation and self-check acceptance criteria.
+
+## Validation Notes
+- `node --test codexbox/webui-server.test.js`
+- Result: pass (10 tests) on 2026-03-06
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #10` in the PR description.
+
+## Self-Check
+- `GET /api/git/show` and `GET /api/git/diff` are implemented backend-only.
+- New, modified, deleted, and repo-escape cases are covered by tests.
+- Bundled WebUI consumption remains explicitly tracked in Issue #11.

--- a/tasks/archived/2026-03-06-issue-10-git-diff-apis/requirements.md
+++ b/tasks/archived/2026-03-06-issue-10-git-diff-apis/requirements.md
@@ -1,0 +1,30 @@
+# Issue 10 Requirements
+
+## Goal
+- Add read-only Git diff endpoints for workspace file comparison views.
+
+## In Scope
+- Add `GET /api/git/show` for repository content lookup.
+- Add `GET /api/git/diff` for HEAD vs worktree comparison of a single repo-relative path.
+- Handle new and deleted file cases without assuming `HEAD:path` always exists.
+- Reject repo escape and non-text responses.
+- Add regression validation for backend diff behavior.
+
+## Out of Scope
+- Diff pane rendering in the bundled WebUI.
+- Turn-local snapshot diffs from Issue #13.
+- Reconnect or session behavior from Issue #12.
+
+## Acceptance Criteria Mapping
+- Diff endpoint exists.
+- File show endpoint exists.
+- New and deleted file cases are handled.
+- Response shape is sufficient for the bundled WebUI work in Issue #11.
+- Validation covers backend diff contract and edge cases.
+
+## Constraints and Assumptions
+- Keep the change backend-only.
+- Reuse the existing workspace path and text-file safety constraints where practical.
+
+## Open Questions
+- None blocking.


### PR DESCRIPTION
## Summary
- add `GET /api/git/show` and `GET /api/git/diff` for read-only Git-backed file comparison
- cover modified, new, deleted, and path traversal cases with backend tests
- archive the completed Issue #10 task artifacts

## Validation
- node --test codexbox/webui-server.test.js

Closes #10