### PR TITLE
feat(turn): track turn-local changed files

### DIFF
--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -2,7 +2,7 @@ const http = require("node:http");
 const path = require("node:path");
 const fs = require("node:fs");
 const { spawn, execFile } = require("node:child_process");
-const { randomUUID } = require("node:crypto");
+const { randomUUID, createHash } = require("node:crypto");
 const { promisify } = require("node:util");
 
 const PORT = Number(process.env.PORT || 8080);
@@ -501,6 +501,216 @@ async function readGitDiff(requestedPath) {
   };
 }
 
+function hashBuffer(buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function defaultGitStatus(status = {}) {
+  return {
+    gitStatus: status.gitStatus || status.code || "  ",
+    indexStatus: status.indexStatus || " ",
+    worktreeStatus: status.worktreeStatus || " ",
+  };
+}
+
+async function captureWorkspaceSnapshotEntry(relativePath, tracked, status) {
+  const absolutePath = path.resolve(WORKSPACE_ROOT_REALPATH, relativePath);
+  const statusFields = defaultGitStatus(status);
+
+  let entryStat = null;
+  try {
+    entryStat = await fs.promises.lstat(absolutePath);
+  } catch (err) {
+    if (err && err.code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  if (!entryStat) {
+    return {
+      path: relativePath,
+      tracked,
+      exists: false,
+      kind: "missing",
+      digest: null,
+      ...statusFields,
+    };
+  }
+
+  if (entryStat.isSymbolicLink()) {
+    const resolvedPath = fs.realpathSync.native(absolutePath);
+    if (!isPathInside(WORKSPACE_ROOT_REALPATH, resolvedPath)) {
+      throw new Error(`path escapes workspace: ${relativePath}`);
+    }
+    const linkTarget = await fs.promises.readlink(absolutePath, "utf8");
+    return {
+      path: relativePath,
+      tracked,
+      exists: true,
+      kind: "symlink",
+      digest: hashBuffer(Buffer.from(linkTarget, "utf8")),
+      ...statusFields,
+    };
+  }
+
+  const resolvedPath = fs.realpathSync.native(absolutePath);
+  if (!isPathInside(WORKSPACE_ROOT_REALPATH, resolvedPath)) {
+    throw new Error(`path escapes workspace: ${relativePath}`);
+  }
+
+  const resolvedStat = await fs.promises.stat(resolvedPath);
+  if (resolvedStat.isFile()) {
+    const buffer = await fs.promises.readFile(resolvedPath);
+    return {
+      path: relativePath,
+      tracked,
+      exists: true,
+      kind: "file",
+      digest: hashBuffer(buffer),
+      ...statusFields,
+    };
+  }
+
+  return {
+    path: relativePath,
+    tracked,
+    exists: true,
+    kind: "other",
+    digest: hashBuffer(Buffer.from(`${entryStat.mode}:${resolvedStat.size}`)),
+    ...statusFields,
+  };
+}
+
+async function captureWorkspaceSnapshot() {
+  const [trackedOutput, statusOutput] = await Promise.all([
+    runGit(["ls-files", "-z", "--cached"]),
+    runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
+  ]);
+
+  const statuses = parseGitStatusPorcelain(statusOutput);
+  const trackedPaths = new Set(trackedOutput.split("\0").filter(Boolean));
+  const snapshotPaths = new Set([...trackedPaths, ...statuses.keys()]);
+  const sortedPaths = Array.from(snapshotPaths).sort((left, right) => left.localeCompare(right));
+
+  const entries = await Promise.all(
+    sortedPaths.map((relativePath) => captureWorkspaceSnapshotEntry(
+      relativePath,
+      trackedPaths.has(relativePath),
+      statuses.get(relativePath),
+    )),
+  );
+
+  return new Map(entries.map((entry) => [entry.path, entry]));
+}
+
+function virtualSnapshotEntry(pathname) {
+  return {
+    path: pathname,
+    tracked: false,
+    exists: false,
+    kind: "missing",
+    digest: null,
+    gitStatus: "  ",
+    indexStatus: " ",
+    worktreeStatus: " ",
+  };
+}
+
+function snapshotEntriesEqual(left, right) {
+  return (
+    left.tracked === right.tracked &&
+    left.exists === right.exists &&
+    left.kind === right.kind &&
+    left.digest === right.digest &&
+    left.gitStatus === right.gitStatus &&
+    left.indexStatus === right.indexStatus &&
+    left.worktreeStatus === right.worktreeStatus
+  );
+}
+
+function serializeSnapshotEntry(entry) {
+  return {
+    exists: entry.exists,
+    kind: entry.kind,
+    tracked: entry.tracked,
+    gitStatus: entry.gitStatus,
+    indexStatus: entry.indexStatus,
+    worktreeStatus: entry.worktreeStatus,
+  };
+}
+
+function determineTurnFileChangeType(beforeEntry, afterEntry) {
+  if (!beforeEntry.exists && afterEntry.exists) {
+    return "created";
+  }
+  if (beforeEntry.exists && !afterEntry.exists) {
+    return "deleted";
+  }
+  return "updated";
+}
+
+function diffWorkspaceSnapshots(beforeSnapshot, afterSnapshot) {
+  const changedFiles = [];
+  const paths = new Set([...beforeSnapshot.keys(), ...afterSnapshot.keys()]);
+
+  for (const pathname of Array.from(paths).sort((left, right) => left.localeCompare(right))) {
+    const beforeEntry = beforeSnapshot.get(pathname) || virtualSnapshotEntry(pathname);
+    const afterEntry = afterSnapshot.get(pathname) || virtualSnapshotEntry(pathname);
+
+    if (snapshotEntriesEqual(beforeEntry, afterEntry)) {
+      continue;
+    }
+
+    changedFiles.push({
+      path: pathname,
+      changeType: determineTurnFileChangeType(beforeEntry, afterEntry),
+      before: serializeSnapshotEntry(beforeEntry),
+      after: serializeSnapshotEntry(afterEntry),
+    });
+  }
+
+  return changedFiles;
+}
+
+function rememberCompletedTurnChanges(session, turnChanges) {
+  session.completedTurnChanges.set(turnChanges.turnId, turnChanges);
+  while (session.completedTurnChanges.size > 20) {
+    const oldestTurnId = session.completedTurnChanges.keys().next().value;
+    session.completedTurnChanges.delete(oldestTurnId);
+  }
+}
+
+async function finalizeTurnChanges(session, params) {
+  const turnId = String(params?.turn?.id || "").trim();
+  if (!turnId) {
+    return;
+  }
+
+  const activeTurn = session.activeTurnSnapshots.get(turnId);
+  if (!activeTurn) {
+    return;
+  }
+
+  try {
+    const completedSnapshot = await captureWorkspaceSnapshot();
+    const turnChanges = {
+      turnId,
+      threadId: String(params?.threadId || activeTurn.threadId || session.threadId || "").trim() || null,
+      startedAt: activeTurn.startedAt,
+      completedAt: nowMs(),
+      changedFiles: diffWorkspaceSnapshots(activeTurn.snapshot, completedSnapshot),
+    };
+    session.activeTurnSnapshots.delete(turnId);
+    rememberCompletedTurnChanges(session, turnChanges);
+  } catch (err) {
+    session.activeTurnSnapshots.delete(turnId);
+    emitSessionEvent(session, "turn/changes_error", {
+      turnId,
+      error: normalizeError(err),
+    });
+  }
+}
+
 function makeSession() {
   const sessionId = randomUUID();
   const session = {
@@ -515,6 +725,8 @@ function makeSession() {
     pendingRequests: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    activeTurnSnapshots: new Map(),
+    completedTurnChanges: new Map(),
     sseClients: new Set(),
     threadId: null,
   };
@@ -950,6 +1162,10 @@ function handleRpcNotification(session, message) {
     });
   }
 
+  if (message.method === "turn/completed") {
+    finalizeTurnChanges(session, message.params || {});
+  }
+
   touchSession(session);
 }
 
@@ -1018,6 +1234,8 @@ function shutdownSession(session, reason) {
     clearTimeout(request.timeoutHandle);
   }
   session.pendingUserInputs.clear();
+  session.activeTurnSnapshots.clear();
+  session.completedTurnChanges.clear();
 
   if (session.child && !session.child.killed) {
     session.child.kill("SIGTERM");
@@ -1244,7 +1462,18 @@ async function handlePostApi(req, res, pathname) {
       }
     }
 
+    const turnStartedAt = nowMs();
+    const turnSnapshot = await captureWorkspaceSnapshot();
     const result = await rpcRequest(session, "turn/start", params);
+    const turnId = String(result?.turn?.id || "").trim();
+    if (turnId) {
+      session.activeTurnSnapshots.set(turnId, {
+        turnId,
+        threadId: String(params.threadId || session.threadId || "").trim() || null,
+        startedAt: turnStartedAt,
+        snapshot: turnSnapshot,
+      });
+    }
     touchSession(session);
     sendJson(res, 200, { ok: true, result });
     return;
@@ -1382,6 +1611,25 @@ async function handleGetApi(req, res, pathname, searchParams) {
     sendJson(res, 200, {
       ok: true,
       pendingUserInputs: listPendingUserInputs(session),
+    });
+    return;
+  }
+
+  if (pathname === "/api/turn/changes") {
+    const session = ensureSession(searchParams.get("sessionId"));
+    const turnId = String(searchParams.get("turnId") || "").trim();
+    if (!turnId) {
+      throw new Error("turnId is required");
+    }
+
+    const turnChanges = session.completedTurnChanges.get(turnId);
+    if (!turnChanges) {
+      throw new Error(`turn changes not found: ${turnId}`);
+    }
+
+    sendJson(res, 200, {
+      ok: true,
+      turnChanges,
     });
     return;
   }

--- a/codexbox/webui-server.test.js
+++ b/codexbox/webui-server.test.js
@@ -488,3 +488,171 @@ rl.on("line", (line) => {
   assert.equal(readBody.result.thread.turns[0].items[0].type, "userMessage");
   assert.equal(readBody.result.thread.turns[0].items[1].text, "Hi there");
 });
+
+test("GET /api/turn/changes returns snapshot-based turn-local changed files", async (t) => {
+  const repoDir = await createTempGitRepo(t);
+  await fs.writeFile(path.join(repoDir, "preexisting.txt"), "base-before\n");
+  await fs.writeFile(path.join(repoDir, "remove-me.txt"), "remove-me\n");
+  await fs.writeFile(path.join(repoDir, "deleted-before.txt"), "deleted-before\n");
+  await git(repoDir, ["add", "preexisting.txt", "remove-me.txt", "deleted-before.txt"]);
+  await git(repoDir, ["commit", "-qm", "add more tracked files"]);
+
+  await fs.writeFile(path.join(repoDir, "preexisting.txt"), "dirty-before\n");
+  await fs.writeFile(path.join(repoDir, "existing-untracked.txt"), "untracked-before\n");
+  await fs.rm(path.join(repoDir, "deleted-before.txt"));
+
+  const fakeCodex = await createFakeCodexBin(
+    t,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline");
+
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: { protocolVersion: "2026-03-01" } });
+    return;
+  }
+
+  if (message.method === "thread/start") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { thread: { id: "thread-1" } },
+    });
+    return;
+  }
+
+  if (message.method === "turn/start") {
+    const cwd = process.cwd();
+    fs.writeFileSync(path.join(cwd, "tracked.txt"), "changed-during-turn\\n");
+    fs.writeFileSync(path.join(cwd, "preexisting.txt"), "dirty-after\\n");
+    fs.writeFileSync(path.join(cwd, "new-turn-file.txt"), "created-in-turn\\n");
+    fs.rmSync(path.join(cwd, "remove-me.txt"));
+
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        turn: {
+          id: "turn-1",
+          status: "inProgress",
+          items: [],
+        },
+      },
+    });
+
+    setTimeout(() => {
+      send({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            items: [],
+          },
+        },
+      });
+    }, 20);
+    return;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(message, "id")) {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+`,
+  );
+
+  const { port } = await startServer(t, {
+    workspaceRoot: repoDir,
+    codexBin: fakeCodex,
+  });
+
+  const startResponse = await fetch(`http://127.0.0.1:${port}/api/session/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  const startBody = await startResponse.json();
+
+  const threadResponse = await fetch(`http://127.0.0.1:${port}/api/thread/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+      params: {},
+    }),
+  });
+  const threadBody = await threadResponse.json();
+  assert.equal(threadBody.result.thread.id, "thread-1");
+
+  const turnResponse = await fetch(`http://127.0.0.1:${port}/api/turn/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+      threadId: "thread-1",
+      prompt: "Change files",
+    }),
+  });
+  assert.equal(turnResponse.status, 200);
+  const turnBody = await turnResponse.json();
+  assert.equal(turnBody.ok, true);
+  assert.equal(turnBody.result.turn.id, "turn-1");
+
+  await new Promise((resolve) => setTimeout(resolve, 80));
+
+  const changesResponse = await fetch(
+    `http://127.0.0.1:${port}/api/turn/changes?sessionId=${encodeURIComponent(startBody.sessionId)}&turnId=turn-1`,
+  );
+  assert.equal(changesResponse.status, 200);
+  const changesBody = await changesResponse.json();
+  assert.equal(changesBody.ok, true);
+  assert.equal(changesBody.turnChanges.turnId, "turn-1");
+  assert.equal(changesBody.turnChanges.threadId, "thread-1");
+
+  const changedPaths = changesBody.turnChanges.changedFiles.map((entry) => entry.path).sort();
+  assert.deepEqual(changedPaths, [
+    "new-turn-file.txt",
+    "preexisting.txt",
+    "remove-me.txt",
+    "tracked.txt",
+  ]);
+
+  const preexisting = changesBody.turnChanges.changedFiles.find((entry) => entry.path === "preexisting.txt");
+  assert.equal(preexisting.changeType, "updated");
+  assert.equal(preexisting.before.gitStatus, " M");
+  assert.equal(preexisting.after.gitStatus, " M");
+
+  const created = changesBody.turnChanges.changedFiles.find((entry) => entry.path === "new-turn-file.txt");
+  assert.equal(created.changeType, "created");
+  assert.equal(created.before.exists, false);
+  assert.equal(created.after.exists, true);
+
+  const deleted = changesBody.turnChanges.changedFiles.find((entry) => entry.path === "remove-me.txt");
+  assert.equal(deleted.changeType, "deleted");
+  assert.equal(deleted.before.exists, true);
+  assert.equal(deleted.after.exists, false);
+
+  assert.equal(changedPaths.includes("existing-untracked.txt"), false);
+  assert.equal(changedPaths.includes("deleted-before.txt"), false);
+
+  const missingResponse = await fetch(
+    `http://127.0.0.1:${port}/api/turn/changes?sessionId=${encodeURIComponent(startBody.sessionId)}&turnId=does-not-exist`,
+  );
+  assert.equal(missingResponse.status, 400);
+  const missingBody = await missingResponse.json();
+  assert.equal(missingBody.ok, false);
+  assert.match(missingBody.error, /turn changes not found/);
+});

