### PR TITLE
feat(exec): add one-shot streaming route

### DIFF
--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -933,6 +933,16 @@ function serializeSessionSnapshot(session) {
   };
 }
 
+function readExecPrompt(body) {
+  if (typeof body?.prompt === "string" && body.prompt.trim()) {
+    return body.prompt;
+  }
+  if (typeof body?.text === "string" && body.text.trim()) {
+    return body.text;
+  }
+  throw new Error("prompt is required");
+}
+
 function normalizeUserInputResult(request, body) {
   if (body.result && typeof body.result === "object") {
     return body.result;
@@ -1545,6 +1555,123 @@ async function handlePostApi(req, res, pathname) {
       ok: true,
       resolved,
     });
+    return;
+  }
+
+  if (pathname === "/api/exec") {
+    const prompt = readExecPrompt(body);
+    const jobId = randomUUID();
+    let nextEventId = 1;
+    let stdoutBuffer = "";
+    let finished = false;
+
+    const writeExecEvent = (eventName, payload) => {
+      if (res.writableEnded) {
+        return;
+      }
+      writeSse(res, eventName, { jobId, ...payload }, nextEventId++);
+    };
+
+    const flushStdoutLine = (line) => {
+      const text = String(line || "").trim();
+      if (!text) {
+        return;
+      }
+
+      try {
+        writeExecEvent("exec/event", {
+          event: JSON.parse(text),
+        });
+      } catch (err) {
+        writeExecEvent("exec/error", {
+          error: `failed to parse exec json: ${normalizeError(err)}`,
+          line: text,
+        });
+      }
+    };
+
+    const child = spawn(
+      CODEX_BIN,
+      [
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "--sandbox",
+        CODEX_DEFAULT_SANDBOX,
+        "-C",
+        WORKSPACE_ROOT,
+        prompt,
+      ],
+      {
+        cwd: WORKSPACE_ROOT,
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+      "x-accel-buffering": "no",
+    });
+    res.write("retry: 1500\n\n");
+    writeExecEvent("exec/started", {
+      command: "codex exec --json",
+      sandbox: CODEX_DEFAULT_SANDBOX,
+    });
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdoutBuffer += chunk;
+      const parts = stdoutBuffer.split(/\r?\n/);
+      stdoutBuffer = parts.pop() || "";
+      for (const part of parts) {
+        flushStdoutLine(part);
+      }
+    });
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      writeExecEvent("exec/stderr", {
+        chunk: String(chunk),
+      });
+    });
+
+    child.on("error", (err) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      writeExecEvent("exec/error", {
+        error: `failed to start exec: ${normalizeError(err)}`,
+      });
+      writeExecEvent("exec/completed", {
+        exitCode: null,
+        signal: null,
+      });
+      res.end();
+    });
+
+    child.on("exit", (code, signal) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      flushStdoutLine(stdoutBuffer);
+      writeExecEvent("exec/completed", {
+        exitCode: code === null ? null : code,
+        signal: signal || null,
+      });
+      res.end();
+    });
+
+    res.on("close", () => {
+      if (!finished && child && !child.killed) {
+        child.kill("SIGTERM");
+      }
+    });
+
     return;
   }
 

--- a/codexbox/webui-server.test.js
+++ b/codexbox/webui-server.test.js
@@ -120,6 +120,21 @@ async function createFakeCodexBin(t, scriptSource) {
   return binPath;
 }
 
