### PR TITLE
feat(frontend): add file tree and diff panes

### DIFF
--- a/codexbox/public/app.js
+++ b/codexbox/public/app.js
@@ -19,17 +19,36 @@ function createApp(env = {}) {
     messageById: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    workspaceTree: [],
+    selectedPath: null,
+    selectedFile: null,
+    selectedDiff: null,
+    selectedEntry: null,
+    filePreviewError: "",
+    diffError: "",
+    loadingWorkspaceTree: false,
+    loadingSelection: false,
+    activePane: "chat",
+    selectionRequestToken: 0,
   };
 
   const els = {
+    shell: doc.getElementById("shell"),
     status: doc.getElementById("status"),
     sessionId: doc.getElementById("session-id"),
     messages: doc.getElementById("messages"),
+    workspaceTree: doc.getElementById("workspace-tree"),
+    selectedPath: doc.getElementById("selected-path"),
+    filePreview: doc.getElementById("file-preview"),
+    diffView: doc.getElementById("diff-view"),
     approvals: doc.getElementById("approvals"),
     userInputs: doc.getElementById("user-inputs"),
     composer: doc.getElementById("composer"),
     prompt: doc.getElementById("prompt"),
     send: doc.getElementById("send"),
+    tabChat: doc.getElementById("tab-chat"),
+    tabFiles: doc.getElementById("tab-files"),
+    tabDiff: doc.getElementById("tab-diff"),
   };
 
   function setStatus(text) {
@@ -90,6 +109,306 @@ function createApp(env = {}) {
     } catch {
       return null;
     }
+  }
+
+  function findFirstFileNode(nodes) {
+    for (const node of nodes || []) {
+      if (node.type === "file") {
+        return node;
+      }
+      if (node.type === "directory") {
+        const nested = findFirstFileNode(node.children || []);
+        if (nested) {
+          return nested;
+        }
+      }
+    }
+    return null;
+  }
+
+  function findEntryByPath(nodes, targetPath) {
+    for (const node of nodes || []) {
+      if (node.path === targetPath) {
+        return node;
+      }
+      if (node.type === "directory") {
+        const nested = findEntryByPath(node.children || [], targetPath);
+        if (nested) {
+          return nested;
+        }
+      }
+    }
+    return null;
+  }
+
+  function describeGitStatus(code) {
+    const trimmed = String(code || "").trim();
+    return trimmed || "clean";
+  }
+
+  function setActivePane(pane) {
+    state.activePane = pane;
+    if (els.shell) {
+      els.shell.dataset.activePane = pane;
+    }
+
+    const tabMap = [
+      [els.tabChat, "chat"],
+      [els.tabFiles, "files"],
+      [els.tabDiff, "diff"],
+    ];
+    for (const [button, buttonPane] of tabMap) {
+      if (!button) {
+        continue;
+      }
+      button.classList.toggle("is-active", buttonPane === pane);
+    }
+  }
+
+  function renderWorkspaceTreeNodes(nodes, container, depth) {
+    for (const node of nodes || []) {
+      if (node.type === "directory") {
+        const directory = createElement("section", "tree-directory");
+        const label = createElement("div", "tree-directory-label", node.name);
+        label.dataset.depth = String(depth);
+
+        const children = createElement("div", "tree-children");
+        children.dataset.depth = String(depth + 1);
+
+        directory.appendChild(label);
+        renderWorkspaceTreeNodes(node.children || [], children, depth + 1);
+        directory.appendChild(children);
+        container.appendChild(directory);
+        continue;
+      }
+
+      const button = createElement("button", "tree-file");
+      const name = createElement("span", "tree-file-name", node.name);
+      const status = createElement("span", "tree-file-status", describeGitStatus(node.gitStatus));
+
+      button.type = "button";
+      button.dataset.path = node.path;
+      button.dataset.depth = String(depth);
+      button.classList.toggle("is-selected", node.path === state.selectedPath);
+      button.addEventListener("click", async () => {
+        await selectPath(node.path);
+        setActivePane("diff");
+      });
+
+      button.appendChild(name);
+      button.appendChild(status);
+      container.appendChild(button);
+    }
+  }
+
+  function renderWorkspaceTree() {
+    const nodes = state.workspaceTree || [];
+    els.workspaceTree.classList.toggle("empty", nodes.length === 0);
+
+    if (state.loadingWorkspaceTree) {
+      els.workspaceTree.textContent = "Loading files...";
+      return;
+    }
+
+    if (nodes.length === 0) {
+      els.workspaceTree.textContent = "No files available.";
+      return;
+    }
+
+    els.workspaceTree.replaceChildren();
+    renderWorkspaceTreeNodes(nodes, els.workspaceTree, 0);
+  }
+
+  function renderFilePreview() {
+    els.filePreview.classList.toggle("empty", !state.selectedPath || state.loadingSelection);
+
+    if (!state.selectedPath) {
+      els.selectedPath.textContent = "Select a file to inspect.";
+      els.filePreview.textContent = "Select a file from the tree to inspect its workspace contents.";
+      return;
+    }
+
+    els.selectedPath.textContent = state.selectedPath;
+
+    if (state.loadingSelection) {
+      els.filePreview.textContent = `Loading workspace file for ${state.selectedPath}...`;
+      return;
+    }
+
+    if (state.filePreviewError) {
+      els.filePreview.textContent = state.filePreviewError;
+      return;
+    }
+
+    if (!state.selectedFile) {
+      els.filePreview.textContent = "No workspace file content available.";
+      return;
+    }
+
+    const card = createElement("article", "inspector-card");
+    const meta = createElement(
+      "p",
+      "inspector-meta",
+      `${state.selectedFile.path} · ${state.selectedFile.size} bytes`,
+    );
+    const body = createElement("pre", "code-block", state.selectedFile.content);
+
+    card.appendChild(meta);
+    card.appendChild(body);
+    els.filePreview.replaceChildren(card);
+  }
+
+  function createDiffSide(title, payload) {
+    const side = createElement("article", "diff-side");
+    const heading = createElement("div", "diff-side-heading");
+    const titleNode = createElement("h3", "diff-side-title", title);
+    const refNode = createElement("p", "diff-side-ref", payload.ref || "");
+    const body = createElement("pre", "code-block", payload.exists ? payload.content : "");
+
+    heading.appendChild(titleNode);
+    heading.appendChild(refNode);
+    side.appendChild(heading);
+
+    if (!payload.exists) {
+      side.appendChild(createElement("p", "diff-empty", "File does not exist on this side."));
+      return side;
+    }
+
+    side.appendChild(body);
+    return side;
+  }
+
+  function renderDiffView() {
+    els.diffView.classList.toggle("empty", !state.selectedPath || state.loadingSelection);
+
+    if (!state.selectedPath) {
+      els.diffView.textContent = "Select a file to render its Git-backed diff.";
+      return;
+    }
+
+    if (state.loadingSelection) {
+      els.diffView.textContent = `Loading Git diff for ${state.selectedPath}...`;
+      return;
+    }
+
+    if (state.diffError) {
+      els.diffView.textContent = state.diffError;
+      return;
+    }
+
+    if (!state.selectedDiff) {
+      els.diffView.textContent = "No Git diff available.";
+      return;
+    }
+
+    const wrapper = createElement("article", "diff-card");
+    const meta = createElement(
+      "p",
+      "inspector-meta",
+      `${state.selectedDiff.path} · status ${describeGitStatus(state.selectedDiff.gitStatus)}`,
+    );
+    const columns = createElement("div", "diff-columns");
+
+    columns.appendChild(createDiffSide("HEAD", state.selectedDiff.left));
+    columns.appendChild(createDiffSide("WORKTREE", state.selectedDiff.right));
+    wrapper.appendChild(meta);
+    wrapper.appendChild(columns);
+    els.diffView.replaceChildren(wrapper);
+  }
+
+  async function loadWorkspaceTree() {
+    state.loadingWorkspaceTree = true;
+    renderWorkspaceTree();
+
+    try {
+      const response = await api("/api/fs/tree", null, "GET");
+      state.workspaceTree = Array.isArray(response.tree) ? response.tree : [];
+      renderWorkspaceTree();
+
+      const currentEntry = state.selectedPath
+        ? findEntryByPath(state.workspaceTree, state.selectedPath)
+        : null;
+      if (currentEntry) {
+        await selectPath(currentEntry.path);
+        return;
+      }
+
+      const firstFile = findFirstFileNode(state.workspaceTree);
+      if (firstFile) {
+        await selectPath(firstFile.path);
+      } else {
+        state.selectedPath = null;
+        state.selectedEntry = null;
+        state.selectedFile = null;
+        state.selectedDiff = null;
+        state.filePreviewError = "";
+        state.diffError = "";
+        renderFilePreview();
+        renderDiffView();
+      }
+    } catch (err) {
+      state.workspaceTree = [];
+      els.workspaceTree.classList.add("empty");
+      els.workspaceTree.textContent = `Failed to load workspace tree: ${err.message}`;
+      setStatus(`Workspace error: ${err.message}`);
+    } finally {
+      state.loadingWorkspaceTree = false;
+      renderWorkspaceTree();
+    }
+  }
+
+  async function selectPath(pathname) {
+    const path = String(pathname || "");
+    if (!path) {
+      return;
+    }
+
+    state.selectedPath = path;
+    state.selectedEntry = findEntryByPath(state.workspaceTree, path);
+    state.selectedFile = null;
+    state.selectedDiff = null;
+    state.filePreviewError = "";
+    state.diffError = "";
+    state.loadingSelection = true;
+    const token = ++state.selectionRequestToken;
+
+    renderWorkspaceTree();
+    renderFilePreview();
+    renderDiffView();
+
+    const encodedPath = encodeURIComponent(path);
+    const [fileResult, diffResult] = await Promise.allSettled([
+      api(`/api/fs/file?path=${encodedPath}`, null, "GET"),
+      api(`/api/git/diff?path=${encodedPath}`, null, "GET"),
+    ]);
+
+    if (token !== state.selectionRequestToken) {
+      return;
+    }
+
+    state.loadingSelection = false;
+
+    if (fileResult.status === "fulfilled") {
+      state.selectedFile = fileResult.value.file || null;
+    } else {
+      state.filePreviewError = `Failed to load file: ${fileResult.reason.message}`;
+    }
+
+    if (diffResult.status === "fulfilled") {
+      state.selectedDiff = diffResult.value.diff || null;
+    } else {
+      state.diffError = `Failed to load diff: ${diffResult.reason.message}`;
+    }
+
+    renderWorkspaceTree();
+    renderFilePreview();
+    renderDiffView();
+
+    if (state.filePreviewError || state.diffError) {
+      setStatus(`Inspect error: ${state.filePreviewError || state.diffError}`);
+      return;
+    }
+    setStatus(`Loaded ${path}`);
   }
 
   function renderApprovals() {
@@ -530,11 +849,35 @@ function createApp(env = {}) {
     });
   }
 
