### PR TITLE
refactor: split webui server api routing

### DIFF
--- a/codexbox/server/sse.js
+++ b/codexbox/server/sse.js
@@ -1,0 +1,22 @@
+"use strict";
+
+function writeSse(res, eventName, data, eventId) {
+  res.write(`id: ${eventId}\n`);
+  res.write(`event: ${eventName}\n`);
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function openSseStream(res) {
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache, no-transform",
+    connection: "keep-alive",
+    "x-accel-buffering": "no",
+  });
+  res.write("retry: 1500\n\n");
+}
+
+module.exports = {
+  openSseStream,
+  writeSse,
+};

--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const { spawn, execFile } = require("node:child_process");
 const { randomUUID, createHash } = require("node:crypto");
 const { promisify } = require("node:util");
+const { openSseStream, writeSse } = require("./server/sse");
 
 const PORT = Number(process.env.PORT || 8080);
 const HOST = process.env.HOST || "0.0.0.0";
@@ -738,12 +739,6 @@ function touchSession(session) {
   session.lastActivityAt = nowMs();
 }
 
-function writeSse(res, eventName, data, eventId) {
-  res.write(`id: ${eventId}\n`);
-  res.write(`event: ${eventName}\n`);
-  res.write(`data: ${JSON.stringify(data)}\n\n`);
-}
-
 function emitSessionEvent(session, eventName, payload) {
   const eventId = session.nextSseId++;
   const data = {
@@ -1381,426 +1376,426 @@ function serveStaticFile(res, filePath, contentType) {
   });
 }
 