--- a/docs/codex-webui-docker-lan-design.md
+++ b/docs/codex-webui-docker-lan-design.md
@@ -253,6 +253,8 @@ Notes:
 - Do not use plain `git diff --name-only` at `turn/completed` as the turn diff.
 - Compute turn-local changes against a snapshot captured at turn start.
 - At minimum store starting status and file hashes.
+- Expose completed turn-local changes through `GET /api/turn/changes?sessionId=...&turnId=...`.
+- Return per-path `changeType` plus before/after snapshot summaries so later UI work can render turn-local change state without re-deriving it from the current workspace.
 
 ## 13. UI Design
 

--- a/tasks/archived/2026-03-07-issue-13-turn-local-changes/design.md
+++ b/tasks/archived/2026-03-07-issue-13-turn-local-changes/design.md
@@ -1,0 +1,44 @@
+# Issue 13 Design
+
+## Overview
+- Add session-local turn tracking maps for active turn snapshots and completed turn change sets.
+- Capture a normalized workspace snapshot before `turn/start` is sent to app-server.
+- When the backend receives `turn/completed`, compute the changed-file set for that `turnId` and expose it through a new backend endpoint.
+
+## Main Decisions
+- Use `GET /api/turn/changes?sessionId=...&turnId=...` as the explicit consumer contract for follow-up UI work.
+- Compare snapshots by path using existence, entry kind, content hash, and Git status metadata.
+- Include tracked clean files, untracked files, and deleted tracked paths in snapshots so dirty baselines are preserved accurately.
+- Keep snapshots and completed turn change sets only for the lifetime of the in-memory session.
+
+## Session Data Additions
+- `activeTurnSnapshots: Map<turnId, TurnSnapshotRecord>`
+- `completedTurnChanges: Map<turnId, TurnChangeRecord>`
+
+## Snapshot Shape
+- Per path:
+  - `path`
+  - `tracked`
+  - `exists`
+  - `kind` (`file`, `symlink`, `other`, `missing`)
+  - `digest`
+  - `gitStatus`, `indexStatus`, `worktreeStatus`
+
+## API Contract
+- `GET /api/turn/changes?sessionId=...&turnId=...`
+- Response:
+  - `turnId`
+  - `threadId`
+  - `startedAt`
+  - `completedAt`
+  - `changedFiles[]`
+- Each changed file includes:
+  - `path`
+  - `changeType` (`created`, `deleted`, `updated`)
+  - `before` and `after` summaries with `exists`, `kind`, `tracked`, and Git status fields
+
+## Risks
+- Whole-workspace snapshots add I/O overhead at turn start and completion.
+  - Mitigation: limit snapshot enumeration to tracked and status-visible repo-relative paths instead of recursively scanning the filesystem.
+- Turn tracking relies on `turn.id` being present on the `turn/start` response and completion notification.
+  - Mitigation: fail clearly if lookup is requested for a turn that never produced a tracked snapshot.

