### PR TITLE
refactor: extract session runtime modules

### DIFF
--- a/codexbox/server/session-runtime.js
+++ b/codexbox/server/session-runtime.js
@@ -1,0 +1,456 @@
+"use strict";
+
+const { spawn } = require("node:child_process");
+const {
+  approvalDefaultResult,
+  normalizeUserInputResult,
+  serializeApproval,
+  serializeUserInputRequest,
+  userInputDefaultResponse,
+} = require("./session-store");
+
+const APPROVAL_REQUEST_METHODS = new Set([
+  "item/commandExecution/requestApproval",
+  "item/fileChange/requestApproval",
+  "execCommandApproval",
+  "applyPatchApproval",
+]);
+
+function createSessionRuntime({
+  codexBin,
+  workspaceRoot,
+  approvalTimeoutMs,
+  userInputTimeoutMs,
+  rpcTimeoutMs,
+  emitSessionEvent,
+  normalizeError,
+  nowMs,
+  onTurnCompleted,
+  shutdownSession,
+  touchSession,
+}) {
+  function rpcWrite(session, message) {
+    if (!session.child || session.closed) {
+      throw new Error("session is not running");
+    }
+    const line = JSON.stringify(message);
+    session.child.stdin.write(`${line}\n`);
+    touchSession(session);
+  }
+
+  function rpcNotify(session, method, params) {
+    const message = {
+      jsonrpc: "2.0",
+      method,
+    };
+    if (params !== undefined) {
+      message.params = params;
+    }
+    rpcWrite(session, message);
+  }
+
+  function rpcRespond(session, requestId, result) {
+    rpcWrite(session, {
+      jsonrpc: "2.0",
+      id: requestId,
+      result,
+    });
+  }
+
+  function rpcError(session, requestId, message, code = -32601, data = null) {
+    rpcWrite(session, {
+      jsonrpc: "2.0",
+      id: requestId,
+      error: {
+        code,
+        message,
+        data,
+      },
+    });
+  }
+
+  function rpcRequest(session, method, params) {
+    const requestId = session.nextRpcId++;
+    const key = String(requestId);
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        session.pendingRequests.delete(key);
+        reject(new Error(`RPC timeout for method ${method}`));
+      }, rpcTimeoutMs);
+
+      session.pendingRequests.set(key, {
+        method,
+        resolve,
+        reject,
+        timeout,
+      });
+
+      try {
+        rpcWrite(session, {
+          jsonrpc: "2.0",
+          id: requestId,
+          method,
+          params,
+        });
+      } catch (err) {
+        clearTimeout(timeout);
+        session.pendingRequests.delete(key);
+        reject(err);
+      }
+    });
+  }
+
+  function handleRpcResponse(session, message) {
+    const key = String(message.id);
+    const pending = session.pendingRequests.get(key);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    session.pendingRequests.delete(key);
+
+    if (message.error) {
+      pending.reject(new Error(normalizeError(message.error)));
+      return;
+    }
+
+    pending.resolve(message.result);
+  }
+
+  function resolveUserInputRequest(session, requestId, result, resolutionType) {
+    const key = String(requestId);
+    const request = session.pendingUserInputs.get(key);
+    if (!request) {
+      throw new Error(`user input request ${requestId} not found`);
+    }
+
+    clearTimeout(request.timeoutHandle);
+    session.pendingUserInputs.delete(key);
+
+    rpcRespond(session, request.rpcId, result);
+    emitSessionEvent(session, "user_input/resolved", {
+      resolutionType,
+      request: serializeUserInputRequest(request),
+      result,
+    });
+    touchSession(session);
+
+    return {
+      requestId: request.requestId,
+      resolutionType,
+      result,
+    };
+  }
+
+  function handleUserInputTimeout(session, requestId) {
+    const key = String(requestId);
+    const request = session.pendingUserInputs.get(key);
+    if (!request) {
+      return;
+    }
+
+    const timeoutResult = userInputDefaultResponse(request.params);
+    try {
+      resolveUserInputRequest(session, requestId, timeoutResult, "timeout");
+    } catch (err) {
+      session.pendingUserInputs.delete(key);
+      emitSessionEvent(session, "user_input/timed_out", {
+        request: serializeUserInputRequest(request),
+        reason: normalizeError(err),
+      });
+    }
+  }
+
+  function resolveApproval(session, requestId, result, resolutionType) {
+    const key = String(requestId);
+    const approval = session.pendingApprovals.get(key);
+    if (!approval) {
+      throw new Error(`approval ${requestId} not found`);
+    }
+
+    clearTimeout(approval.timeoutHandle);
+    session.pendingApprovals.delete(key);
+
+    rpcRespond(session, approval.requestId, result);
+    emitSessionEvent(session, "approval/resolved", {
+      resolutionType,
+      approval: serializeApproval(approval),
+      result,
+    });
+    touchSession(session);
+
+    return {
+      requestId: approval.requestId,
+      resolutionType,
+      result,
+    };
+  }
+
+  function handleApprovalTimeout(session, requestId) {
+    const key = String(requestId);
+    const approval = session.pendingApprovals.get(key);
+    if (!approval) {
+      return;
+    }
+
+    const timeoutResult = approvalDefaultResult(approval.method, "cancel");
+    if (!timeoutResult) {
+      session.pendingApprovals.delete(key);
+      emitSessionEvent(session, "approval/timed_out", {
+        approval: serializeApproval(approval),
+        reason: "unsupported-approval-type",
+      });
+      return;
+    }
+
+    try {
+      resolveApproval(session, requestId, timeoutResult, "timeout");
+    } catch (err) {
+      emitSessionEvent(session, "approval/timed_out", {
+        approval: serializeApproval(approval),
+        reason: normalizeError(err),
+      });
+    }
+  }
+
+  function handleApprovalRequest(session, message) {
+    const requestId = String(message.id);
+    const createdAt = nowMs();
+    const approval = {
+      requestId,
+      method: message.method,
+      params: message.params || {},
+      createdAt,
+      expiresAt: createdAt + approvalTimeoutMs,
+      timeoutHandle: null,
+    };
+
+    approval.timeoutHandle = setTimeout(() => {
+      handleApprovalTimeout(session, requestId);
+    }, approvalTimeoutMs);
+
+    session.pendingApprovals.set(requestId, approval);
+    emitSessionEvent(session, "approval/pending", {
+      approval: serializeApproval(approval),
+    });
+    touchSession(session);
+  }
+
+  function handleUserInputRequestFromServer(session, message) {
+    const requestId = String(message.id);
+    const createdAt = nowMs();
+    const request = {
+      requestId,
+      rpcId: message.id,
+      method: message.method,
+      params: message.params || {},
+      createdAt,
+      expiresAt: createdAt + userInputTimeoutMs,
+      timeoutHandle: null,
+    };
+
+    request.timeoutHandle = setTimeout(() => {
+      handleUserInputTimeout(session, requestId);
+    }, userInputTimeoutMs);
+
+    session.pendingUserInputs.set(requestId, request);
+    emitSessionEvent(session, "user_input/pending", {
+      request: serializeUserInputRequest(request),
+    });
+    touchSession(session);
+  }
+
+  function handleUnsupportedToolCall(session, message) {
+    const result = {
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: "Dynamic tool execution is not supported in this bridge.",
+        },
+      ],
+    };
+    rpcRespond(session, message.id, result);
+    emitSessionEvent(session, "tool_call/unsupported", {
+      requestId: String(message.id),
+      method: message.method,
+      params: message.params || {},
+      result,
+    });
+    touchSession(session);
+  }
+
+  const serverRequestHandlers = {
+    "item/tool/requestUserInput": handleUserInputRequestFromServer,
+    "item/tool/call": handleUnsupportedToolCall,
+  };
+
+  function handleRpcRequestFromServer(session, message) {
+    const method = message.method;
+
+    if (APPROVAL_REQUEST_METHODS.has(method)) {
+      handleApprovalRequest(session, message);
+      return;
+    }
+
+    const handler = serverRequestHandlers[method];
+    if (handler) {
+      handler(session, message);
+      return;
+    }
+
+    rpcError(session, message.id, `Unsupported server request method: ${method}`);
+    emitSessionEvent(session, "rpc/server_request_unsupported", {
+      requestId: String(message.id),
+      method: typeof method === "string" ? method : null,
+      reason: "unsupported-server-request-method",
+    });
+    touchSession(session);
+  }
+
+  function handleThreadStartedNotification(session, message) {
+    const threadId = message.params?.thread?.id;
+    if (typeof threadId === "string") {
+      session.threadId = threadId;
+    }
+  }
+
+  function handleAgentMessageDeltaNotification(session, message) {
+    emitSessionEvent(session, "chat/delta", {
+      params: message.params || {},
+    });
+  }
+
+  function handleTurnCompletedNotification(session, message) {
+    if (typeof onTurnCompleted === "function") {
+      onTurnCompleted(session, message.params || {});
+    }
+  }
+
+  const notificationHandlers = {
+    "thread/started": handleThreadStartedNotification,
+    "item/agentMessage/delta": handleAgentMessageDeltaNotification,
+    "turn/completed": handleTurnCompletedNotification,
+  };
+
+  function handleRpcNotification(session, message) {
+    emitSessionEvent(session, "rpc/notification", { message });
+
+    const handler = notificationHandlers[message.method];
+    if (handler) {
+      handler(session, message);
+    }
+
+    touchSession(session);
+  }
+
+  function handleRpcMessage(session, message) {
+    if (!message || typeof message !== "object") {
+      return;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(message, "id") && Object.prototype.hasOwnProperty.call(message, "method")) {
+      handleRpcRequestFromServer(session, message);
+      return;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(message, "id")) {
+      handleRpcResponse(session, message);
+      return;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(message, "method")) {
+      handleRpcNotification(session, message);
+    }
+  }
+
+  function handleChildStdout(session, chunk) {
+    session.stdoutBuffer += chunk;
+    const parts = session.stdoutBuffer.split(/\r?\n/);
+    session.stdoutBuffer = parts.pop() || "";
+
+    for (const part of parts) {
+      const line = part.trim();
+      if (!line) {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(line);
+        handleRpcMessage(session, parsed);
+      } catch (err) {
+        emitSessionEvent(session, "rpc/parse_error", {
+          line,
+          error: normalizeError(err),
+        });
+      }
+    }
+  }
+
+  async function startSessionRuntime(session) {
+    const child = spawn(codexBin, ["app-server", "--listen", "stdio://"], {
+      cwd: workspaceRoot,
+      env: process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    session.child = child;
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      handleChildStdout(session, chunk);
+    });
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      emitSessionEvent(session, "rpc/stderr", { chunk: String(chunk) });
+    });
+
+    child.on("error", (err) => {
+      if (session.closed) {
+        return;
+      }
+      emitSessionEvent(session, "session/error", {
+        error: `app-server process error: ${normalizeError(err)}`,
+      });
+      shutdownSession(session, `app-server process error: ${normalizeError(err)}`);
+    });
+
+    child.on("exit", (code, signal) => {
+      if (session.closed) {
+        return;
+      }
+      shutdownSession(session, `app-server exited (code=${code}, signal=${signal})`);
+    });
+
+    const initResult = await rpcRequest(session, "initialize", {
+      clientInfo: {
+        name: "codex-webui",
+        version: "0.1.0",
+      },
+      capabilities: {
+        experimentalApi: true,
+      },
+    });
+
+    rpcNotify(session, "initialized");
+    emitSessionEvent(session, "session/started", { initResult });
+    touchSession(session);
+
+    return initResult;
+  }
+
+  return {
+    normalizeUserInputResult,
+    resolveApproval,
+    resolveUserInputRequest,
+    rpcRequest,
+    startSessionRuntime,
+  };
+}
+
+module.exports = {
+  createSessionRuntime,
+};