-async function handlePostApi(req, res, pathname) {
-  const body = await readRequestBody(req);
-
-  if (pathname === "/api/session/start") {
-    const session = makeSession();
-    try {
-      const initResult = await startSessionRuntime(session);
-      sendJson(res, 200, {
-        ok: true,
-        sessionId: session.id,
-        initResult,
-        idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS,
-        approvalTimeoutMs: APPROVAL_TIMEOUT_MS,
-        userInputTimeoutMs: USER_INPUT_TIMEOUT_MS,
-      });
-      return;
-    } catch (err) {
-      shutdownSession(session, `startup_failed: ${normalizeError(err)}`);
-      sendJson(res, 500, {
-        ok: false,
-        error: `failed to start session: ${normalizeError(err)}`,
-      });
-      return;
-    }
-  }
-
-  if (pathname === "/api/session/end") {
-    const session = ensureSession(body.sessionId);
-    shutdownSession(session, "session ended by client");
-    sendJson(res, 200, { ok: true });
-    return;
-  }
-
-  if (pathname === "/api/session/reconnect") {
-    const session = ensureSession(body.sessionId);
-    touchSession(session);
+async function handleSessionStartRoute(req, res) {
+  const session = makeSession();
+  try {
+    const initResult = await startSessionRuntime(session);
     sendJson(res, 200, {
       ok: true,
-      ...serializeSessionSnapshot(session),
+      sessionId: session.id,
+      initResult,
       idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS,
       approvalTimeoutMs: APPROVAL_TIMEOUT_MS,
       userInputTimeoutMs: USER_INPUT_TIMEOUT_MS,
     });
-    return;
+  } catch (err) {
+    shutdownSession(session, `startup_failed: ${normalizeError(err)}`);
+    sendJson(res, 500, {
+      ok: false,
+      error: `failed to start session: ${normalizeError(err)}`,
+    });
+  }
+}
+
+async function handleSessionEndRoute(req, res, body) {
+  const session = ensureSession(body.sessionId);
+  shutdownSession(session, "session ended by client");
+  sendJson(res, 200, { ok: true });
+}
+
+async function handleSessionReconnectRoute(req, res, body) {
+  const session = ensureSession(body.sessionId);
+  touchSession(session);
+  sendJson(res, 200, {
+    ok: true,
+    ...serializeSessionSnapshot(session),
+    idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS,
+    approvalTimeoutMs: APPROVAL_TIMEOUT_MS,
+    userInputTimeoutMs: USER_INPUT_TIMEOUT_MS,
+  });
+}
+
+async function handleThreadStartRoute(req, res, body, pathname) {
+  const session = ensureSession(body.sessionId);
+  const rawParams = body.params && typeof body.params === "object" ? body.params : {};
+  assertNoUnsafeOverrides(rawParams, ["approvalPolicy", "sandbox", "cwd"], pathname);
+
+  const params = {
+    ...rawParams,
+    approvalPolicy: CODEX_DEFAULT_APPROVAL_POLICY,
+    sandbox: CODEX_DEFAULT_SANDBOX,
+  };
+
+  const result = await rpcRequest(session, "thread/start", params);
+  if (typeof result?.thread?.id === "string") {
+    session.threadId = result.thread.id;
+  }
+  touchSession(session);
+  sendJson(res, 200, { ok: true, result });
+}
+
+async function handleTurnStartRoute(req, res, body, pathname) {
+  const session = ensureSession(body.sessionId);
+  const params = body.params && typeof body.params === "object" ? { ...body.params } : {};
+  assertNoUnsafeOverrides(params, ["approvalPolicy", "sandboxPolicy", "cwd"], pathname);
+
+  if (!params.threadId) {
+    params.threadId = body.threadId || session.threadId;
+  }
+  if (!params.threadId) {
+    throw new Error("threadId is required (call /api/thread/start first)");
   }
 
-  if (pathname === "/api/thread/start") {
-    const session = ensureSession(body.sessionId);
-    const rawParams = body.params && typeof body.params === "object" ? body.params : {};
-    assertNoUnsafeOverrides(rawParams, ["approvalPolicy", "sandbox", "cwd"], pathname);
-
-    const params = {
-      ...rawParams,
-      approvalPolicy: CODEX_DEFAULT_APPROVAL_POLICY,
-      sandbox: CODEX_DEFAULT_SANDBOX,
-    };
-
-    const result = await rpcRequest(session, "thread/start", params);
-    if (typeof result?.thread?.id === "string") {
-      session.threadId = result.thread.id;
+  if (!Array.isArray(params.input)) {
+    if (Array.isArray(body.input)) {
+      params.input = body.input;
+    } else if (typeof body.prompt === "string") {
+      params.input = [{ type: "text", text: body.prompt }];
+    } else if (typeof body.text === "string") {
+      params.input = [{ type: "text", text: body.text }];
+    } else {
+      throw new Error("input is required (set params.input array or prompt/text string)");
     }
-    touchSession(session);
-    sendJson(res, 200, { ok: true, result });
-    return;
   }
 
-  if (pathname === "/api/turn/start") {
-    const session = ensureSession(body.sessionId);
+  const turnStartedAt = nowMs();
+  const turnSnapshot = await captureWorkspaceSnapshot();
+  const result = await rpcRequest(session, "turn/start", params);
+  const turnId = String(result?.turn?.id || "").trim();
+  if (turnId) {
+    session.activeTurnSnapshots.set(turnId, {
+      turnId,
+      threadId: String(params.threadId || session.threadId || "").trim() || null,
+      startedAt: turnStartedAt,
+      snapshot: turnSnapshot,
+    });
+  }
+  touchSession(session);
+  sendJson(res, 200, { ok: true, result });
+}
 
-    const params = body.params && typeof body.params === "object" ? { ...body.params } : {};
-    assertNoUnsafeOverrides(params, ["approvalPolicy", "sandboxPolicy", "cwd"], pathname);
+async function handleThreadReadRoute(req, res, body) {
+  const session = ensureSession(body.sessionId);
+  const threadId = String(body.threadId || session.threadId || "").trim();
+  if (!threadId) {
+    throw new Error("threadId is required");
+  }
 
-    if (!params.threadId) {
-      params.threadId = body.threadId || session.threadId;
+  const includeTurns = body.includeTurns !== false;
+  const result = await rpcRequest(session, "thread/read", {
+    threadId,
+    includeTurns,
+  });
+  if (typeof result?.thread?.id === "string") {
+    session.threadId = result.thread.id;
+  }
+  touchSession(session);
+  sendJson(res, 200, { ok: true, result });
+}
+
+async function handleApprovalRespondRoute(req, res, body) {
+  const session = ensureSession(body.sessionId);
+  const requestId = body.requestId;
+  if (requestId === undefined || requestId === null) {
+    throw new Error("requestId is required");
+  }
+
+  const approval = session.pendingApprovals.get(String(requestId));
+  if (!approval) {
+    throw new Error(`pending approval not found: ${requestId}`);
+  }
+
+  const result = body.result && typeof body.result === "object"
+    ? body.result
+    : approvalDefaultResult(approval.method, body.decision || "deny");
+
+  if (!result) {
+    throw new Error(`unsupported approval method: ${approval.method}`);
+  }
+
+  const resolved = resolveApproval(session, requestId, result, "manual");
+  sendJson(res, 200, {
+    ok: true,
+    resolved,
+  });
+}
+
+async function handleUserInputRespondRoute(req, res, body) {
+  const session = ensureSession(body.sessionId);
+  const requestId = body.requestId;
+  if (requestId === undefined || requestId === null) {
+    throw new Error("requestId is required");
+  }
+
+  const request = session.pendingUserInputs.get(String(requestId));
+  if (!request) {
+    throw new Error(`pending user input request not found: ${requestId}`);
+  }
+
+  const result = normalizeUserInputResult(request, body);
+  const resolved = resolveUserInputRequest(session, requestId, result, "manual");
+  sendJson(res, 200, {
+    ok: true,
+    resolved,
+  });
+}
+
+async function handleExecRoute(req, res, body) {
+  const prompt = readExecPrompt(body);
+  const jobId = randomUUID();
+  let nextEventId = 1;
+  let stdoutBuffer = "";
+  let finished = false;
+
+  const writeExecEvent = (eventName, payload) => {
+    if (res.writableEnded) {
+      return;
     }
-    if (!params.threadId) {
-      throw new Error("threadId is required (call /api/thread/start first)");
+    writeSse(res, eventName, { jobId, ...payload }, nextEventId++);
+  };
+
+  const flushStdoutLine = (line) => {
+    const text = String(line || "").trim();
+    if (!text) {
+      return;
     }
 
-    if (!Array.isArray(params.input)) {
-      if (Array.isArray(body.input)) {
-        params.input = body.input;
-      } else if (typeof body.prompt === "string") {
-        params.input = [{ type: "text", text: body.prompt }];
-      } else if (typeof body.text === "string") {
-        params.input = [{ type: "text", text: body.text }];
-      } else {
-        throw new Error("input is required (set params.input array or prompt/text string)");
-      }
-    }
-
-    const turnStartedAt = nowMs();
-    const turnSnapshot = await captureWorkspaceSnapshot();
-    const result = await rpcRequest(session, "turn/start", params);
-    const turnId = String(result?.turn?.id || "").trim();
-    if (turnId) {
-      session.activeTurnSnapshots.set(turnId, {
-        turnId,
-        threadId: String(params.threadId || session.threadId || "").trim() || null,
-        startedAt: turnStartedAt,
-        snapshot: turnSnapshot,
+    try {
+      writeExecEvent("exec/event", {
+        event: JSON.parse(text),
       });
-    }
-    touchSession(session);
-    sendJson(res, 200, { ok: true, result });
-    return;
-  }
-
-  if (pathname === "/api/thread/read") {
-    const session = ensureSession(body.sessionId);
-    const threadId = String(body.threadId || session.threadId || "").trim();
-    if (!threadId) {
-      throw new Error("threadId is required");
-    }
-
-    const includeTurns = body.includeTurns !== false;
-    const result = await rpcRequest(session, "thread/read", {
-      threadId,
-      includeTurns,
-    });
-    if (typeof result?.thread?.id === "string") {
-      session.threadId = result.thread.id;
-    }
-    touchSession(session);
-    sendJson(res, 200, { ok: true, result });
-    return;
-  }
-
-  if (pathname === "/api/approvals/respond") {
-    const session = ensureSession(body.sessionId);
-    const requestId = body.requestId;
-    if (requestId === undefined || requestId === null) {
-      throw new Error("requestId is required");
-    }
-
-    const approval = session.pendingApprovals.get(String(requestId));
-    if (!approval) {
-      throw new Error(`pending approval not found: ${requestId}`);
-    }
-
-    const result = body.result && typeof body.result === "object"
-      ? body.result
-      : approvalDefaultResult(approval.method, body.decision || "deny");
-
-    if (!result) {
-      throw new Error(`unsupported approval method: ${approval.method}`);
-    }
-
-    const resolved = resolveApproval(session, requestId, result, "manual");
-    sendJson(res, 200, {
-      ok: true,
-      resolved,
-    });
-    return;
-  }
-
-  if (pathname === "/api/user-input/respond") {
-    const session = ensureSession(body.sessionId);
-    const requestId = body.requestId;
-    if (requestId === undefined || requestId === null) {
-      throw new Error("requestId is required");
-    }
-
-    const request = session.pendingUserInputs.get(String(requestId));
-    if (!request) {
-      throw new Error(`pending user input request not found: ${requestId}`);
-    }
-
-    const result = normalizeUserInputResult(request, body);
-    const resolved = resolveUserInputRequest(session, requestId, result, "manual");
-    sendJson(res, 200, {
-      ok: true,
-      resolved,
-    });
-    return;
-  }
-
-  if (pathname === "/api/exec") {
-    const prompt = readExecPrompt(body);
-    const jobId = randomUUID();
-    let nextEventId = 1;
-    let stdoutBuffer = "";
-    let finished = false;
-
-    const writeExecEvent = (eventName, payload) => {
-      if (res.writableEnded) {
-        return;
-      }
-      writeSse(res, eventName, { jobId, ...payload }, nextEventId++);
-    };
-
-    const flushStdoutLine = (line) => {
-      const text = String(line || "").trim();
-      if (!text) {
-        return;
-      }
-
-      try {
-        writeExecEvent("exec/event", {
-          event: JSON.parse(text),
-        });
-      } catch (err) {
-        writeExecEvent("exec/error", {
-          error: `failed to parse exec json: ${normalizeError(err)}`,
-          line: text,
-        });
-      }
-    };
-
-    const child = spawn(
-      CODEX_BIN,
-      [
-        "exec",
-        "--json",
-        "--skip-git-repo-check",
-        "--sandbox",
-        CODEX_DEFAULT_SANDBOX,
-        "-C",
-        WORKSPACE_ROOT,
-        prompt,
-      ],
-      {
-        cwd: WORKSPACE_ROOT,
-        env: process.env,
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
-
-    res.writeHead(200, {
-      "content-type": "text/event-stream",
-      "cache-control": "no-cache, no-transform",
-      connection: "keep-alive",
-      "x-accel-buffering": "no",
-    });
-    res.write("retry: 1500\n\n");
-    writeExecEvent("exec/started", {
-      command: "codex exec --json",
-      sandbox: CODEX_DEFAULT_SANDBOX,
-    });
-
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => {
-      stdoutBuffer += chunk;
-      const parts = stdoutBuffer.split(/\r?\n/);
-      stdoutBuffer = parts.pop() || "";
-      for (const part of parts) {
-        flushStdoutLine(part);
-      }
-    });
-
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk) => {
-      writeExecEvent("exec/stderr", {
-        chunk: String(chunk),
-      });
-    });
-
-    child.on("error", (err) => {
-      if (finished) {
-        return;
-      }
-      finished = true;
+    } catch (err) {
       writeExecEvent("exec/error", {
-        error: `failed to start exec: ${normalizeError(err)}`,
+        error: `failed to parse exec json: ${normalizeError(err)}`,
+        line: text,
       });
-      writeExecEvent("exec/completed", {
-        exitCode: null,
-        signal: null,
-      });
-      res.end();
-    });
+    }
+  };
 
-    child.on("exit", (code, signal) => {
-      if (finished) {
-        return;
-      }
-      finished = true;
-      flushStdoutLine(stdoutBuffer);
-      writeExecEvent("exec/completed", {
-        exitCode: code === null ? null : code,
-        signal: signal || null,
-      });
-      res.end();
-    });
+  const child = spawn(
+    CODEX_BIN,
+    [
+      "exec",
+      "--json",
+      "--skip-git-repo-check",
+      "--sandbox",
+      CODEX_DEFAULT_SANDBOX,
+      "-C",
+      WORKSPACE_ROOT,
+      prompt,
+    ],
+    {
+      cwd: WORKSPACE_ROOT,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
 
-    res.on("close", () => {
-      if (!finished && child && !child.killed) {
-        child.kill("SIGTERM");
-      }
-    });
+  openSseStream(res);
+  writeExecEvent("exec/started", {
+    command: "codex exec --json",
+    sandbox: CODEX_DEFAULT_SANDBOX,
+  });
 
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdoutBuffer += chunk;
+    const parts = stdoutBuffer.split(/\r?\n/);
+    stdoutBuffer = parts.pop() || "";
+    for (const part of parts) {
+      flushStdoutLine(part);
+    }
+  });
+
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    writeExecEvent("exec/stderr", {
+      chunk: String(chunk),
+    });
+  });
+
+  child.on("error", (err) => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    writeExecEvent("exec/error", {
+      error: `failed to start exec: ${normalizeError(err)}`,
+    });
+    writeExecEvent("exec/completed", {
+      exitCode: null,
+      signal: null,
+    });
+    res.end();
+  });
+
+  child.on("exit", (code, signal) => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    flushStdoutLine(stdoutBuffer);
+    writeExecEvent("exec/completed", {
+      exitCode: code === null ? null : code,
+      signal: signal || null,
+    });
+    res.end();
+  });
+
+  res.on("close", () => {
+    if (!finished && child && !child.killed) {
+      child.kill("SIGTERM");
+    }
+  });
+}
+
+async function handleHealthzRoute(req, res) {
+  sendJson(res, 200, {
+    ok: true,
+    service: "codexbox",
+    sessions: sessions.size,
+    now: nowMs(),
+  });
+}
+
+async function handleSessionEventsRoute(req, res, searchParams) {
+  const session = ensureSession(searchParams.get("sessionId"));
+
+  openSseStream(res);
+  session.sseClients.add(res);
+  touchSession(session);
+
+  writeSse(
+    res,
+    "session/snapshot",
+    serializeSessionSnapshot(session),
+    session.nextSseId++,
+  );
+
+  const heartbeat = setInterval(() => {
+    if (!res.writableEnded) {
+      res.write(`: heartbeat ${Date.now()}\n\n`);
+    }
+  }, 15000);
+
+  req.on("close", () => {
+    clearInterval(heartbeat);
+    session.sseClients.delete(res);
+  });
+}
+
+async function handleApprovalsRoute(req, res, searchParams) {
+  const session = ensureSession(searchParams.get("sessionId"));
+  sendJson(res, 200, {
+    ok: true,
+    pendingApprovals: listPendingApprovals(session),
+  });
+}
+
+async function handleUserInputRoute(req, res, searchParams) {
+  const session = ensureSession(searchParams.get("sessionId"));
+  sendJson(res, 200, {
+    ok: true,
+    pendingUserInputs: listPendingUserInputs(session),
+  });
+}
+
+async function handleTurnChangesRoute(req, res, searchParams) {
+  const session = ensureSession(searchParams.get("sessionId"));
+  const turnId = String(searchParams.get("turnId") || "").trim();
+  if (!turnId) {
+    throw new Error("turnId is required");
+  }
+
+  const turnChanges = session.completedTurnChanges.get(turnId);
+  if (!turnChanges) {
+    throw new Error(`turn changes not found: ${turnId}`);
+  }
+
+  sendJson(res, 200, {
+    ok: true,
+    turnChanges,
+  });
+}
+
+async function handleFsTreeRoute(req, res) {
+  const entries = await listWorkspaceFiles();
+  sendJson(res, 200, {
+    ok: true,
+    rootPath: ".",
+    entries,
+    tree: buildFileTree(entries),
+  });
+}
+
+async function handleFsFileRoute(req, res, searchParams) {
+  const file = await readWorkspaceFile(searchParams.get("path"));
+  sendJson(res, 200, {
+    ok: true,
+    file,
+  });
+}
+
+async function handleGitShowRoute(req, res, searchParams) {
+  const ref = String(searchParams.get("ref") || "HEAD").trim() || "HEAD";
+  const file = await readGitFile(searchParams.get("path"), ref);
+  sendJson(res, 200, {
+    ok: true,
+    file,
+  });
+}
+
+async function handleGitDiffRoute(req, res, searchParams) {
+  const diff = await readGitDiff(searchParams.get("path"));
+  sendJson(res, 200, {
+    ok: true,
+    diff,
+  });
+}
+
+const postApiRoutes = {
+  "/api/session/start": handleSessionStartRoute,
+  "/api/session/end": handleSessionEndRoute,
+  "/api/session/reconnect": handleSessionReconnectRoute,
+  "/api/thread/start": handleThreadStartRoute,
+  "/api/turn/start": handleTurnStartRoute,
+  "/api/thread/read": handleThreadReadRoute,
+  "/api/approvals/respond": handleApprovalRespondRoute,
+  "/api/user-input/respond": handleUserInputRespondRoute,
+  "/api/exec": handleExecRoute,
+};
+
+const getApiRoutes = {
+  "/api/healthz": handleHealthzRoute,
+  "/api/session/events": handleSessionEventsRoute,
+  "/api/approvals": handleApprovalsRoute,
+  "/api/user-input": handleUserInputRoute,
+  "/api/turn/changes": handleTurnChangesRoute,
+  "/api/fs/tree": handleFsTreeRoute,
+  "/api/fs/file": handleFsFileRoute,
+  "/api/git/show": handleGitShowRoute,
+  "/api/git/diff": handleGitDiffRoute,
+};
+
+async function handlePostApi(req, res, pathname) {
+  const routeHandler = postApiRoutes[pathname];
+  if (!routeHandler) {
+    sendJson(res, 404, { ok: false, error: "not found" });
     return;
   }
 
-  sendJson(res, 404, { ok: false, error: "not found" });
+  const body = await readRequestBody(req);
+  await routeHandler(req, res, body, pathname);
 }
 
 async function handleGetApi(req, res, pathname, searchParams) {
-  if (pathname === "/api/healthz") {
-    sendJson(res, 200, {
-      ok: true,
-      service: "codexbox",
-      sessions: sessions.size,
-      now: nowMs(),
-    });
+  const routeHandler = getApiRoutes[pathname];
+  if (!routeHandler) {
+    sendJson(res, 404, { ok: false, error: "not found" });
     return;
   }
 
-  if (pathname === "/api/session/events") {
-    const session = ensureSession(searchParams.get("sessionId"));
-
-    res.writeHead(200, {
-      "content-type": "text/event-stream",
-      "cache-control": "no-cache, no-transform",
-      connection: "keep-alive",
-      "x-accel-buffering": "no",
-    });
-    res.write("retry: 1500\n\n");
-
-    session.sseClients.add(res);
-    touchSession(session);
-
-    writeSse(
-      res,
-      "session/snapshot",
-      serializeSessionSnapshot(session),
-      session.nextSseId++,
-    );
-
-    const heartbeat = setInterval(() => {
-      if (!res.writableEnded) {
-        res.write(`: heartbeat ${Date.now()}\n\n`);
-      }
-    }, 15000);
-
-    req.on("close", () => {
-      clearInterval(heartbeat);
-      session.sseClients.delete(res);
-    });
-
-    return;
-  }
-
-  if (pathname === "/api/approvals") {
-    const session = ensureSession(searchParams.get("sessionId"));
-    sendJson(res, 200, {
-      ok: true,
-      pendingApprovals: listPendingApprovals(session),
-    });
-    return;
-  }
-
-  if (pathname === "/api/user-input") {
-    const session = ensureSession(searchParams.get("sessionId"));
-    sendJson(res, 200, {
-      ok: true,
-      pendingUserInputs: listPendingUserInputs(session),
-    });
-    return;
-  }
-
-  if (pathname === "/api/turn/changes") {
-    const session = ensureSession(searchParams.get("sessionId"));
-    const turnId = String(searchParams.get("turnId") || "").trim();
-    if (!turnId) {
-      throw new Error("turnId is required");
-    }
-
-    const turnChanges = session.completedTurnChanges.get(turnId);
-    if (!turnChanges) {
-      throw new Error(`turn changes not found: ${turnId}`);
-    }
-
-    sendJson(res, 200, {
-      ok: true,
-      turnChanges,
-    });
-    return;
-  }
-
-  if (pathname === "/api/fs/tree") {
-    const entries = await listWorkspaceFiles();
-    sendJson(res, 200, {
-      ok: true,
-      rootPath: ".",
-      entries,
-      tree: buildFileTree(entries),
-    });
-    return;
-  }
-
-  if (pathname === "/api/fs/file") {
-    const file = await readWorkspaceFile(searchParams.get("path"));
-    sendJson(res, 200, {
-      ok: true,
-      file,
-    });
-    return;
-  }
-
-  if (pathname === "/api/git/show") {
-    const ref = String(searchParams.get("ref") || "HEAD").trim() || "HEAD";
-    const file = await readGitFile(searchParams.get("path"), ref);
-    sendJson(res, 200, {
-      ok: true,
-      file,
-    });
-    return;
-  }
-
-  if (pathname === "/api/git/diff") {
-    const diff = await readGitDiff(searchParams.get("path"));
-    sendJson(res, 200, {
-      ok: true,
-      diff,
-    });
-    return;
-  }
-
-  sendJson(res, 404, { ok: false, error: "not found" });
+  await routeHandler(req, res, searchParams, pathname);
 }
 
 assertValidServerSafetyDefaults();

--- a/tasks/archived/2026-03-07-issue-30-routing-transport/design.md
+++ b/tasks/archived/2026-03-07-issue-30-routing-transport/design.md
@@ -1,0 +1,27 @@
+# Issue 30 Design
+
+## Overview
+- Introduce a small SSE transport helper module for common framing and stream-opening behavior.
+- Replace `handlePostApi` and `handleGetApi` monolithic condition chains with route tables composed of named handler functions.
+- Keep all business logic in the current server file for now; this issue only improves HTTP and transport structure.
+
+## Main Decisions
+- Use plain object route tables keyed by path for GET and POST API routes.
+- Keep request-body parsing centralized in `handlePostApi`, then delegate to route handlers.
+- Share SSE headers and retry prelude through a helper module instead of duplicating the setup in session and exec paths.
+- Leave deeper runtime/service extraction to follow-up issues `#31` and `#32`.
+
+## Component Boundaries
+- `codexbox/server/sse.js`
+  - `writeSse()`
+  - `openSseStream()`
+- `codexbox/webui-server.js`
+  - route handler functions
+  - route tables
+  - existing business logic and state
+
+## Risks
+- Route extraction can accidentally change control flow around early returns.
+  - Mitigation: keep handlers thin and preserve existing response bodies/statuses.
+- Shared SSE helpers could change framing subtly.
+  - Mitigation: preserve exact headers, retry prelude, and `writeSse` payload format.

--- a/tasks/archived/2026-03-07-issue-30-routing-transport/plan.md
+++ b/tasks/archived/2026-03-07-issue-30-routing-transport/plan.md
@@ -1,0 +1,24 @@
+# Issue 30 Plan
+
+## TDD
+- TDD: yes
+- Rationale: routing and SSE transport behavior already has stable backend tests that should catch regressions while structure changes underneath.
+
+## Steps
+- [x] Extract shared SSE framing/opening helpers.
+- [x] Replace GET/POST API condition chains with route tables and named handlers.
+- [x] Run backend validation and confirm route behavior remains compatible.
+- [ ] Create PR, merge, close the issue, and archive task artifacts.
+
+## Validation Notes
+- Primary: `node --test codexbox/webui-server.test.js`
+- Secondary: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+- Result: both commands passed on 2026-03-07 after the route-table and SSE helper refactor.
+
+## Risks and Deferred Items
+- Runtime/service extraction is deferred to `#31` and `#32`.
+- Static asset routing can stay lightweight as long as API routing is cleaned up here.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #30` in the PR description.

--- a/tasks/archived/2026-03-07-issue-30-routing-transport/requirements.md
+++ b/tasks/archived/2026-03-07-issue-30-routing-transport/requirements.md
@@ -1,0 +1,39 @@
+# Issue 30 Requirements
+
+## Goal
+- Refactor the backend HTTP layer so route registration and SSE transport concerns are easier to extend without continuing to grow `codexbox/webui-server.js`.
+
+## In Scope
+- Replace the large backend GET/POST API condition chains with explicit route dispatch tables or equivalent structured routing.
+- Extract shared SSE framing/opening helpers used by session event streams and one-shot exec streams.
+- Preserve existing backend routes, status codes, and response/event contracts.
+- Validate the refactored backend layer through existing shipped API tests.
+
+## Out of Scope
+- Changing API semantics or payload shapes.
+- Reworking session/runtime ownership beyond what is necessary for route extraction.
+- Frontend changes.
+
+## Acceptance Criteria Mapping
+- Backend route handling no longer depends on a single large `if`/`else` chain for all GET/POST APIs.
+- Session SSE and one-shot exec SSE framing share a common helper or abstraction.
+- Existing routes remain behaviorally compatible.
+- Validation covers the refactored backend route layer.
+
+## Consumers and Workflows
+- Bundled WebUI routes already shipped in the repository.
+- Backend-only callers of `/api/exec`, `/api/fs/*`, `/api/git/*`, and `/api/turn/changes`.
+
+## Edge Cases and Error Handling
+- Unknown routes still return the same 404 behavior.
+- Unsupported methods still return the same 405 behavior.
+- SSE responses still set the current headers and retry prelude.
+- Refactor must not silently change per-route body parsing assumptions.
+
+## Constraints and Assumptions
+- Keep the existing CommonJS runtime and Node standard library stack.
+- Prefer structural extraction over behavioral rewrites.
+- Preserve current test coverage as the primary safety net.
+
+## Open Questions
+- None blocking.


### PR DESCRIPTION
## Summary
- extract shared SSE framing/opening helpers into a dedicated server module
- replace GET/POST API condition chains with route tables and named handlers
- archive the Issue #30 task artifacts with validation notes

## Testing
- node --test codexbox/webui-server.test.js
- node --test codexbox/webui-server.test.js codexbox/public/app.test.js

Closes #30