--- a/tasks/archived/2026-03-07-issue-13-turn-local-changes/plan.md
+++ b/tasks/archived/2026-03-07-issue-13-turn-local-changes/plan.md
@@ -1,0 +1,29 @@
+# Issue 13 Plan
+
+## TDD
+- TDD: yes
+- Rationale: snapshot diff behavior and dirty-worktree edge cases are well-defined backend behaviors with stable request/response seams.
+
+## Steps
+- [x] Add backend regression tests for snapshot-based turn change tracking and dirty baseline edge cases.
+- [x] Implement snapshot capture, comparison, and session-local turn tracking.
+- [x] Expose `GET /api/turn/changes` for completed turns.
+- [x] Update durable design documentation for the new backend contract.
+- [x] Run validation and self-check acceptance criteria.
+- [ ] Create PR, merge, and close the issue.
+
+## Validation Notes
+- Primary: `node --test codexbox/webui-server.test.js`
+- Secondary: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+
+## Validation Results
+- Passed: `node --test codexbox/webui-server.test.js`
+- Passed: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+
+## Risks and Deferred Items
+- No bundled UI consumer is added here; later UI work should query the explicit backend contract.
+- Snapshot data is in-memory only and disappears when the session ends.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #13` in the PR description.

--- a/tasks/archived/2026-03-07-issue-13-turn-local-changes/requirements.md
+++ b/tasks/archived/2026-03-07-issue-13-turn-local-changes/requirements.md
@@ -1,0 +1,41 @@
+# Issue 13 Requirements
+
+## Goal
+- Compute per-turn changed files from a workspace snapshot captured at `turn/start`, instead of reusing raw current-worktree diff state.
+
+## In Scope
+- Capture a turn-start snapshot for each backend turn.
+- Derive completed-turn changed files from the difference between the turn-start snapshot and the workspace state at `turn/completed`.
+- Expose a backend contract that later consumers can query by `turnId`.
+- Validate dirty worktree edge cases against the snapshot-based contract.
+
+## Out of Scope
+- New bundled WebUI presentation for turn-local changed files.
+- Broader file tree or diff UX changes.
+- Cross-session or durable persistence of turn snapshots after the session ends.
+
+## Acceptance Criteria Mapping
+- Turn-start snapshot is captured before backend turn execution starts.
+- Turn-local changed files are derived from the snapshot rather than raw `git diff --name-only`.
+- Dirty worktree edge cases are handled, including pre-existing modified, deleted, and untracked paths.
+- The consumer-facing contract for turn-local changes is explicit enough for later UI work.
+- Validation demonstrates snapshot-based behavior rather than only current worktree diff behavior.
+
+## Consumers and Workflows
+- No shipped frontend consumer in this issue.
+- Future WebUI work can query the backend by `sessionId` and `turnId` after a turn completes.
+
+## Edge Cases and Error Handling
+- Pre-existing dirty files that do not change during the turn must not appear in the turn-local set.
+- Pre-existing dirty files that change again during the turn must appear even if their Git status code stays the same.
+- Pre-existing deleted tracked files that remain deleted must not appear in the turn-local set.
+- Untracked files that already existed before the turn and stay unchanged must not appear in the turn-local set.
+- Unknown or incomplete `turnId` requests return a clear API error instead of falling back to workspace-wide diff state.
+
+## Constraints and Assumptions
+- Keep the contract backend-only for this issue.
+- Use the app-server `turn.id` as the stable lookup key for turn-local changes.
+- Snapshot comparison may inspect current workspace bytes or symlink targets when needed to detect changes beyond Git status code changes.
+
+## Open Questions
+- None blocking.


### PR DESCRIPTION
## Summary
- capture workspace snapshots at `turn/start` and compute completed turn-local changed files against that baseline
- expose `GET /api/turn/changes` as the backend contract for future turn-local diff consumers
- document the contract and validate dirty-worktree edge cases with a fake app-server harness

## Testing
- node --test codexbox/webui-server.test.js
- node --test codexbox/webui-server.test.js codexbox/public/app.test.js

Closes #13