+function parseSseTranscript(text) {
+  return String(text || "")
+    .split("\n\n")
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .map((chunk) => {
+      const eventMatch = chunk.match(/^event: (.+)$/m);
+      const dataMatch = chunk.match(/^data: (.+)$/m);
+      return {
+        event: eventMatch ? eventMatch[1] : null,
+        data: dataMatch ? JSON.parse(dataMatch[1]) : null,
+      };
+    });
+}
+
 test("GET /api/fs/tree returns tracked files", async (t) => {
   const { port } = await startServer(t);
   const response = await fetch(`http://127.0.0.1:${port}/api/fs/tree`);
@@ -655,4 +670,77 @@ rl.on("line", (line) => {
   const missingBody = await missingResponse.json();
   assert.equal(missingBody.ok, false);
   assert.match(missingBody.error, /turn changes not found/);
+});
+
+test("POST /api/exec streams one-shot codex exec output without creating a session", async (t) => {
+  const fakeCodex = await createFakeCodexBin(
+    t,
+    `#!/usr/bin/env node
+if (process.argv[2] === "exec") {
+  process.stdout.write(JSON.stringify({ type: "thread.started", thread_id: "thread-1" }) + "\\n");
+  process.stdout.write(JSON.stringify({ type: "turn.started" }) + "\\n");
+  process.stderr.write("exec stderr line\\n");
+  process.stdout.write(JSON.stringify({
+    type: "item.completed",
+    item: { id: "item_0", type: "agent_message", text: "ok" },
+  }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    type: "turn.completed",
+    usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+  }) + "\\n");
+  process.exit(0);
+}
+
+process.stderr.write("unsupported fake codex mode\\n");
+process.exit(1);
+`,
+  );
+
+  const { port } = await startServer(t, { codexBin: fakeCodex });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/exec`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      prompt: "reply with ok",
+    }),
+  });
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type") || "", /text\/event-stream/);
+
+  const transcript = await response.text();
+  const sseEvents = parseSseTranscript(transcript).filter((entry) => entry.event);
+  const eventNames = sseEvents.map((entry) => entry.event);
+
+  assert.equal(eventNames[0], "exec/started");
+  assert.equal(eventNames[eventNames.length - 1], "exec/completed");
+  assert.equal(eventNames.filter((name) => name === "exec/event").length, 4);
+  assert.ok(eventNames.includes("exec/stderr"));
+
+  const jobId = sseEvents[0].data.jobId;
+  assert.ok(jobId);
+  const execEvents = sseEvents.filter((entry) => entry.event === "exec/event");
+  const stderrEvent = sseEvents.find((entry) => entry.event === "exec/stderr");
+  const completedEvent = sseEvents.find((entry) => entry.event === "exec/completed");
+
+  assert.ok(execEvents.every((entry) => entry.data.jobId === jobId));
+  assert.equal(execEvents[0].data.event.type, "thread.started");
+  assert.equal(execEvents[3].data.event.type, "turn.completed");
+  assert.match(stderrEvent.data.chunk, /exec stderr line/);
+  assert.equal(completedEvent.data.exitCode, 0);
+  assert.equal(completedEvent.data.signal, null);
+
+  const healthzResponse = await fetch(`http://127.0.0.1:${port}/api/healthz`);
+  const healthzBody = await healthzResponse.json();
+  assert.equal(healthzBody.sessions, 0);
+
+  const missingPromptResponse = await fetch(`http://127.0.0.1:${port}/api/exec`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  assert.equal(missingPromptResponse.status, 400);
+  const missingPromptBody = await missingPromptResponse.json();
+  assert.equal(missingPromptBody.ok, false);
+  assert.match(missingPromptBody.error, /prompt is required/);
 });

--- a/docs/codex-webui-docker-lan-design.md
+++ b/docs/codex-webui-docker-lan-design.md
@@ -223,6 +223,8 @@ Notes:
 ### 11.4 One-shot Execution
 - If needed later, add a separate `codex exec --json` path.
 - Keep one-shot jobs separate from the stateful conversation UI.
+- Use `POST /api/exec` as a stateless streaming route for one-shot jobs.
+- Stream the raw `codex exec --json` JSONL payloads as SSE `exec/event` frames, with separate `exec/stderr`, `exec/error`, and `exec/completed` frames.
 
 ## 12. FS and Git API Design
 

--- a/tasks/archived/2026-03-07-issue-14-one-shot-exec/design.md
+++ b/tasks/archived/2026-03-07-issue-14-one-shot-exec/design.md
@@ -1,0 +1,37 @@
+# Issue 14 Design
+
+## Overview
+- Add `POST /api/exec` as a stateless streaming route.
+- Spawn a dedicated `codex exec --json` child process per request.
+- Convert each JSONL line from `codex exec --json` into an SSE `exec/event` frame on the response stream.
+
+## Main Decisions
+- Use a single request/response stream instead of a job manager because the issue is explicitly stateless.
+- Keep one-shot execution outside the session map entirely.
+- Forward parsed JSON lines as opaque `event` payloads so later consumers can decide which `codex exec` event types they care about.
+- Emit explicit SSE frames for:
+  - `exec/started`
+  - `exec/event`
+  - `exec/stderr`
+  - `exec/error`
+  - `exec/completed`
+
+## Route Contract
+- `POST /api/exec`
+- Request body:
+  - `prompt` or `text` string
+- Response:
+  - `content-type: text/event-stream`
+  - SSE payloads with a generated `jobId`
+
+## Separation from Session Runtime
+- No `sessionId`
+- No reuse of `/api/session/events`
+- No writes to `sessions`
+- No interaction with app-server JSON-RPC bridging
+
+## Risks
+- `codex exec --json` event types may evolve.
+  - Mitigation: keep the forwarded payload opaque and only promise transport-level framing.
+- Streaming responses can fail mid-run if the client disconnects.
+  - Mitigation: terminate the child process on request close.

--- a/tasks/archived/2026-03-07-issue-14-one-shot-exec/plan.md
+++ b/tasks/archived/2026-03-07-issue-14-one-shot-exec/plan.md
@@ -1,0 +1,28 @@
+# Issue 14 Plan
+
+## TDD
+- TDD: yes
+- Rationale: the route shape, stream framing, and separation from the session manager are stable backend behaviors with clear observable outputs.
+
+## Steps
+- [x] Add backend regression coverage for stateless one-shot exec streaming.
+- [x] Implement `POST /api/exec` with streaming SSE framing around `codex exec --json`.
+- [x] Update durable docs for the one-shot backend contract.
+- [x] Run validation and self-check acceptance criteria.
+- [ ] Create PR, merge, close the issue, and archive task artifacts.
+
+## Validation Notes
+- Primary: `node --test codexbox/webui-server.test.js`
+- Secondary: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+
+## Validation Results
+- Passed: `node --test codexbox/webui-server.test.js`
+- Passed: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+
+## Risks and Deferred Items
+- No bundled WebUI caller is added here; a later consumer will use the explicit backend stream contract.
+- The route does not persist completed jobs or support replay after disconnect.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #14` in the PR description.

--- a/tasks/archived/2026-03-07-issue-14-one-shot-exec/requirements.md
+++ b/tasks/archived/2026-03-07-issue-14-one-shot-exec/requirements.md
@@ -1,0 +1,40 @@
+# Issue 14 Requirements
+
+## Goal
+- Add a stateless backend execution path that streams `codex exec --json` output without reusing the session-based chat runtime.
+
+## In Scope
+- Add a backend route for one-shot exec requests.
+- Spawn `codex exec --json` as a separate child process from the session/app-server flow.
+- Stream one-shot exec events to the caller in a clear backend contract.
+- Validate the one-shot path end-to-end at the backend boundary.
+
+## Out of Scope
+- Bundled WebUI UI for launching one-shot jobs.
+- Reusing browser session IDs, SSE channels, or app-server session state for one-shot jobs.
+- Long-lived job persistence or resume support.
+
+## Acceptance Criteria Mapping
+- A one-shot route exists.
+- `codex exec --json` output is streamed to the caller.
+- One-shot jobs are operationally separated from the session-based chat runtime.
+- The backend response and event shape are explicit enough for later consumer work.
+- Validation covers the stateless execution path end-to-end at the backend boundary.
+
+## Consumers and Workflows
+- No shipped bundled UI consumer in this issue.
+- Later clients can call the backend route directly and consume the streamed event contract.
+
+## Edge Cases and Error Handling
+- Missing prompts return a clear API error.
+- Child-process spawn failures surface as stream errors instead of hanging the request.
+- `stderr` output is forwarded separately from parsed JSON events.
+- One-shot execution must not create or require a session entry in the session manager.
+
+## Constraints and Assumptions
+- Keep the route backend-only for this issue.
+- Stream the raw `codex exec --json` events rather than inventing a second semantic event model.
+- Use the configured workspace root as the one-shot working directory.
+
+## Open Questions
+- None blocking.


### PR DESCRIPTION
## Summary
- add a stateless `POST /api/exec` backend route that streams `codex exec --json` output as SSE frames
- keep one-shot jobs separate from the session/app-server runtime and forward stderr plus completion frames explicitly
- document the one-shot backend contract and validate the stream end-to-end with a fake codex binary

## Testing
- node --test codexbox/webui-server.test.js
- node --test codexbox/webui-server.test.js codexbox/public/app.test.js

Closes #14
