### PR TITLE
feat(session): add reconnect and transcript recovery

### DIFF
--- a/codexbox/public/app.js
+++ b/codexbox/public/app.js
@@ -5,10 +5,23 @@ function splitAnswerText(text) {
     .filter(Boolean);
 }
 
+const SESSION_STORAGE_KEY = "codex-webui.sessionId";
+
 function createApp(env = {}) {
   const doc = env.document || document;
   const fetchImpl = env.fetch || fetch;
   const EventSourceImpl = env.EventSource || EventSource;
+  const storage = env.storage || (
+    typeof window !== "undefined" && window.localStorage
+      ? window.localStorage
+      : {
+        getItem() {
+          return null;
+        },
+        setItem() {},
+        removeItem() {},
+      }
+  );
   const autoStart = env.autoStart !== false;
 
   const state = {
@@ -55,6 +68,40 @@ function createApp(env = {}) {
     els.status.textContent = text;
   }
 
+  function loadPersistedSessionId() {
+    try {
+      return String(storage.getItem(SESSION_STORAGE_KEY) || "").trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  function persistSessionId(sessionId) {
+    try {
+      storage.setItem(SESSION_STORAGE_KEY, String(sessionId || ""));
+    } catch {
+      // Ignore storage failures; reconnect is best-effort.
+    }
+  }
+
+  function clearPersistedSessionId() {
+    try {
+      storage.removeItem(SESSION_STORAGE_KEY);
+    } catch {
+      // Ignore storage failures; reconnect is best-effort.
+    }
+  }
+
+  function setSessionId(sessionId) {
+    state.sessionId = sessionId ? String(sessionId) : null;
+    els.sessionId.textContent = state.sessionId || "-";
+    if (state.sessionId) {
+      persistSessionId(state.sessionId);
+    } else {
+      clearPersistedSessionId();
+    }
+  }
+
   function createElement(tagName, className, text) {
     const node = doc.createElement(tagName);
     if (className) {
@@ -77,6 +124,11 @@ function createApp(env = {}) {
     els.messages.appendChild(node);
     els.messages.scrollTop = els.messages.scrollHeight;
     return node;
+  }
+
+  function clearMessages() {
+    state.messageById.clear();
+    els.messages.replaceChildren();
   }
 
   function updateComposerState() {
@@ -144,6 +196,41 @@ function createApp(env = {}) {
   function describeGitStatus(code) {
     const trimmed = String(code || "").trim();
     return trimmed || "clean";
+  }
+
+  function extractUserMessageText(item) {
+    const parts = [];
+    for (const contentItem of item?.content || []) {
+      if (contentItem?.type === "text" && typeof contentItem.text === "string") {
+        parts.push(contentItem.text);
+      }
+    }
+    return parts.join("\n").trim();
+  }
+
+  function rebuildTranscriptFromThread(thread) {
+    clearMessages();
+
+    const turns = Array.isArray(thread?.turns) ? thread.turns : [];
+    for (const turn of turns) {
+      for (const item of turn?.items || []) {
+        if (!item || typeof item !== "object") {
+          continue;
+        }
+
+        if (item.type === "userMessage") {
+          const text = extractUserMessageText(item);
+          if (text) {
+            appendMessage("user", text, { itemId: item.id });
+          }
+          continue;
+        }
+
+        if (item.type === "agentMessage" && typeof item.text === "string") {
+          appendMessage("assistant", item.text, { itemId: item.id });
+        }
+      }
+    }
   }
 
   function setActivePane(pane) {
@@ -732,6 +819,7 @@ function createApp(env = {}) {
     setStatus(`Session closed: ${payload?.reason || "unknown"}`);
     state.sending = false;
     state.threadId = null;
+    setSessionId(null);
     state.pendingApprovals.clear();
     state.pendingUserInputs.clear();
     renderApprovals();
@@ -740,6 +828,10 @@ function createApp(env = {}) {
   }
 
   function connectSse() {
+    if (state.eventSource && typeof state.eventSource.close === "function") {
+      state.eventSource.close();
+    }
+
     const url = `/api/session/events?sessionId=${encodeURIComponent(state.sessionId)}`;
     const eventSource = new EventSourceImpl(url);
     state.eventSource = eventSource;
@@ -789,15 +881,51 @@ function createApp(env = {}) {
     });
 
     eventSource.onerror = () => {
-      setStatus("SSE disconnected. Refresh to reconnect.");
+      setStatus("SSE disconnected. Reconnecting if the session is still alive.");
     };
+  }
+
+  async function resyncThreadTranscript() {
+    if (!state.sessionId || !state.threadId) {
+      return;
+    }
+
+    const response = await api("/api/thread/read", {
+      sessionId: state.sessionId,
+      threadId: state.threadId,
+      includeTurns: true,
+    });
+    rebuildTranscriptFromThread(response.result?.thread || null);
+  }
+
+  async function reconnectSession(sessionId) {
+    const reconnect = await api("/api/session/reconnect", {
+      sessionId,
+    });
+
+    setSessionId(reconnect.sessionId);
+    applySessionSnapshot(reconnect);
+    connectSse();
+
+    if (!state.threadId) {
+      setStatus("Reconnected. Waiting for a thread to start.");
+      return true;
+    }
+
+    try {
+      await resyncThreadTranscript();
+      setStatus(`Reconnected. Thread: ${state.threadId}`);
+    } catch (err) {
+      setStatus(`Reconnected, but transcript sync failed: ${err.message}`);
+    }
+
+    return true;
   }
 
   async function startSession() {
     setStatus("Starting session...");
     const session = await api("/api/session/start", {});
-    state.sessionId = session.sessionId;
-    els.sessionId.textContent = state.sessionId;
+    setSessionId(session.sessionId);
 
     connectSse();
 
@@ -816,6 +944,21 @@ function createApp(env = {}) {
     } else {
       setStatus("Ready, but thread ID is missing.");
     }
+  }
+
+  async function bootstrapSession() {
+    const storedSessionId = loadPersistedSessionId();
+    if (storedSessionId) {
+      try {
+        await reconnectSession(storedSessionId);
+        return;
+      } catch (err) {
+        clearPersistedSessionId();
+        setStatus(`Reconnect failed: ${err.message}. Starting a new session...`);
+      }
+    }
+
+    await startSession();
   }
 
   async function sendTurn(text) {
@@ -880,7 +1023,7 @@ function createApp(env = {}) {
     await loadWorkspaceTree();
 
     if (autoStart) {
-      await startSession();
+      await bootstrapSession();
     }
   }
 
@@ -897,6 +1040,8 @@ function createApp(env = {}) {
     handleUserInputTimedOut,
     renderUserInputs,
     splitAnswerText,
+    rebuildTranscriptFromThread,
+    reconnectSession,
   };
 }
 

--- a/codexbox/public/app.test.js
+++ b/codexbox/public/app.test.js
@@ -148,6 +148,46 @@ class FakeDocument {
   }
 }
 
+class FakeStorage {
+  constructor(initial = {}) {
+    this.values = new Map(Object.entries(initial));
+  }
+
+  getItem(key) {
+    return this.values.has(key) ? this.values.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.values.set(String(key), String(value));
+  }
+
+  removeItem(key) {
+    this.values.delete(String(key));
+  }
+}
+
+class FakeEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = new Map();
+    this.closed = false;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, []);
+    }
+    this.listeners.get(type).push(listener);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+FakeEventSource.instances = [];
+
 function findFirst(node, predicate) {
   if (predicate(node)) {
     return node;
@@ -251,6 +291,109 @@ test("bundled UI renders and submits pending user-input requests", async () => {
     },
   });
   assert.match(userInputRoot.textContent, /No pending user input requests/);
+});
+
+test("bundled UI reconnects a stored session and rebuilds transcript from thread/read", async () => {
+  const document = new FakeDocument();
+  const storage = new FakeStorage({
+    "codex-webui.sessionId": "session-restore",
+  });
+  const calls = [];
+  FakeEventSource.instances = [];
+
+  const app = createApp({
+    document,
+    storage,
+    EventSource: FakeEventSource,
+    fetch: async (requestPath, options) => {
+      calls.push({
+        requestPath,
+        method: options.method,
+        body: options.body ? JSON.parse(options.body) : null,
+      });
+
+      if (requestPath === "/api/fs/tree") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, tree: [] }),
+        };
+      }
+
+      if (requestPath === "/api/session/reconnect") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            sessionId: "session-restore",
+            threadId: "thread-restore",
+            pendingApprovals: [
+              {
+                requestId: "approval-1",
+                method: "item/commandExecution/requestApproval",
+                params: { command: ["pwd"] },
+              },
+            ],
+            pendingUserInputs: [],
+          }),
+        };
+      }
+
+      if (requestPath === "/api/thread/read") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            result: {
+              thread: {
+                id: "thread-restore",
+                turns: [
+                  {
+                    id: "turn-1",
+                    items: [
+                      {
+                        id: "user-1",
+                        type: "userMessage",
+                        content: [{ type: "text", text: "Reconnect me" }],
+                      },
+                      {
+                        id: "assistant-1",
+                        type: "agentMessage",
+                        text: "Transcript restored",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected request: ${requestPath}`);
+    },
+  });
+
+  await app.init();
+
+  const messages = document.getElementById("messages");
+  const approvals = document.getElementById("approvals");
+
+  assert.equal(app.state.sessionId, "session-restore");
+  assert.equal(app.state.threadId, "thread-restore");
+  assert.match(messages.textContent, /Reconnect me/);
+  assert.match(messages.textContent, /Transcript restored/);
+  assert.match(approvals.textContent, /item\/commandExecution\/requestApproval/);
+  assert.equal(document.getElementById("session-id").textContent, "session-restore");
+  assert.equal(FakeEventSource.instances.length, 1);
+  assert.equal(FakeEventSource.instances[0].url, "/api/session/events?sessionId=session-restore");
+
+  assert.ok(calls.some((call) => call.requestPath === "/api/session/reconnect"));
+  assert.ok(calls.some((call) => call.requestPath === "/api/thread/read"));
+  assert.equal(calls.some((call) => call.requestPath === "/api/session/start"), false);
+  assert.equal(storage.getItem("codex-webui.sessionId"), "session-restore");
 });
 
 test("bundled UI renders workspace tree and Git-backed file inspection", async () => {

--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -712,6 +712,15 @@ function listPendingUserInputs(session) {
     .map(serializeUserInputRequest);
 }
 
+function serializeSessionSnapshot(session) {
+  return {
+    sessionId: session.id,
+    threadId: session.threadId,
+    pendingApprovals: listPendingApprovals(session),
+    pendingUserInputs: listPendingUserInputs(session),
+  };
+}
+
 function normalizeUserInputResult(request, body) {
   if (body.result && typeof body.result === "object") {
     return body.result;
@@ -1177,6 +1186,19 @@ async function handlePostApi(req, res, pathname) {
     return;
   }
 
+  if (pathname === "/api/session/reconnect") {
+    const session = ensureSession(body.sessionId);
+    touchSession(session);
+    sendJson(res, 200, {
+      ok: true,
+      ...serializeSessionSnapshot(session),
+      idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS,
+      approvalTimeoutMs: APPROVAL_TIMEOUT_MS,
+      userInputTimeoutMs: USER_INPUT_TIMEOUT_MS,
+    });
+    return;
+  }
+
   if (pathname === "/api/thread/start") {
     const session = ensureSession(body.sessionId);
     const rawParams = body.params && typeof body.params === "object" ? body.params : {};
@@ -1223,6 +1245,26 @@ async function handlePostApi(req, res, pathname) {
     }
 
     const result = await rpcRequest(session, "turn/start", params);
+    touchSession(session);
+    sendJson(res, 200, { ok: true, result });
+    return;
+  }
+
+  if (pathname === "/api/thread/read") {
+    const session = ensureSession(body.sessionId);
+    const threadId = String(body.threadId || session.threadId || "").trim();
+    if (!threadId) {
+      throw new Error("threadId is required");
+    }
+
+    const includeTurns = body.includeTurns !== false;
+    const result = await rpcRequest(session, "thread/read", {
+      threadId,
+      includeTurns,
+    });
+    if (typeof result?.thread?.id === "string") {
+      session.threadId = result.thread.id;
+    }
     touchSession(session);
     sendJson(res, 200, { ok: true, result });
     return;
@@ -1308,12 +1350,7 @@ async function handleGetApi(req, res, pathname, searchParams) {
     writeSse(
       res,
       "session/snapshot",
-      {
-        sessionId: session.id,
-        threadId: session.threadId,
-        pendingApprovals: listPendingApprovals(session),
-        pendingUserInputs: listPendingUserInputs(session),
-      },
+      serializeSessionSnapshot(session),
       session.nextSseId++,
     );
 

--- a/codexbox/webui-server.test.js
+++ b/codexbox/webui-server.test.js
@@ -83,6 +83,7 @@ async function startServer(t, options = {}) {
       ...process.env,
       HOST: "127.0.0.1",
       PORT: String(port),
+      CODEX_BIN: options.codexBin || process.env.CODEX_BIN || "codex",
       MAX_FILE_BYTES: options.maxFileBytes || "128",
       WORKSPACE_ROOT: options.workspaceRoot || REPO_ROOT,
     },
@@ -107,6 +108,16 @@ async function startServer(t, options = {}) {
 
   await waitForServer(port);
   return { port };
+}
+
+async function createFakeCodexBin(t, scriptSource) {
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-webui-fake-codex-"));
+  const binPath = path.join(binDir, "codex");
+  await fs.writeFile(binPath, scriptSource, { mode: 0o755 });
+  t.after(async () => {
+    await fs.rm(binDir, { recursive: true, force: true });
+  });
+  return binPath;
 }
 
 test("GET /api/fs/tree returns tracked files", async (t) => {
@@ -323,4 +334,157 @@ test("GET /api/git/diff blocks path traversal", async (t) => {
   const body = await response.json();
   assert.equal(body.ok, false);
   assert.match(body.error, /path escapes workspace/);
+});
+
+test("session reconnect returns snapshot and thread/read resyncs transcript", async (t) => {
+  const fakeCodex = await createFakeCodexBin(
+    t,
+    `#!/usr/bin/env node
+const readline = require("node:readline");
+
+const rl = readline.createInterface({ input: process.stdin });
+let approvalSent = false;
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: { protocolVersion: "2026-03-01" } });
+    return;
+  }
+
+  if (message.method === "thread/start") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        thread: {
+          id: "thread-1",
+        },
+      },
+    });
+    if (!approvalSent) {
+      approvalSent = true;
+      send({
+        jsonrpc: "2.0",
+        id: "approval-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          command: ["pwd"],
+          cwd: "/workspace",
+        },
+      });
+    }
+    return;
+  }
+
+  if (message.method === "thread/read") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        thread: {
+          id: "thread-1",
+          cliVersion: "0.111.0",
+          createdAt: 1,
+          cwd: "/workspace",
+          ephemeral: false,
+          modelProvider: "openai",
+          preview: "Hello",
+          source: "appServer",
+          status: "idle",
+          updatedAt: 2,
+          turns: [
+            {
+              id: "turn-1",
+              status: "completed",
+              items: [
+                {
+                  id: "user-1",
+                  type: "userMessage",
+                  content: [{ type: "text", text: "Hello" }],
+                },
+                {
+                  id: "assistant-1",
+                  type: "agentMessage",
+                  text: "Hi there",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    return;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(message, "id")) {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+`,
+  );
+
+  const { port } = await startServer(t, { codexBin: fakeCodex });
+
+  const startResponse = await fetch(`http://127.0.0.1:${port}/api/session/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  assert.equal(startResponse.status, 200);
+  const startBody = await startResponse.json();
+  assert.equal(startBody.ok, true);
+
+  const threadResponse = await fetch(`http://127.0.0.1:${port}/api/thread/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+      params: {},
+    }),
+  });
+  assert.equal(threadResponse.status, 200);
+  const threadBody = await threadResponse.json();
+  assert.equal(threadBody.ok, true);
+  assert.equal(threadBody.result.thread.id, "thread-1");
+
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  const reconnectResponse = await fetch(`http://127.0.0.1:${port}/api/session/reconnect`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+    }),
+  });
+  assert.equal(reconnectResponse.status, 200);
+
+  const reconnectBody = await reconnectResponse.json();
+  assert.equal(reconnectBody.ok, true);
+  assert.equal(reconnectBody.sessionId, startBody.sessionId);
+  assert.equal(reconnectBody.threadId, "thread-1");
+  assert.equal(reconnectBody.pendingApprovals.length, 1);
+  assert.equal(reconnectBody.pendingApprovals[0].requestId, "approval-1");
+
+  const readResponse = await fetch(`http://127.0.0.1:${port}/api/thread/read`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+      threadId: "thread-1",
+    }),
+  });
+  assert.equal(readResponse.status, 200);
+
+  const readBody = await readResponse.json();
+  assert.equal(readBody.ok, true);
+  assert.equal(readBody.result.thread.id, "thread-1");
+  assert.equal(readBody.result.thread.turns.length, 1);
+  assert.equal(readBody.result.thread.turns[0].items[0].type, "userMessage");
+  assert.equal(readBody.result.thread.turns[0].items[1].text, "Hi there");
 });