--- a/codexbox/server/session-store.js
+++ b/codexbox/server/session-store.js
@@ -1,0 +1,249 @@
+"use strict";
+
+const { writeSse } = require("./sse");
+
+function approvalDefaultResult(method, decision) {
+  const normalized = String(decision || "deny").toLowerCase();
+
+  if (method === "item/commandExecution/requestApproval") {
+    if (normalized === "allow") return { decision: "accept" };
+    if (normalized === "cancel") return { decision: "cancel" };
+    return { decision: "decline" };
+  }
+
+  if (method === "item/fileChange/requestApproval") {
+    if (normalized === "allow") return { decision: "accept" };
+    if (normalized === "cancel") return { decision: "cancel" };
+    return { decision: "decline" };
+  }
+
+  if (method === "execCommandApproval" || method === "applyPatchApproval") {
+    if (normalized === "allow") return { decision: "approved" };
+    if (normalized === "cancel") return { decision: "abort" };
+    return { decision: "denied" };
+  }
+
+  return null;
+}
+
+function serializeApproval(approval) {
+  return {
+    requestId: approval.requestId,
+    method: approval.method,
+    params: approval.params,
+    createdAt: approval.createdAt,
+    expiresAt: approval.expiresAt,
+  };
+}
+
+function listPendingApprovals(session) {
+  return Array.from(session.pendingApprovals.values())
+    .sort((a, b) => a.createdAt - b.createdAt)
+    .map(serializeApproval);
+}
+
+function userInputDefaultResponse(params) {
+  const answers = {};
+  const questions = Array.isArray(params?.questions) ? params.questions : [];
+  for (const question of questions) {
+    const id = question && typeof question.id === "string" ? question.id : null;
+    if (!id) {
+      continue;
+    }
+    answers[id] = { answers: [] };
+  }
+  return { answers };
+}
+
+function serializeUserInputRequest(request) {
+  return {
+    requestId: request.requestId,
+    method: request.method,
+    params: request.params,
+    createdAt: request.createdAt,
+    expiresAt: request.expiresAt,
+  };
+}
+
+function listPendingUserInputs(session) {
+  return Array.from(session.pendingUserInputs.values())
+    .sort((a, b) => a.createdAt - b.createdAt)
+    .map(serializeUserInputRequest);
+}
+
+function serializeSessionSnapshot(session) {
+  return {
+    sessionId: session.id,
+    threadId: session.threadId,
+    pendingApprovals: listPendingApprovals(session),
+    pendingUserInputs: listPendingUserInputs(session),
+  };
+}
+
+function normalizeUserInputResult(request, body) {
+  if (body.result && typeof body.result === "object") {
+    return body.result;
+  }
+
+  const result = userInputDefaultResponse(request.params);
+  const rawAnswers = body.answers;
+  if (!rawAnswers || typeof rawAnswers !== "object") {
+    return result;
+  }
+
+  for (const [questionId, rawAnswer] of Object.entries(rawAnswers)) {
+    if (Array.isArray(rawAnswer)) {
+      result.answers[questionId] = { answers: rawAnswer.map((value) => String(value)) };
+      continue;
+    }
+    if (rawAnswer && typeof rawAnswer === "object" && Array.isArray(rawAnswer.answers)) {
+      result.answers[questionId] = {
+        answers: rawAnswer.answers.map((value) => String(value)),
+      };
+    }
+  }
+
+  return result;
+}
+
+function createSessionStore({ randomUUID, nowMs }) {
+  const sessions = new Map();
+
+  function createSession() {
+    const sessionId = randomUUID();
+    const session = {
+      id: sessionId,
+      createdAt: nowMs(),
+      lastActivityAt: nowMs(),
+      nextRpcId: 1,
+      nextSseId: 1,
+      stdoutBuffer: "",
+      child: null,
+      closed: false,
+      pendingRequests: new Map(),
+      pendingApprovals: new Map(),
+      pendingUserInputs: new Map(),
+      activeTurnSnapshots: new Map(),
+      completedTurnChanges: new Map(),
+      sseClients: new Set(),
+      threadId: null,
+    };
+    sessions.set(sessionId, session);
+    return session;
+  }
+
+  function touchSession(session) {
+    session.lastActivityAt = nowMs();
+  }
+
+  function emitSessionEvent(session, eventName, payload) {
+    const eventId = session.nextSseId++;
+    const data = {
+      sessionId: session.id,
+      emittedAt: nowMs(),
+      ...payload,
+    };
+
+    for (const client of session.sseClients) {
+      if (client.writableEnded || client.destroyed) {
+        session.sseClients.delete(client);
+        continue;
+      }
+      try {
+        writeSse(client, eventName, data, eventId);
+      } catch {
+        session.sseClients.delete(client);
+      }
+    }
+  }
+
+  function ensureSession(sessionId) {
+    const id = String(sessionId || "").trim();
+    if (!id) {
+      throw new Error("sessionId is required");
+    }
+
+    const session = sessions.get(id);
+    if (!session) {
+      throw new Error(`session not found: ${id}`);
+    }
+
+    if (session.closed) {
+      throw new Error(`session is closed: ${id}`);
+    }
+
+    return session;
+  }
+
+  function shutdownSession(session, reason) {
+    if (!session || session.closed) {
+      return;
+    }
+
+    session.closed = true;
+
+    for (const pending of session.pendingRequests.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error(`session closed: ${reason}`));
+    }
+    session.pendingRequests.clear();
+
+    for (const approval of session.pendingApprovals.values()) {
+      clearTimeout(approval.timeoutHandle);
+    }
+    session.pendingApprovals.clear();
+
+    for (const request of session.pendingUserInputs.values()) {
+      clearTimeout(request.timeoutHandle);
+    }
+    session.pendingUserInputs.clear();
+    session.activeTurnSnapshots.clear();
+    session.completedTurnChanges.clear();
+
+    if (session.child && !session.child.killed) {
+      session.child.kill("SIGTERM");
+      setTimeout(() => {
+        if (session.child && !session.child.killed) {
+          session.child.kill("SIGKILL");
+        }
+      }, 1000).unref();
+    }
+
+    emitSessionEvent(session, "session/closed", { reason });
+
+    for (const client of session.sseClients) {
+      try {
+        client.end();
+      } catch {
+        // no-op
+      }
+    }
+    session.sseClients.clear();
+
+    sessions.delete(session.id);
+  }
+
+  return {
+    sessions,
+    createSession,
+    touchSession,
+    emitSessionEvent,
+    ensureSession,
+    shutdownSession,
+    listPendingApprovals,
+    listPendingUserInputs,
+    serializeSessionSnapshot,
+  };
+}
+
+module.exports = {
+  approvalDefaultResult,
+  createSessionStore,
+  listPendingApprovals,
+  listPendingUserInputs,
+  normalizeUserInputResult,
+  serializeApproval,
+  serializeSessionSnapshot,
+  serializeUserInputRequest,
+  userInputDefaultResponse,
+};