+  function bindPaneTabs() {
+    const tabs = [
+      [els.tabChat, "chat"],
+      [els.tabFiles, "files"],
+      [els.tabDiff, "diff"],
+    ];
+
+    for (const [button, pane] of tabs) {
+      if (!button) {
+        continue;
+      }
+      button.addEventListener("click", () => {
+        setActivePane(pane);
+      });
+    }
+  }
+
   async function init() {
+    setActivePane(state.activePane);
     updateComposerState();
+    renderWorkspaceTree();
+    renderFilePreview();
+    renderDiffView();
     renderApprovals();
     renderUserInputs();
     bindComposer();
+    bindPaneTabs();
+
+    await loadWorkspaceTree();
 
     if (autoStart) {
       await startSession();
@@ -546,6 +889,8 @@ function createApp(env = {}) {
     els,
     init,
     api,
+    loadWorkspaceTree,
+    selectPath,
     applySessionSnapshot,
     handleUserInputPending,
     handleUserInputResolved,

--- a/codexbox/public/app.test.js
+++ b/codexbox/public/app.test.js
@@ -118,14 +118,22 @@ class FakeDocument {
   constructor() {
     this.nodes = new Map();
     for (const id of [
+      "shell",
       "status",
       "session-id",
       "messages",
+      "workspace-tree",
+      "selected-path",
+      "file-preview",
+      "diff-view",
       "approvals",
       "user-inputs",
       "composer",
       "prompt",
       "send",
+      "tab-chat",
+      "tab-files",
+      "tab-diff",
     ]) {
       this.nodes.set(id, new FakeElement("div", id));
     }
@@ -227,9 +235,9 @@ test("bundled UI renders and submits pending user-input requests", async () => {
     preventDefault() {},
   });
 
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].requestPath, "/api/user-input/respond");
-  assert.deepEqual(calls[0].body, {
+  const respondCall = calls.find((call) => call.requestPath === "/api/user-input/respond");
+  assert.ok(respondCall);
+  assert.deepEqual(respondCall.body, {
     sessionId: "session-1",
     requestId: "42",
     answers: {
@@ -243,4 +251,173 @@ test("bundled UI renders and submits pending user-input requests", async () => {
     },
   });
   assert.match(userInputRoot.textContent, /No pending user input requests/);
+});
+
+test("bundled UI renders workspace tree and Git-backed file inspection", async () => {
+  const document = new FakeDocument();
+  const calls = [];
+  const app = createApp({
+    document,
+    autoStart: false,
+    EventSource: class {},
+    fetch: async (requestPath, options) => {
+      calls.push({
+        requestPath,
+        method: options.method,
+      });
+
+      if (requestPath === "/api/fs/tree") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            tree: [
+              {
+                type: "file",
+                name: "README.md",
+                path: "README.md",
+                tracked: true,
+                gitStatus: " M",
+                indexStatus: " ",
+                worktreeStatus: "M",
+              },
+              {
+                type: "directory",
+                name: "docs",
+                path: "docs",
+                children: [
+                  {
+                    type: "file",
+                    name: "notes.md",
+                    path: "docs/notes.md",
+                    tracked: true,
+                    gitStatus: "??",
+                    indexStatus: "?",
+                    worktreeStatus: "?",
+                  },
+                ],
+              },
+            ],
+          }),
+        };
+      }
+
+      if (requestPath === "/api/fs/file?path=README.md") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            file: {
+              path: "README.md",
+              size: 12,
+              content: "hello world\n",
+            },
+          }),
+        };
+      }
+
+      if (requestPath === "/api/git/diff?path=README.md") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            diff: {
+              path: "README.md",
+              gitStatus: " M",
+              left: {
+                path: "README.md",
+                ref: "HEAD",
+                exists: true,
+                size: 5,
+                content: "hello",
+              },
+              right: {
+                path: "README.md",
+                ref: "WORKTREE",
+                exists: true,
+                size: 12,
+                content: "hello world\n",
+              },
+            },
+          }),
+        };
+      }
+
+      if (requestPath === "/api/fs/file?path=docs%2Fnotes.md") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            file: {
+              path: "docs/notes.md",
+              size: 11,
+              content: "notes here\n",
+            },
+          }),
+        };
+      }
+
+      if (requestPath === "/api/git/diff?path=docs%2Fnotes.md") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            diff: {
+              path: "docs/notes.md",
+              gitStatus: "??",
+              left: {
+                path: "docs/notes.md",
+                ref: "HEAD",
+                exists: false,
+                size: 0,
+                content: "",
+              },
+              right: {
+                path: "docs/notes.md",
+                ref: "WORKTREE",
+                exists: true,
+                size: 11,
+                content: "notes here\n",
+              },
+            },
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected request: ${requestPath}`);
+    },
+  });
+
+  await app.init();
+
+  const workspaceTree = document.getElementById("workspace-tree");
+  const filePreview = document.getElementById("file-preview");
+  const diffView = document.getElementById("diff-view");
+
+  assert.match(workspaceTree.textContent, /README\.md/);
+  assert.match(workspaceTree.textContent, /notes\.md/);
+  assert.match(filePreview.textContent, /hello world/);
+  assert.match(diffView.textContent, /HEAD/);
+  assert.match(diffView.textContent, /WORKTREE/);
+  await document.getElementById("tab-files").dispatchEvent({ type: "click" });
+  assert.equal(document.getElementById("shell").dataset.activePane, "files");
+
+  const notesButton = findFirst(
+    workspaceTree,
+    (node) => node.tagName === "BUTTON" && node.dataset.path === "docs/notes.md",
+  );
+  assert.ok(notesButton);
+  await notesButton.dispatchEvent({ type: "click" });
+
+  assert.equal(app.state.selectedPath, "docs/notes.md");
+  assert.equal(document.getElementById("shell").dataset.activePane, "diff");
+  assert.match(filePreview.textContent, /notes here/);
+  assert.match(diffView.textContent, /File does not exist on this side/);
+  assert.ok(calls.some((call) => call.requestPath === "/api/fs/tree"));
+  assert.ok(calls.some((call) => call.requestPath === "/api/git/diff?path=docs%2Fnotes.md"));
 });

--- a/codexbox/public/index.html
+++ b/codexbox/public/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
-    <div class="shell">
+    <div id="shell" class="shell" data-active-pane="chat">
       <header class="topbar">
         <div>
           <h1>Codex WebUI</h1>
@@ -19,8 +19,24 @@
         </div>
       </header>
 
+      <nav class="workspace-nav" aria-label="Workspace panes">
+        <button id="tab-chat" class="pane-tab is-active" type="button">Chat</button>
+        <button id="tab-files" class="pane-tab" type="button">Files</button>
+        <button id="tab-diff" class="pane-tab" type="button">Inspect</button>
+      </nav>
+
       <main class="layout">
-        <section class="chat-panel">
+        <aside class="explorer-panel" data-pane="files">
+          <section class="panel-section">
+            <div class="panel-heading">
+              <h2>Files</h2>
+              <p>Read-only workspace tree</p>
+            </div>
+            <div id="workspace-tree" class="workspace-tree empty">Loading files...</div>
+          </section>
+        </aside>
+
+        <section class="chat-panel" data-pane="chat">
           <div id="messages" class="messages" aria-live="polite"></div>
           <form id="composer" class="composer">
             <textarea id="prompt" placeholder="Type your prompt..." rows="3"></textarea>
@@ -28,14 +44,36 @@
           </form>
         </section>
 
-        <aside class="approval-panel">
+        <aside class="side-panel" data-pane="diff">
           <section class="panel-section">
-            <h2>Approvals</h2>
+            <div class="panel-heading">
+              <h2>File</h2>
+              <p id="selected-path" class="selected-path">Select a file to inspect.</p>
+            </div>
+            <div id="file-preview" class="file-preview empty">Select a file from the tree to inspect its workspace contents.</div>
+          </section>
+
+          <section class="panel-section">
+            <div class="panel-heading">
+              <h2>Diff</h2>
+              <p>HEAD vs worktree</p>
+            </div>
+            <div id="diff-view" class="diff-view empty">Select a file to render its Git-backed diff.</div>
+          </section>
+
+          <section class="panel-section">
+            <div class="panel-heading">
+              <h2>Approvals</h2>
+              <p>Pending tool or file-change requests</p>
+            </div>
             <div id="approvals" class="approvals empty">No pending approvals.</div>
           </section>
 
           <section class="panel-section">
-            <h2>User Input</h2>
+            <div class="panel-heading">
+              <h2>User Input</h2>
+              <p>Questions waiting on browser input</p>
+            </div>
             <div id="user-inputs" class="user-inputs empty">No pending user input requests.</div>
           </section>
         </aside>

--- a/codexbox/public/styles.css
+++ b/codexbox/public/styles.css
@@ -7,7 +7,9 @@
   --accent-soft: #d6ece7;
   --warn: #8b2f2f;
   --line: #d7c9bb;
+  --line-soft: #eadfd4;
   --panel: #fffefc;
+  --panel-soft: #fbf5ee;
 }
 
 * {
@@ -26,7 +28,7 @@ body {
 }
 
 .shell {
-  max-width: 1200px;
+  max-width: 1440px;
   margin: 0 auto;
   padding: 20px;
 }
@@ -69,18 +71,50 @@ body {
   color: var(--ink-0);
 }
 
-.layout {
-  display: grid;
-  grid-template-columns: 1.8fr 1fr;
-  gap: 14px;
+.workspace-nav {
+  display: none;
+  gap: 8px;
+  margin-bottom: 12px;
 }
 
+.pane-tab {
+  border: 1px solid #cebcae;
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--ink-1);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.pane-tab.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.9fr) minmax(420px, 1.5fr) minmax(320px, 1.1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.explorer-panel,
 .chat-panel,
-.approval-panel {
+.side-panel {
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 14px;
   box-shadow: 0 6px 20px rgba(49, 37, 20, 0.07);
+}
+
+.explorer-panel,
+.side-panel {
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+  align-content: start;
 }
 
 .chat-panel {
@@ -88,6 +122,32 @@ body {
   display: grid;
   grid-template-rows: 1fr auto;
   overflow: hidden;
+}
+
+.panel-section {
+  display: grid;
+  gap: 10px;
+}
+
+.panel-heading {
+  display: grid;
+  gap: 3px;
+}
+
+.panel-heading h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.panel-heading p,
+.selected-path,
+.inspector-meta,
+.approval-method,
+.user-input-method,
+.diff-side-ref {
+  margin: 0;
+  color: var(--ink-1);
+  font-size: 0.85rem;
 }
 
 .messages {
@@ -134,11 +194,10 @@ body {
   gap: 10px;
 }
 
-.composer textarea {
+.composer textarea,
+.user-input-answer {
   width: 100%;
   resize: vertical;
-  min-height: 50px;
-  max-height: 180px;
   border: 1px solid #cbb8a5;
   border-radius: 10px;
   padding: 10px;
@@ -146,7 +205,13 @@ body {
   background: #fffdfb;
 }
 
-.composer button {
+.composer textarea {
+  min-height: 50px;
+  max-height: 180px;
+}
+
+.composer button,
+.user-input-submit {
   border: none;
   border-radius: 10px;
   background: var(--accent);
@@ -161,24 +226,9 @@ body {
   cursor: not-allowed;
 }
 
-.approval-panel {
-  padding: 12px;
-  display: grid;
-  grid-template-rows: auto auto;
-  gap: 10px;
-  align-content: start;
-}
-
-.panel-section {
-  display: grid;
-  gap: 10px;
-}
-
-.approval-panel h2 {
-  margin: 0;
-  font-size: 1rem;
-}
-
+.workspace-tree,
+.file-preview,
+.diff-view,
 .approvals,
 .user-inputs {
   display: grid;
@@ -186,60 +236,72 @@ body {
   align-content: start;
 }
 
+.workspace-tree.empty,
+.file-preview.empty,
+.diff-view.empty,
 .approvals.empty,
 .user-inputs.empty {
   color: var(--ink-1);
   font-size: 0.92rem;
 }
 
-.approval-card {
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 9px;
-  background: #fff;
+.tree-directory {
+  display: grid;
+  gap: 8px;
 }
 
-.approval-method {
-  margin: 0 0 6px;
-  font-size: 0.86rem;
+.tree-directory-label {
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--ink-1);
+  padding-left: calc(var(--depth, 0) * 12px);
 }
 
-.approval-body {
-  margin: 0;
-  max-height: 140px;
-  overflow: auto;
-  font-size: 0.78rem;
-  background: #f8f4ef;
-  border: 1px solid #e0d2c3;
-  border-radius: 8px;
-  padding: 8px;
-}
-
-.approval-actions {
-  display: flex;
+.tree-children {
+  display: grid;
   gap: 6px;
-  margin-top: 8px;
 }
 
-.approval-actions button {
-  border: 1px solid #c7b39d;
+.tree-file {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  border: 1px solid var(--line-soft);
   background: #fff;
-  border-radius: 8px;
-  padding: 5px 8px;
+  border-radius: 10px;
+  padding: 8px 10px;
   cursor: pointer;
+  text-align: left;
+  font: inherit;
 }
 
-.approval-actions button[data-decision="allow"] {
-  background: var(--accent-soft);
+.tree-file.is-selected {
   border-color: #9dcabc;
+  background: #f2f8f6;
 }
 
-.approval-actions button[data-decision="deny"],
-.approval-actions button[data-decision="cancel"] {
-  color: var(--warn);
+.tree-file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
+.tree-file-status {
+  flex: none;
+  border-radius: 999px;
+  border: 1px solid #d6ccc1;
+  padding: 2px 7px;
+  font-size: 0.76rem;
+  color: var(--ink-1);
+  background: var(--panel-soft);
+}
+
+.inspector-card,
+.diff-card,
+.approval-card,
 .user-input-card {
   border: 1px solid var(--line);
   border-radius: 10px;
@@ -247,31 +309,46 @@ body {
   background: #fff;
 }
 
-.user-input-method {
-  margin: 0 0 8px;
-  font-size: 0.86rem;
-  color: var(--ink-1);
+.code-block,
+.approval-body {
+  margin: 0;
+  max-height: 220px;
+  overflow: auto;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  background: #f8f4ef;
+  border: 1px solid #e0d2c3;
+  border-radius: 8px;
+  padding: 8px;
 }
 
-.user-input-form {
+.diff-columns {
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
 }
 
-.user-input-question {
+.diff-side {
   display: grid;
-  gap: 6px;
-  padding: 8px;
-  border: 1px solid #e6d8ca;
-  border-radius: 10px;
-  background: #fdf8f2;
+  gap: 8px;
 }
 
+.diff-side-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.diff-side-title,
 .user-input-question-title {
   margin: 0;
   font-size: 0.95rem;
 }
 
+.diff-empty,
 .user-input-question-body,
 .user-input-empty {
   margin: 0;
@@ -279,12 +356,15 @@ body {
   color: var(--ink-1);
 }
 
+.approval-actions,
+.user-input-actions,
 .user-input-options {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
 
+.approval-actions button,
 .user-input-option,
 .user-input-actions button {
   border: 1px solid #c7b39d;
@@ -295,30 +375,32 @@ body {
   font: inherit;
 }
 
-.user-input-answer {
-  width: 100%;
-  resize: vertical;
-  min-height: 72px;
-  border: 1px solid #cbb8a5;
-  border-radius: 10px;
-  padding: 10px;
-  font: inherit;
-  background: #fffdfb;
+.approval-actions button[data-decision="allow"] {
+  background: var(--accent-soft);
+  border-color: #9dcabc;
 }
 
-.user-input-actions {
-  display: flex;
-  gap: 8px;
-}
-
-.user-input-submit {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-}
-
+.approval-actions button[data-decision="deny"],
+.approval-actions button[data-decision="cancel"],
 .user-input-skip {
   color: var(--warn);
+}
+
+.user-input-form,
+.user-input-question {
+  display: grid;
+  gap: 10px;
+}
+
+.user-input-question {
+  padding: 8px;
+  border: 1px solid #e6d8ca;
+  border-radius: 10px;
+  background: #fdf8f2;
+}
+
+.user-input-answer {
+  min-height: 72px;
 }
 
 @keyframes rise {
@@ -332,16 +414,39 @@ body {
   }
 }
 
-@media (max-width: 920px) {
+@media (max-width: 1100px) {
   .layout {
+    grid-template-columns: minmax(220px, 0.85fr) minmax(360px, 1.35fr) minmax(280px, 1fr);
+  }
+
+  .diff-columns {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 920px) {
+  .workspace-nav {
+    display: flex;
+  }
+
+  .layout {
+    display: block;
+  }
+
+  .explorer-panel,
+  .chat-panel,
+  .side-panel {
+    display: none;
+    min-height: 0;
+  }
+
+  .shell[data-active-pane="files"] .explorer-panel,
+  .shell[data-active-pane="chat"] .chat-panel,
+  .shell[data-active-pane="diff"] .side-panel {
+    display: grid;
   }
 
   .chat-panel {
     min-height: 60vh;
-  }
-
-  .approval-panel {
-    min-height: 220px;
   }
 }

--- a/tasks/archived/2026-03-07-issue-11-file-tree-diff-ui/design.md
+++ b/tasks/archived/2026-03-07-issue-11-file-tree-diff-ui/design.md
@@ -1,0 +1,19 @@
+# Issue 11 Design
+
+## Overview
+- Expand the bundled page to a three-pane workspace layout on desktop.
+- Use a file explorer on the left, chat in the center, and file inspection plus diff on the right.
+- Keep approvals and pending user input below the inspection panels.
+
+## Main Decisions
+- Load the workspace tree from `/api/fs/tree` during app init.
+- Auto-select the first available file so file content and diff panes have meaningful initial content.
+- Fetch `/api/fs/file` and `/api/git/diff` together when a file is selected.
+- On mobile, use explicit pane tabs to switch between chat, files, and inspection views.
+- Render Git diffs as split HEAD and WORKTREE text panels rather than implementing a full line-by-line diff algorithm.
+
+## Risks
+- Browser-side state can become inconsistent if rapid file selections race each other.
+  - Mitigation: track a selection request token and ignore stale responses.
+- Loading workspace data during startup could make the initial UI feel busier.
+  - Mitigation: use simple loading placeholders and keep chat startup independent.

--- a/tasks/archived/2026-03-07-issue-11-file-tree-diff-ui/plan.md
+++ b/tasks/archived/2026-03-07-issue-11-file-tree-diff-ui/plan.md
@@ -1,0 +1,21 @@
+# Issue 11 Plan
+
+## TDD
+- TDD: partial
+- Rationale: the DOM flow for file-tree selection and diff rendering is stable enough to lock down with browser-side regression tests first, while layout and styling still need direct implementation work.
+
+## Steps
+- [ ] Add bundled UI structure for explorer, chat, and inspection panes.
+- [ ] Load and render the workspace file tree from `/api/fs/tree`.
+- [ ] Load workspace file content and Git diff data for the selected file.
+- [ ] Preserve approvals and pending user-input controls in the updated layout.
+- [ ] Add browser-side regression coverage for file selection and diff rendering.
+- [ ] Run validation and self-check acceptance criteria.
+
+## Validation Notes
+- Primary: `node --test codexbox/public/app.test.js`
+- Secondary: `node --test codexbox/webui-server.test.js`
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #11` in the PR description.