--- a/tasks/archived/2026-03-07-issue-12-reconnect-recovery/design.md
+++ b/tasks/archived/2026-03-07-issue-12-reconnect-recovery/design.md
@@ -1,0 +1,33 @@
+# Issue 12 Design
+
+## Overview
+- Add a lightweight `POST /api/session/reconnect` endpoint that validates and returns the current session snapshot for an existing session.
+- Add `POST /api/thread/read` as a thin JSON-RPC bridge to app-server.
+- On the bundled client, persist the current session ID in browser storage, attempt reconnect on startup, then rebuild the chat transcript from `thread/read`.
+
+## Main Decisions
+- Keep reconnect scoped to the existing in-memory session map; if the process or idle sweep already removed the session, the client falls back to a new session.
+- Do not add server-side event replay. Reconnect state comes from the existing SSE snapshot plus an explicit `thread/read` fetch.
+- Treat transcript resync as a replace operation: clear rendered chat messages and rebuild from `thread/read` items in order.
+- Persist only minimal client metadata needed for reconnect, starting with the session ID.
+
+## Component Responsibilities
+- `codexbox/webui-server.js`
+  - validate existing session IDs for reconnect
+  - expose `thread/read`
+  - keep pending approvals and pending user inputs in the snapshot payload
+- `codexbox/public/app.js`
+  - save and clear reconnect metadata
+  - choose reconnect-or-start during bootstrap
+  - rebuild visible chat items from `thread/read`
+  - keep current live SSE updates after reconnect
+
+## Consumer Impact
+- Bundled WebUI consumer work is in scope now.
+- No separate follow-up issue is needed for the shipped reconnect path.
+
+## Risks
+- `thread/read` item shapes are broader than the current chat renderer.
+  - Mitigation: rebuild only caller-visible message items needed for the chat transcript and ignore unsupported item types.
+- Stored session IDs can go stale after idle timeout or process restart.
+  - Mitigation: reconnect failure clears stored metadata and falls back to a fresh session.