--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -5,6 +5,15 @@ const { spawn, execFile } = require("node:child_process");
 const { randomUUID, createHash } = require("node:crypto");
 const { promisify } = require("node:util");
 const { openSseStream, writeSse } = require("./server/sse");
+const {
+  approvalDefaultResult,
+  createSessionStore,
+  listPendingApprovals,
+  listPendingUserInputs,
+  normalizeUserInputResult,
+  serializeSessionSnapshot,
+} = require("./server/session-store");
+const { createSessionRuntime } = require("./server/session-runtime");
 
 const PORT = Number(process.env.PORT || 8080);
 const HOST = process.env.HOST || "0.0.0.0";
@@ -21,7 +30,6 @@ const STATIC_DIR = path.join(__dirname, "public");
 const MAX_FILE_BYTES = Number(process.env.MAX_FILE_BYTES || 256 * 1024);
 const execFileAsync = promisify(execFile);
 
-const sessions = new Map();
 const VALID_APPROVAL_POLICIES = new Set(["untrusted", "on-failure", "on-request", "never"]);
 const VALID_SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 const WORKSPACE_ROOT_REALPATH = fs.realpathSync.native(WORKSPACE_ROOT);
@@ -712,221 +720,38 @@ async function finalizeTurnChanges(session, params) {
   }
 }
 