--- a/tasks/archived/2026-03-07-issue-11-file-tree-diff-ui/requirements.md
+++ b/tasks/archived/2026-03-07-issue-11-file-tree-diff-ui/requirements.md
@@ -1,0 +1,41 @@
+# Issue 11 Requirements
+
+## Goal
+- Add the bundled WebUI file tree and inspection panes that consume the existing read-only FS and Git APIs.
+
+## In Scope
+- Render a workspace file tree in the bundled WebUI.
+- Allow selecting a file and viewing its workspace contents.
+- Render the Git-backed HEAD vs worktree comparison for the selected file.
+- Preserve the existing approvals and pending user-input controls in the layout.
+- Add browser-side regression coverage for the shipped UI flow.
+
+## Out of Scope
+- Thread list UI.
+- Tool execution log UI.
+- Editable files or write-capable workspace actions.
+- Turn-local changed-file presentation from Issue #13.
+
+## Consumer Boundary
+- This Issue is the first-party bundled WebUI consumer of `/api/fs/tree`, `/api/fs/file`, `/api/git/show`, and `/api/git/diff`.
+- Backend API behavior is already covered by Issue #10 and its follow-up edge-case fix.
+
+## Acceptance Criteria
+- File tree pane is visible.
+- File content can be inspected from the bundled WebUI.
+- Diff pane renders Git-backed diffs from the selected file.
+- Mobile layout provides an explicit way to switch between chat, files, and inspection panes.
+- Validation covers the bundled browser-side flow.
+
+## Edge Cases and Error Handling
+- Empty or failed workspace-tree loads are visible in the UI.
+- Selecting a file surfaces file-load or diff-load errors without breaking chat input.
+- New-file diffs and missing left-side content render cleanly in the diff pane.
+
+## Constraints and Assumptions
+- Keep the UI read-only.
+- Preserve the existing visual language instead of introducing a new design system.
+- Prefer straightforward DOM rendering over framework adoption.
+
+## Open Questions
+- None blocking.


### PR DESCRIPTION
## Summary
- add bundled workspace explorer and inspection panes to the WebUI
- load read-only file content and Git-backed diffs for the selected file
- add browser-side regression coverage for file selection, diff rendering, and pane switching

## Validation
- node --test codexbox/public/app.test.js
- node --test codexbox/webui-server.test.js

Closes #11