--- a/tasks/archived/2026-03-07-issue-12-reconnect-recovery/plan.md
+++ b/tasks/archived/2026-03-07-issue-12-reconnect-recovery/plan.md
@@ -1,0 +1,31 @@
+# Issue 12 Plan
+
+## TDD
+- TDD: partial
+- Rationale: reconnect and transcript rebuild have clear behavioral seams for regression tests, but backend/client plumbing still needs setup scaffolding first.
+
+## Steps
+- [x] Add backend reconnect and `thread/read` endpoints.
+- [x] Add backend regression coverage with a fake app-server harness for reconnect snapshot and `thread/read`.
+- [x] Add client-side session persistence and reconnect-first bootstrap logic.
+- [x] Add transcript rebuild logic from `thread/read`.
+- [x] Add bundled UI regression coverage for reconnect bootstrap and transcript restore.
+- [x] Run validation and self-check acceptance criteria.
+
+## Validation Notes
+- Backend: `node --test codexbox/webui-server.test.js`
+- Frontend: `node --test codexbox/public/app.test.js`
+- Final: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+
+## Validation Results
+- Passed: `node --test codexbox/webui-server.test.js`
+- Passed: `node --test codexbox/public/app.test.js`
+- Passed: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+
+## Risks and Deferred Items
+- Unsupported historical thread item types will remain omitted from the minimal chat transcript.
+- Exact SSE event replay by `Last-Event-ID` is deferred because Issue #12 only requires resync via snapshot and `thread/read`.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #12` in the PR description.