-function makeSession() {
-  const sessionId = randomUUID();
-  const session = {
-    id: sessionId,
-    createdAt: nowMs(),
-    lastActivityAt: nowMs(),
-    nextRpcId: 1,
-    nextSseId: 1,
-    stdoutBuffer: "",
-    child: null,
-    closed: false,
-    pendingRequests: new Map(),
-    pendingApprovals: new Map(),
-    pendingUserInputs: new Map(),
-    activeTurnSnapshots: new Map(),
-    completedTurnChanges: new Map(),
-    sseClients: new Set(),
-    threadId: null,
-  };
-  sessions.set(sessionId, session);
-  return session;
-}
+const sessionStore = createSessionStore({
+  randomUUID,
+  nowMs,
+});
 
-function touchSession(session) {
-  session.lastActivityAt = nowMs();
-}
+const {
+  sessions,
+  createSession: makeSession,
+  emitSessionEvent,
+  ensureSession,
+  shutdownSession,
+  touchSession,
+} = sessionStore;
 
-function emitSessionEvent(session, eventName, payload) {
-  const eventId = session.nextSseId++;
-  const data = {
-    sessionId: session.id,
-    emittedAt: nowMs(),
-    ...payload,
-  };
-
-  for (const client of session.sseClients) {
-    if (client.writableEnded || client.destroyed) {
-      session.sseClients.delete(client);
-      continue;
-    }
-    try {
-      writeSse(client, eventName, data, eventId);
-    } catch {
-      session.sseClients.delete(client);
-    }
-  }
-}
-
-function rpcWrite(session, message) {
-  if (!session.child || session.closed) {
-    throw new Error("session is not running");
-  }
-  const line = JSON.stringify(message);
-  session.child.stdin.write(`${line}\n`);
-  touchSession(session);
-}
-
-function rpcNotify(session, method, params) {
-  const message = {
-    jsonrpc: "2.0",
-    method,
-  };
-  if (params !== undefined) {
-    message.params = params;
-  }
-  rpcWrite(session, message);
-}
-
-function rpcRespond(session, requestId, result) {
-  rpcWrite(session, {
-    jsonrpc: "2.0",
-    id: requestId,
-    result,
-  });
-}
-
-function rpcError(session, requestId, message, code = -32601, data = null) {
-  rpcWrite(session, {
-    jsonrpc: "2.0",
-    id: requestId,
-    error: {
-      code,
-      message,
-      data,
-    },
-  });
-}
-
-function rpcRequest(session, method, params) {
-  const requestId = session.nextRpcId++;
-  const key = String(requestId);
-
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      session.pendingRequests.delete(key);
-      reject(new Error(`RPC timeout for method ${method}`));
-    }, RPC_TIMEOUT_MS);
-
-    session.pendingRequests.set(key, {
-      method,
-      resolve,
-      reject,
-      timeout,
-    });
-
-    try {
-      rpcWrite(session, {
-        jsonrpc: "2.0",
-        id: requestId,
-        method,
-        params,
-      });
-    } catch (err) {
-      clearTimeout(timeout);
-      session.pendingRequests.delete(key);
-      reject(err);
-    }
-  });
-}
-
-function handleRpcResponse(session, message) {
-  const key = String(message.id);
-  const pending = session.pendingRequests.get(key);
-  if (!pending) {
-    return;
-  }
-
-  clearTimeout(pending.timeout);
-  session.pendingRequests.delete(key);
-
-  if (message.error) {
-    pending.reject(new Error(normalizeError(message.error)));
-    return;
-  }
-
-  pending.resolve(message.result);
-}
-
-function approvalDefaultResult(method, decision) {
-  const normalized = String(decision || "deny").toLowerCase();
-
-  if (method === "item/commandExecution/requestApproval") {
-    if (normalized === "allow") return { decision: "accept" };
-    if (normalized === "cancel") return { decision: "cancel" };
-    return { decision: "decline" };
-  }
-
-  if (method === "item/fileChange/requestApproval") {
-    if (normalized === "allow") return { decision: "accept" };
-    if (normalized === "cancel") return { decision: "cancel" };
-    return { decision: "decline" };
-  }
-
-  if (method === "execCommandApproval" || method === "applyPatchApproval") {
-    if (normalized === "allow") return { decision: "approved" };
-    if (normalized === "cancel") return { decision: "abort" };
-    return { decision: "denied" };
-  }
-
-  return null;
-}
-
-function serializeApproval(approval) {
-  return {
-    requestId: approval.requestId,
-    method: approval.method,
-    params: approval.params,
-    createdAt: approval.createdAt,
-    expiresAt: approval.expiresAt,
-  };
-}
-
-function listPendingApprovals(session) {
-  return Array.from(session.pendingApprovals.values())
-    .sort((a, b) => a.createdAt - b.createdAt)
-    .map(serializeApproval);
-}
-
-function userInputDefaultResponse(params) {
-  const answers = {};
-  const questions = Array.isArray(params?.questions) ? params.questions : [];
-  for (const question of questions) {
-    const id = question && typeof question.id === "string" ? question.id : null;
-    if (!id) {
-      continue;
-    }
-    answers[id] = { answers: [] };
-  }
-  return { answers };
-}
-
-function serializeUserInputRequest(request) {
-  return {
-    requestId: request.requestId,
-    method: request.method,
-    params: request.params,
-    createdAt: request.createdAt,
-    expiresAt: request.expiresAt,
-  };
-}
-
-function listPendingUserInputs(session) {
-  return Array.from(session.pendingUserInputs.values())
-    .sort((a, b) => a.createdAt - b.createdAt)
-    .map(serializeUserInputRequest);
-}
-
-function serializeSessionSnapshot(session) {
-  return {
-    sessionId: session.id,
-    threadId: session.threadId,
-    pendingApprovals: listPendingApprovals(session),
-    pendingUserInputs: listPendingUserInputs(session),
-  };
-}
+const {
+  resolveApproval,
+  resolveUserInputRequest,
+  rpcRequest,
+  startSessionRuntime,
+} = createSessionRuntime({
+  codexBin: CODEX_BIN,
+  workspaceRoot: WORKSPACE_ROOT,
+  approvalTimeoutMs: APPROVAL_TIMEOUT_MS,
+  userInputTimeoutMs: USER_INPUT_TIMEOUT_MS,
+  rpcTimeoutMs: RPC_TIMEOUT_MS,
+  emitSessionEvent,
+  normalizeError,
+  nowMs,
+  onTurnCompleted: finalizeTurnChanges,
+  shutdownSession,
+  touchSession,
+});
 
 function readExecPrompt(body) {
   if (typeof body?.prompt === "string" && body.prompt.trim()) {
@@ -936,386 +761,6 @@ function readExecPrompt(body) {
     return body.text;
   }
   throw new Error("prompt is required");
-}
-
-function normalizeUserInputResult(request, body) {
-  if (body.result && typeof body.result === "object") {
-    return body.result;
-  }
-
-  const result = userInputDefaultResponse(request.params);
-  const rawAnswers = body.answers;
-  if (!rawAnswers || typeof rawAnswers !== "object") {
-    return result;
-  }
-
-  for (const [questionId, rawAnswer] of Object.entries(rawAnswers)) {
-    if (Array.isArray(rawAnswer)) {
-      result.answers[questionId] = { answers: rawAnswer.map((value) => String(value)) };
-      continue;
-    }
-    if (rawAnswer && typeof rawAnswer === "object" && Array.isArray(rawAnswer.answers)) {
-      result.answers[questionId] = {
-        answers: rawAnswer.answers.map((value) => String(value)),
-      };
-    }
-  }
-
-  return result;
-}
-
-function resolveUserInputRequest(session, requestId, result, resolutionType) {
-  const key = String(requestId);
-  const request = session.pendingUserInputs.get(key);
-  if (!request) {
-    throw new Error(`user input request ${requestId} not found`);
-  }
-
-  clearTimeout(request.timeoutHandle);
-  session.pendingUserInputs.delete(key);
-
-  rpcRespond(session, request.rpcId, result);
-  emitSessionEvent(session, "user_input/resolved", {
-    resolutionType,
-    request: serializeUserInputRequest(request),
-    result,
-  });
-  touchSession(session);
-
-  return {
-    requestId: request.requestId,
-    resolutionType,
-    result,
-  };
-}
-
-function handleUserInputTimeout(session, requestId) {
-  const key = String(requestId);
-  const request = session.pendingUserInputs.get(key);
-  if (!request) {
-    return;
-  }
-
-  const timeoutResult = userInputDefaultResponse(request.params);
-  try {
-    resolveUserInputRequest(session, requestId, timeoutResult, "timeout");
-  } catch (err) {
-    session.pendingUserInputs.delete(key);
-    emitSessionEvent(session, "user_input/timed_out", {
-      request: serializeUserInputRequest(request),
-      reason: normalizeError(err),
-    });
-  }
-}
-
-function resolveApproval(session, requestId, result, resolutionType) {
-  const key = String(requestId);
-  const approval = session.pendingApprovals.get(key);
-  if (!approval) {
-    throw new Error(`approval ${requestId} not found`);
-  }
-
-  clearTimeout(approval.timeoutHandle);
-  session.pendingApprovals.delete(key);
-
-  rpcRespond(session, approval.requestId, result);
-  emitSessionEvent(session, "approval/resolved", {
-    resolutionType,
-    approval: serializeApproval(approval),
-    result,
-  });
-  touchSession(session);
-
-  return {
-    requestId: approval.requestId,
-    resolutionType,
-    result,
-  };
-}
-
-function handleApprovalTimeout(session, requestId) {
-  const key = String(requestId);
-  const approval = session.pendingApprovals.get(key);
-  if (!approval) {
-    return;
-  }
-
-  const timeoutResult = approvalDefaultResult(approval.method, "cancel");
-  if (!timeoutResult) {
-    session.pendingApprovals.delete(key);
-    emitSessionEvent(session, "approval/timed_out", {
-      approval: serializeApproval(approval),
-      reason: "unsupported-approval-type",
-    });
-    return;
-  }
-
-  try {
-    resolveApproval(session, requestId, timeoutResult, "timeout");
-  } catch (err) {
-    emitSessionEvent(session, "approval/timed_out", {
-      approval: serializeApproval(approval),
-      reason: normalizeError(err),
-    });
-  }
-}
-
-function isApprovalRequestMethod(method) {
-  return (
-    method === "item/commandExecution/requestApproval" ||
-    method === "item/fileChange/requestApproval" ||
-    method === "execCommandApproval" ||
-    method === "applyPatchApproval"
-  );
-}
-
-function handleRpcRequestFromServer(session, message) {
-  const method = message.method;
-
-  if (isApprovalRequestMethod(method)) {
-    const requestId = String(message.id);
-    const createdAt = nowMs();
-    const approval = {
-      requestId,
-      method,
-      params: message.params || {},
-      createdAt,
-      expiresAt: createdAt + APPROVAL_TIMEOUT_MS,
-      timeoutHandle: null,
-    };
-
-    approval.timeoutHandle = setTimeout(() => {
-      handleApprovalTimeout(session, requestId);
-    }, APPROVAL_TIMEOUT_MS);
-
-    session.pendingApprovals.set(requestId, approval);
-    emitSessionEvent(session, "approval/pending", {
-      approval: serializeApproval(approval),
-    });
-    touchSession(session);
-    return;
-  }
-
-  if (method === "item/tool/requestUserInput") {
-    const requestId = String(message.id);
-    const createdAt = nowMs();
-    const request = {
-      requestId,
-      rpcId: message.id,
-      method,
-      params: message.params || {},
-      createdAt,
-      expiresAt: createdAt + USER_INPUT_TIMEOUT_MS,
-      timeoutHandle: null,
-    };
-
-    request.timeoutHandle = setTimeout(() => {
-      handleUserInputTimeout(session, requestId);
-    }, USER_INPUT_TIMEOUT_MS);
-
-    session.pendingUserInputs.set(requestId, request);
-    emitSessionEvent(session, "user_input/pending", {
-      request: serializeUserInputRequest(request),
-    });
-    touchSession(session);
-    return;
-  }
-
-  if (method === "item/tool/call") {
-    const result = {
-      success: false,
-      contentItems: [
-        {
-          type: "inputText",
-          text: "Dynamic tool execution is not supported in this bridge.",
-        },
-      ],
-    };
-    rpcRespond(session, message.id, result);
-    emitSessionEvent(session, "tool_call/unsupported", {
-      requestId: String(message.id),
-      method,
-      params: message.params || {},
-      result,
-    });
-    touchSession(session);
-    return;
-  }
-
-  rpcError(session, message.id, `Unsupported server request method: ${method}`);
-  emitSessionEvent(session, "rpc/server_request_unsupported", {
-    requestId: String(message.id),
-    method: typeof method === "string" ? method : null,
-    reason: "unsupported-server-request-method",
-  });
-  touchSession(session);
-}
-
-function handleRpcNotification(session, message) {
-  emitSessionEvent(session, "rpc/notification", { message });
-
-  if (message.method === "thread/started") {
-    const threadId = message.params?.thread?.id;
-    if (typeof threadId === "string") {
-      session.threadId = threadId;
-    }
-  }
-
-  if (message.method === "item/agentMessage/delta") {
-    emitSessionEvent(session, "chat/delta", {
-      params: message.params || {},
-    });
-  }
-
-  if (message.method === "turn/completed") {
-    finalizeTurnChanges(session, message.params || {});
-  }
-
-  touchSession(session);
-}
-
-function handleRpcMessage(session, message) {
-  if (!message || typeof message !== "object") {
-    return;
-  }
-
-  if (Object.prototype.hasOwnProperty.call(message, "id") && Object.prototype.hasOwnProperty.call(message, "method")) {
-    handleRpcRequestFromServer(session, message);
-    return;
-  }
-
-  if (Object.prototype.hasOwnProperty.call(message, "id")) {
-    handleRpcResponse(session, message);
-    return;
-  }
-
-  if (Object.prototype.hasOwnProperty.call(message, "method")) {
-    handleRpcNotification(session, message);
-  }
-}
-
-function handleChildStdout(session, chunk) {
-  session.stdoutBuffer += chunk;
-  const parts = session.stdoutBuffer.split(/\r?\n/);
-  session.stdoutBuffer = parts.pop() || "";
-
-  for (const part of parts) {
-    const line = part.trim();
-    if (!line) {
-      continue;
-    }
-
-    try {
-      const parsed = JSON.parse(line);
-      handleRpcMessage(session, parsed);
-    } catch (err) {
-      emitSessionEvent(session, "rpc/parse_error", {
-        line,
-        error: normalizeError(err),
-      });
-    }
-  }
-}
-
-function shutdownSession(session, reason) {
-  if (!session || session.closed) {
-    return;
-  }
-
-  session.closed = true;
-
-  for (const pending of session.pendingRequests.values()) {
-    clearTimeout(pending.timeout);
-    pending.reject(new Error(`session closed: ${reason}`));
-  }
-  session.pendingRequests.clear();
-
-  for (const approval of session.pendingApprovals.values()) {
-    clearTimeout(approval.timeoutHandle);
-  }
-  session.pendingApprovals.clear();
-
-  for (const request of session.pendingUserInputs.values()) {
-    clearTimeout(request.timeoutHandle);
-  }
-  session.pendingUserInputs.clear();
-  session.activeTurnSnapshots.clear();
-  session.completedTurnChanges.clear();
-
-  if (session.child && !session.child.killed) {
-    session.child.kill("SIGTERM");
-    setTimeout(() => {
-      if (session.child && !session.child.killed) {
-        session.child.kill("SIGKILL");
-      }
-    }, 1000).unref();
-  }
-
-  emitSessionEvent(session, "session/closed", { reason });
-
-  for (const client of session.sseClients) {
-    try {
-      client.end();
-    } catch {
-      // no-op
-    }
-  }
-  session.sseClients.clear();
-
-  sessions.delete(session.id);
-}
-
-async function startSessionRuntime(session) {
-  const child = spawn(CODEX_BIN, ["app-server", "--listen", "stdio://"], {
-    cwd: WORKSPACE_ROOT,
-    env: process.env,
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-
-  session.child = child;
-
-  child.stdout.setEncoding("utf8");
-  child.stdout.on("data", (chunk) => {
-    handleChildStdout(session, chunk);
-  });
-
-  child.stderr.setEncoding("utf8");
-  child.stderr.on("data", (chunk) => {
-    emitSessionEvent(session, "rpc/stderr", { chunk: String(chunk) });
-  });
-
-  child.on("error", (err) => {
-    if (session.closed) {
-      return;
-    }
-    emitSessionEvent(session, "session/error", {
-      error: `app-server process error: ${normalizeError(err)}`,
-    });
-    shutdownSession(session, `app-server process error: ${normalizeError(err)}`);
-  });
-
-  child.on("exit", (code, signal) => {
-    if (session.closed) {
-      return;
-    }
-    shutdownSession(session, `app-server exited (code=${code}, signal=${signal})`);
-  });
-
-  const initResult = await rpcRequest(session, "initialize", {
-    clientInfo: {
-      name: "codex-webui",
-      version: "0.1.0",
-    },
-    capabilities: {
-      experimentalApi: true,
-    },
-  });
-
-  rpcNotify(session, "initialized");
-  emitSessionEvent(session, "session/started", { initResult });
-  touchSession(session);
-
-  return initResult;
 }
 
 async function readRequestBody(req) {
@@ -1340,24 +785,6 @@ async function readRequestBody(req) {
   }
 
   return JSON.parse(text);
-}
-
-function ensureSession(sessionId) {
-  const id = String(sessionId || "").trim();
-  if (!id) {
-    throw new Error("sessionId is required");
-  }
-
-  const session = sessions.get(id);
-  if (!session) {
-    throw new Error(`session not found: ${id}`);
-  }
-
-  if (session.closed) {
-    throw new Error(`session is closed: ${id}`);
-  }
-
-  return session;
 }
 
 function serveStaticFile(res, filePath, contentType) {

--- a/codexbox/webui-server.test.js
+++ b/codexbox/webui-server.test.js
@@ -49,6 +49,20 @@ async function waitForServer(port) {
   throw new Error("server did not become ready in time");
 }
 
+async function waitForCondition(check, description) {
+  const deadline = Date.now() + 5000;
+
+  while (Date.now() < deadline) {
+    const result = await check();
+    if (result) {
+      return result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(description);
+}
+
 async function git(repoDir, args) {
   const result = await execFileAsync("git", ["-C", repoDir, ...args], {
     encoding: "utf8",
@@ -502,6 +516,191 @@ rl.on("line", (line) => {
   assert.equal(readBody.result.thread.turns.length, 1);
   assert.equal(readBody.result.thread.turns[0].items[0].type, "userMessage");
   assert.equal(readBody.result.thread.turns[0].items[1].text, "Hi there");
+});
+
+test("approval, user input, and session closeout keep runtime state transitions intact", async (t) => {
+  const logDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-webui-runtime-"));
+  const logPath = path.join(logDir, "runtime.log");
+  t.after(async () => {
+    await fs.rm(logDir, { recursive: true, force: true });
+  });
+
+  const fakeCodex = await createFakeCodexBin(
+    t,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const readline = require("node:readline");
+
+const logPath = ${JSON.stringify(logPath)};
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+function log(line) {
+  fs.appendFileSync(logPath, line + "\\n");
+}
+
+rl.on("line", (line) => {
+  if (!line.trim()) {
+    return;
+  }
+
+  const message = JSON.parse(line);
+
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: { protocolVersion: "2026-03-01" } });
+    return;
+  }
+
+  if (message.method === "thread/start") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        thread: {
+          id: "thread-runtime",
+        },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      id: "approval-1",
+      method: "execCommandApproval",
+      params: {
+        command: ["pwd"],
+      },
+    });
+    return;
+  }
+
+  if (message.id === "approval-1") {
+    log("approval:" + JSON.stringify(message.result));
+    send({
+      jsonrpc: "2.0",
+      id: "user-input-1",
+      method: "item/tool/requestUserInput",
+      params: {
+        questions: [
+          {
+            id: "choice",
+            prompt: "Pick one",
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  if (message.id === "user-input-1") {
+    log("user-input:" + JSON.stringify(message.result));
+  }
+});
+`,
+  );
+
+  const { port } = await startServer(t, { codexBin: fakeCodex });
+  const startResponse = await fetch(`http://127.0.0.1:${port}/api/session/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  assert.equal(startResponse.status, 200);
+  const startBody = await startResponse.json();
+  assert.equal(startBody.ok, true);
+
+  const threadResponse = await fetch(`http://127.0.0.1:${port}/api/thread/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+      params: {},
+    }),
+  });
+  assert.equal(threadResponse.status, 200);
+
+  const approvalsBody = await waitForCondition(async () => {
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/approvals?sessionId=${encodeURIComponent(startBody.sessionId)}`,
+    );
+    const body = await response.json();
+    return body.pendingApprovals.length === 1 ? body : null;
+  }, "approval did not become pending");
+  assert.equal(approvalsBody.pendingApprovals[0].requestId, "approval-1");
+
+  const approvalResponse = await fetch(`http://127.0.0.1:${port}/api/approvals/respond`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+      requestId: "approval-1",
+      decision: "allow",
+    }),
+  });
+  assert.equal(approvalResponse.status, 200);
+  const approvalBody = await approvalResponse.json();
+  assert.equal(approvalBody.ok, true);
+  assert.equal(approvalBody.resolved.result.decision, "approved");
+
+  const userInputBody = await waitForCondition(async () => {
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/user-input?sessionId=${encodeURIComponent(startBody.sessionId)}`,
+    );
+    const body = await response.json();
+    return body.pendingUserInputs.length === 1 ? body : null;
+  }, "user input did not become pending");
+  assert.equal(userInputBody.pendingUserInputs[0].requestId, "user-input-1");
+
+  const userInputResponse = await fetch(`http://127.0.0.1:${port}/api/user-input/respond`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+      requestId: "user-input-1",
+      answers: {
+        choice: ["alpha"],
+      },
+    }),
+  });
+  assert.equal(userInputResponse.status, 200);
+  const userInputResolved = await userInputResponse.json();
+  assert.equal(userInputResolved.ok, true);
+  assert.deepEqual(userInputResolved.resolved.result.answers.choice.answers, ["alpha"]);
+
+  const logText = await waitForCondition(async () => {
+    try {
+      const text = await fs.readFile(logPath, "utf8");
+      return text.includes("approval:") && text.includes("user-input:") ? text : null;
+    } catch {
+      return null;
+    }
+  }, "runtime did not record approval and user-input responses");
+  assert.match(logText, /approval:\{"decision":"approved"\}/);
+  assert.match(logText, /user-input:\{"answers":\{"choice":\{"answers":\["alpha"\]\}\}\}/);
+
+  const endResponse = await fetch(`http://127.0.0.1:${port}/api/session/end`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+    }),
+  });
+  assert.equal(endResponse.status, 200);
+  const endBody = await endResponse.json();
+  assert.equal(endBody.ok, true);
+
+  const reconnectResponse = await fetch(`http://127.0.0.1:${port}/api/session/reconnect`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sessionId: startBody.sessionId,
+    }),
+  });
+  assert.equal(reconnectResponse.status, 400);
+  const reconnectBody = await reconnectResponse.json();
+  assert.equal(reconnectBody.ok, false);
+  assert.match(reconnectBody.error, /session not found/);
 });
 
 test("GET /api/turn/changes returns snapshot-based turn-local changed files", async (t) => {

--- a/tasks/archived/2026-03-07-issue-31-runtime-dispatch/design.md
+++ b/tasks/archived/2026-03-07-issue-31-runtime-dispatch/design.md
@@ -1,0 +1,36 @@
+# Issue 31 Design
+
+## Goal
+Reduce `webui-server.js` responsibility by moving session state management and RPC runtime behavior behind backend-internal modules, while keeping the HTTP routes unchanged.
+
+## Proposed Structure
+- `codexbox/server/session-store.js`
+  - owns the in-memory session map
+  - creates session records
+  - exposes session lookup, touch, SSE fanout, snapshot serialization, and shutdown helpers
+- `codexbox/server/session-runtime.js`
+  - owns RPC write/request/response helpers
+  - owns approval and user-input pending state transitions
+  - owns server-request and notification dispatch tables
+  - starts and wires the `codex app-server` child process
+- `codexbox/webui-server.js`
+  - keeps HTTP route handling and workspace/Git helpers
+  - instantiates the session store and runtime with injected dependencies
+
+## Dispatch Strategy
+- Request dispatch keeps approval methods in an explicit supported-method set that routes to one approval handler.
+- Non-approval server requests use a method-to-handler table.
+- Notifications use a method-to-handler table so `thread/started`, `item/agentMessage/delta`, and `turn/completed` stay easy to audit.
+
+## Behavior Constraints
+- Keep session object shape compatible with existing HTTP routes.
+- Keep `turn/completed` snapshot finalization delegated from the runtime into the existing snapshot logic.
+- Preserve current timeout semantics and emitted SSE event names.
+
+## Risks
+- Moving shutdown and pending-state cleanup can introduce lifecycle regressions if a helper forgets to clear timeouts or remove sessions.
+- Dispatch extraction can silently break unsupported-method behavior if the fallback path changes.
+
+## Validation Focus
+- Existing reconnect and turn-change tests cover runtime bootstrap and notification-driven turn finalization.
+- Add approval/user-input/session-end regression coverage so the extracted lifecycle paths stay explicit.

--- a/tasks/archived/2026-03-07-issue-31-runtime-dispatch/plan.md
+++ b/tasks/archived/2026-03-07-issue-31-runtime-dispatch/plan.md
@@ -1,0 +1,22 @@
+# Issue 31 Plan
+
+## TDD
+- TDD: partial
+- Rationale: regression-sensitive approval/user-input/session-close paths are well-suited to tests first or alongside extraction, while the module move itself is structural scaffolding.
+
+## Steps
+- [x] Add or extend backend tests for approval/user-input/session-close runtime paths.
+- [x] Extract session store helpers into a dedicated backend module.
+- [x] Extract RPC runtime and dispatch tables into a dedicated backend module.
+- [x] Rewire `webui-server.js` to consume the extracted runtime/store modules without changing API contracts.
+- [x] Run backend and combined validation.
+- [ ] Create PR, merge, close the issue, and archive task artifacts.
+
+## Validation Notes
+- Primary: `node --test codexbox/webui-server.test.js`
+- Secondary: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+- Result: both commands passed on 2026-03-07 after extracting session-store and session-runtime modules.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #31` in the PR description.

--- a/tasks/archived/2026-03-07-issue-31-runtime-dispatch/requirements.md
+++ b/tasks/archived/2026-03-07-issue-31-runtime-dispatch/requirements.md
@@ -1,0 +1,26 @@
+# Issue 31 Requirements
+
+## Scope Assessment
+- Change size: medium.
+- Reasoning: the refactor spans backend runtime wiring, session lifecycle state, and RPC dispatch paths across multiple files.
+
+## In Scope
+- Extract backend session lifecycle helpers from `codexbox/webui-server.js` into dedicated server modules.
+- Replace long RPC server request/notification condition chains with structured dispatch tables or equivalent explicit dispatch.
+- Preserve existing approval, user-input, reconnect, turn completion, and session closeout behavior.
+- Keep current backend and bundled-client validation green.
+
+## Out of Scope
+- Backend HTTP API contract changes.
+- Frontend behavior changes.
+- Git/FS service extraction handled by `#32`.
+
+## Acceptance Criteria
+- Session creation, lookup, SSE fanout, and shutdown are no longer defined inline inside `webui-server.js`.
+- RPC request/response/notification handling is organized behind explicit runtime helpers, with request and notification dispatch no longer implemented as long method-specific branches.
+- Approval and user-input state mutation paths remain explicit and test-covered.
+- Validation covers the refactored runtime behavior without API regressions.
+
+## Validation Targets
+- `node --test codexbox/webui-server.test.js`
+- `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`


### PR DESCRIPTION
## Summary
- extract backend session lifecycle state into a dedicated session-store module
- extract RPC runtime and explicit request/notification dispatch into a dedicated session-runtime module
- add regression coverage for approval, user input, and session closeout paths

## Testing
- node --test codexbox/webui-server.test.js
- node --test codexbox/webui-server.test.js codexbox/public/app.test.js

Closes #31