--- a/tasks/archived/2026-03-07-issue-12-reconnect-recovery/requirements.md
+++ b/tasks/archived/2026-03-07-issue-12-reconnect-recovery/requirements.md
@@ -1,0 +1,42 @@
+# Issue 12 Requirements
+
+## Goal
+- Let the bundled WebUI reconnect to an existing browser session after a reload or mobile reconnect.
+- Restore pending approvals and resync visible conversation history from `thread/read`.
+
+## In Scope
+- Add a backend reconnect path for an existing session ID without spawning a new app-server child.
+- Add a backend `thread/read` bridge that the bundled WebUI can call for resync.
+- Persist enough client-side session metadata to attempt reconnect on page bootstrap.
+- Rebuild the visible chat transcript from `thread/read` after reconnect.
+- Validate the reconnect path across backend and bundled client behavior.
+
+## Out of Scope
+- Multi-user session discovery or account-level thread browsing.
+- Replaying exact SSE event history by event ID.
+- New UI for thread list, manual thread resume, or one-shot execution.
+- Durable server-side session persistence beyond in-memory session lifetime.
+
+## Acceptance Criteria Mapping
+- Reconnect resumes the same in-memory session instead of always creating a new one.
+- Pending approvals reappear after reconnect through the shipped WebUI path.
+- Conversation state can be resynced from `thread/read` and rendered back into the chat view.
+- Validation covers at least one shipped end-to-end reconnect path.
+
+## Consumers and Workflows
+- Bundled WebUI bootstrap and mobile/browser reload recovery flow.
+- Existing approval controls that depend on the reconnected session ID.
+
+## Edge Cases and Error Handling
+- Missing or unknown stored session IDs fall back to creating a new session.
+- Missing thread IDs do not block session reconnect; the UI skips transcript resync in that case.
+- `thread/read` errors do not kill the session; the UI shows a reconnect warning and can continue live streaming.
+- Session closure clears persisted reconnect metadata so stale sessions are not retried forever.
+
+## Constraints and Assumptions
+- Keep the current single-session bundled UI model.
+- Reuse current SSE snapshot behavior for pending approvals and other pending requests.
+- Use `thread/read` with `includeTurns: true` for transcript resync.
+
+## Open Questions
+- None blocking.


### PR DESCRIPTION
## Summary
- add a reconnect endpoint for existing in-memory sessions and reuse the session snapshot payload
- add a `thread/read` bridge so the bundled WebUI can resync visible conversation history after reconnect
- persist the current session ID in the bundled client and restore approvals plus transcript on reconnect

## Testing
- node --test codexbox/webui-server.test.js
- node --test codexbox/public/app.test.js
- node --test codexbox/webui-server.test.js codexbox/public/app.test.js

Closes #12
