### PR TITLE
refactor: extract workspace and turn services

### DIFF
--- a/codexbox/server/turn-changes.js
+++ b/codexbox/server/turn-changes.js
@@ -1,0 +1,129 @@
+"use strict";
+
+function createTurnChangeService({ captureWorkspaceSnapshot, emitSessionEvent, normalizeError, nowMs }) {
+  function virtualSnapshotEntry(pathname) {
+    return {
+      path: pathname,
+      tracked: false,
+      exists: false,
+      kind: "missing",
+      digest: null,
+      gitStatus: "  ",
+      indexStatus: " ",
+      worktreeStatus: " ",
+    };
+  }
+
+  function snapshotEntriesEqual(left, right) {
+    return (
+      left.tracked === right.tracked &&
+      left.exists === right.exists &&
+      left.kind === right.kind &&
+      left.digest === right.digest &&
+      left.gitStatus === right.gitStatus &&
+      left.indexStatus === right.indexStatus &&
+      left.worktreeStatus === right.worktreeStatus
+    );
+  }
+
+  function serializeSnapshotEntry(entry) {
+    return {
+      exists: entry.exists,
+      kind: entry.kind,
+      tracked: entry.tracked,
+      gitStatus: entry.gitStatus,
+      indexStatus: entry.indexStatus,
+      worktreeStatus: entry.worktreeStatus,
+    };
+  }
+
+  function determineTurnFileChangeType(beforeEntry, afterEntry) {
+    if (!beforeEntry.exists && afterEntry.exists) {
+      return "created";
+    }
+    if (beforeEntry.exists && !afterEntry.exists) {
+      return "deleted";
+    }
+    return "updated";
+  }
+
+  function diffWorkspaceSnapshots(beforeSnapshot, afterSnapshot) {
+    const changedFiles = [];
+    const paths = new Set([...beforeSnapshot.keys(), ...afterSnapshot.keys()]);
+
+    for (const pathname of Array.from(paths).sort((left, right) => left.localeCompare(right))) {
+      const beforeEntry = beforeSnapshot.get(pathname) || virtualSnapshotEntry(pathname);
+      const afterEntry = afterSnapshot.get(pathname) || virtualSnapshotEntry(pathname);
+
+      if (snapshotEntriesEqual(beforeEntry, afterEntry)) {
+        continue;
+      }
+
+      changedFiles.push({
+        path: pathname,
+        changeType: determineTurnFileChangeType(beforeEntry, afterEntry),
+        before: serializeSnapshotEntry(beforeEntry),
+        after: serializeSnapshotEntry(afterEntry),
+      });
+    }
+
+    return changedFiles;
+  }
+
+  function rememberCompletedTurnChanges(session, turnChanges) {
+    session.completedTurnChanges.set(turnChanges.turnId, turnChanges);
+    while (session.completedTurnChanges.size > 20) {
+      const oldestTurnId = session.completedTurnChanges.keys().next().value;
+      session.completedTurnChanges.delete(oldestTurnId);
+    }
+  }
+
+  function rememberActiveTurnSnapshot(session, snapshot) {
+    session.activeTurnSnapshots.set(snapshot.turnId, snapshot);
+  }
+
+  function getCompletedTurnChanges(session, turnId) {
+    return session.completedTurnChanges.get(String(turnId || "").trim());
+  }
+
+  async function finalizeTurnChanges(session, params) {
+    const turnId = String(params?.turn?.id || "").trim();
+    if (!turnId) {
+      return;
+    }
+
+    const activeTurn = session.activeTurnSnapshots.get(turnId);
+    if (!activeTurn) {
+      return;
+    }
+
+    try {
+      const completedSnapshot = await captureWorkspaceSnapshot();
+      const turnChanges = {
+        turnId,
+        threadId: String(params?.threadId || activeTurn.threadId || session.threadId || "").trim() || null,
+        startedAt: activeTurn.startedAt,
+        completedAt: nowMs(),
+        changedFiles: diffWorkspaceSnapshots(activeTurn.snapshot, completedSnapshot),
+      };
+      session.activeTurnSnapshots.delete(turnId);
+      rememberCompletedTurnChanges(session, turnChanges);
+    } catch (err) {
+      session.activeTurnSnapshots.delete(turnId);
+      emitSessionEvent(session, "turn/changes_error", {
+        turnId,
+        error: normalizeError(err),
+      });
+    }
+  }
+
+  return {
+    finalizeTurnChanges,
+    getCompletedTurnChanges,
+    rememberActiveTurnSnapshot,
+  };
+}
+
+module.exports = {
+  createTurnChangeService,
+};

--- a/codexbox/server/workspace-service.js
+++ b/codexbox/server/workspace-service.js
@@ -1,0 +1,556 @@
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+const { execFile } = require("node:child_process");
+const { createHash } = require("node:crypto");
+const { promisify } = require("node:util");
+
+const execFileAsync = promisify(execFile);
+
+function createWorkspaceService({ maxFileBytes, workspaceRootRealPath }) {
+  function isPathInside(parentPath, childPath) {
+    const relativePath = path.relative(parentPath, childPath);
+    return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+  }
+
+  function resolveWorkspacePath(requestedPath) {
+    const rawPath = String(requestedPath || "").trim();
+    if (!rawPath) {
+      throw new Error("path is required");
+    }
+
+    const candidatePath = path.resolve(workspaceRootRealPath, rawPath);
+    let resolvedPath;
+    try {
+      resolvedPath = fs.realpathSync.native(candidatePath);
+    } catch (err) {
+      if (err && err.code === "ENOENT") {
+        throw new Error(`path not found: ${rawPath}`);
+      }
+      throw err;
+    }
+
+    if (!isPathInside(workspaceRootRealPath, resolvedPath)) {
+      throw new Error(`path escapes workspace: ${rawPath}`);
+    }
+
+    return {
+      rawPath,
+      absolutePath: resolvedPath,
+      relativePath: path.relative(workspaceRootRealPath, resolvedPath).split(path.sep).join("/"),
+    };
+  }
+
+  function normalizeRepoRelativePath(requestedPath) {
+    const rawPath = String(requestedPath || "").trim();
+    if (!rawPath) {
+      throw new Error("path is required");
+    }
+
+    const candidatePath = path.resolve(workspaceRootRealPath, rawPath);
+    if (!isPathInside(workspaceRootRealPath, candidatePath)) {
+      throw new Error(`path escapes workspace: ${rawPath}`);
+    }
+
+    const relativePath = path.relative(workspaceRootRealPath, candidatePath).split(path.sep).join("/");
+    if (!relativePath || relativePath === ".") {
+      throw new Error("path must point to a file");
+    }
+
+    return {
+      rawPath,
+      absolutePath: candidatePath,
+      relativePath,
+    };
+  }
+
+  async function runGit(args) {
+    const { stdout } = await execFileAsync("git", ["-C", workspaceRootRealPath, ...args], {
+      encoding: "utf8",
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return stdout;
+  }
+
+  async function runGitBuffer(args) {
+    const { stdout } = await execFileAsync("git", ["-C", workspaceRootRealPath, ...args], {
+      encoding: "buffer",
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return stdout;
+  }
+
+  function isGitMissingObjectError(err) {
+    if (typeof err?.stderr !== "string") {
+      return false;
+    }
+    return (
+      err.stderr.includes("exists on disk, but not in") ||
+      err.stderr.includes("pathspec") ||
+      err.stderr.includes("Not a valid object name") ||
+      err.stderr.includes("invalid object name") ||
+      err.stderr.includes("does not exist in")
+    );
+  }
+
+  function parseGitStatusPorcelain(output) {
+    const statuses = new Map();
+    const records = output.split("\0");
+
+    for (let index = 0; index < records.length; index += 1) {
+      const record = records[index];
+      if (!record) {
+        continue;
+      }
+
+      const code = record.slice(0, 2);
+      const currentPath = record.slice(3);
+      if (!currentPath) {
+        continue;
+      }
+
+      if (code.includes("R") || code.includes("C")) {
+        index += 1;
+      }
+
+      statuses.set(currentPath, {
+        code,
+        indexStatus: code[0],
+        worktreeStatus: code[1],
+        isUntracked: code === "??",
+      });
+    }
+
+    return statuses;
+  }
+
+  function createDirectoryNode(name, nodePath) {
+    return {
+      type: "directory",
+      name,
+      path: nodePath,
+      children: [],
+    };
+  }
+
+  function createFileNode(name, nodePath, metadata) {
+    return {
+      type: "file",
+      name,
+      path: nodePath,
+      tracked: metadata.tracked,
+      gitStatus: metadata.gitStatus,
+      indexStatus: metadata.indexStatus,
+      worktreeStatus: metadata.worktreeStatus,
+    };
+  }
+
+  function sortTreeNodes(nodes) {
+    nodes.sort((left, right) => {
+      if (left.type !== right.type) {
+        return left.type === "directory" ? -1 : 1;
+      }
+      return left.name.localeCompare(right.name);
+    });
+
+    for (const node of nodes) {
+      if (node.type === "directory") {
+        sortTreeNodes(node.children);
+      }
+    }
+  }
+
+  function buildFileTree(fileEntries) {
+    const root = [];
+    const directories = new Map([["", { children: root }]]);
+
+    for (const entry of fileEntries) {
+      const parts = entry.path.split("/").filter(Boolean);
+      let parentPath = "";
+      let parentNode = directories.get(parentPath);
+
+      for (let index = 0; index < parts.length; index += 1) {
+        const name = parts[index];
+        const nodePath = parentPath ? `${parentPath}/${name}` : name;
+        const isLeaf = index === parts.length - 1;
+
+        if (isLeaf) {
+          parentNode.children.push(createFileNode(name, nodePath, entry));
+          continue;
+        }
+
+        let directoryNode = directories.get(nodePath);
+        if (!directoryNode) {
+          directoryNode = createDirectoryNode(name, nodePath);
+          directories.set(nodePath, directoryNode);
+          parentNode.children.push(directoryNode);
+        }
+
+        parentPath = nodePath;
+        parentNode = directoryNode;
+      }
+    }
+
+    sortTreeNodes(root);
+    return root;
+  }
+
+  function ensureTextFile(buffer, requestedPath) {
+    if (buffer.includes(0)) {
+      throw new Error(`binary files are not supported: ${requestedPath}`);
+    }
+  }
+
+  function toTextPayload(pathname, ref, exists, buffer) {
+    if (!exists) {
+      return {
+        path: pathname,
+        ref,
+        exists: false,
+        size: 0,
+        content: "",
+      };
+    }
+
+    if (buffer.length > maxFileBytes) {
+      throw new Error(`file is too large: ${pathname}`);
+    }
+    ensureTextFile(buffer, pathname);
+
+    return {
+      path: pathname,
+      ref,
+      exists: true,
+      size: buffer.length,
+      content: buffer.toString("utf8"),
+    };
+  }
+
+  async function listWorkspaceFiles() {
+    const [trackedOutput, statusOutput] = await Promise.all([
+      runGit(["ls-files", "-z", "--cached"]),
+      runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
+    ]);
+
+    const statuses = parseGitStatusPorcelain(statusOutput);
+    const entries = new Map();
+
+    for (const trackedPath of trackedOutput.split("\0")) {
+      if (!trackedPath) {
+        continue;
+      }
+
+      entries.set(trackedPath, {
+        path: trackedPath,
+        tracked: true,
+        gitStatus: statuses.get(trackedPath)?.code || "  ",
+        indexStatus: statuses.get(trackedPath)?.indexStatus || " ",
+        worktreeStatus: statuses.get(trackedPath)?.worktreeStatus || " ",
+      });
+    }
+
+    for (const [filePath, status] of statuses.entries()) {
+      if (!status.isUntracked) {
+        continue;
+      }
+
+      entries.set(filePath, {
+        path: filePath,
+        tracked: false,
+        gitStatus: status.code,
+        indexStatus: status.indexStatus,
+        worktreeStatus: status.worktreeStatus,
+      });
+    }
+
+    const visibleEntries = [];
+    for (const entry of entries.values()) {
+      const absolutePath = path.resolve(workspaceRootRealPath, entry.path);
+      if (!fs.existsSync(absolutePath)) {
+        continue;
+      }
+
+      let stat;
+      try {
+        const resolvedPath = fs.realpathSync.native(absolutePath);
+        if (!isPathInside(workspaceRootRealPath, resolvedPath)) {
+          continue;
+        }
+        stat = fs.statSync(resolvedPath);
+      } catch {
+        continue;
+      }
+
+      if (!stat.isFile()) {
+        continue;
+      }
+
+      visibleEntries.push(entry);
+    }
+
+    visibleEntries.sort((left, right) => left.path.localeCompare(right.path));
+    return visibleEntries;
+  }
+
+  async function listWorkspaceTree() {
+    return buildFileTree(await listWorkspaceFiles());
+  }
+
+  async function listWorkspaceCatalog() {
+    const entries = await listWorkspaceFiles();
+    return {
+      entries,
+      tree: buildFileTree(entries),
+    };
+  }
+
+  async function readWorkspaceFile(requestedPath) {
+    const resolved = resolveWorkspacePath(requestedPath);
+    const stat = await fs.promises.stat(resolved.absolutePath);
+
+    if (!stat.isFile()) {
+      throw new Error(`path is not a file: ${requestedPath}`);
+    }
+    if (stat.size > maxFileBytes) {
+      throw new Error(`file is too large: ${requestedPath}`);
+    }
+
+    const buffer = await fs.promises.readFile(resolved.absolutePath);
+    ensureTextFile(buffer, requestedPath);
+
+    return {
+      path: resolved.relativePath,
+      size: buffer.length,
+      content: buffer.toString("utf8"),
+    };
+  }
+
+  async function gitObjectExists(ref, relativePath) {
+    try {
+      await runGit(["cat-file", "-e", `${ref}:${relativePath}`]);
+      return true;
+    } catch (err) {
+      if (typeof err?.code === "number" && isGitMissingObjectError(err)) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  async function assertGitRefExists(ref) {
+    try {
+      await runGit(["rev-parse", "--verify", "--quiet", `${ref}^{object}`]);
+    } catch (err) {
+      if (typeof err?.code === "number") {
+        throw new Error(`invalid ref: ${ref}`);
+      }
+      throw err;
+    }
+  }
+
+  async function gitObjectType(ref, relativePath) {
+    const output = await runGit(["cat-file", "-t", `${ref}:${relativePath}`]);
+    return output.trim();
+  }
+
+  async function readGitFile(requestedPath, ref = "HEAD") {
+    const normalized = normalizeRepoRelativePath(requestedPath);
+    await assertGitRefExists(ref);
+    const exists = await gitObjectExists(ref, normalized.relativePath);
+    if (!exists) {
+      return toTextPayload(normalized.relativePath, ref, false, Buffer.alloc(0));
+    }
+
+    const objectType = await gitObjectType(ref, normalized.relativePath);
+    if (objectType !== "blob") {
+      throw new Error(`path is not a file: ${requestedPath}`);
+    }
+
+    const buffer = await runGitBuffer(["show", `${ref}:${normalized.relativePath}`]);
+    return toTextPayload(normalized.relativePath, ref, true, buffer);
+  }
+
+  async function readWorkspaceFileVersion(requestedPath) {
+    const normalized = normalizeRepoRelativePath(requestedPath);
+    if (!fs.existsSync(normalized.absolutePath)) {
+      return toTextPayload(normalized.relativePath, "WORKTREE", false, Buffer.alloc(0));
+    }
+
+    const entryStat = await fs.promises.lstat(normalized.absolutePath);
+    if (entryStat.isSymbolicLink()) {
+      const resolvedPath = fs.realpathSync.native(normalized.absolutePath);
+      if (!isPathInside(workspaceRootRealPath, resolvedPath)) {
+        throw new Error(`path escapes workspace: ${requestedPath}`);
+      }
+      const linkTarget = await fs.promises.readlink(normalized.absolutePath, "utf8");
+      return toTextPayload(normalized.relativePath, "WORKTREE", true, Buffer.from(linkTarget, "utf8"));
+    }
+
+    const resolved = resolveWorkspacePath(normalized.relativePath);
+    const stat = await fs.promises.stat(resolved.absolutePath);
+    if (!stat.isFile()) {
+      throw new Error(`path is not a file: ${requestedPath}`);
+    }
+
+    const buffer = await fs.promises.readFile(resolved.absolutePath);
+    return toTextPayload(normalized.relativePath, "WORKTREE", true, buffer);
+  }
+
+  async function readGitStatus(requestedPath) {
+    const normalized = normalizeRepoRelativePath(requestedPath);
+    const output = await runGit([
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+      "--",
+      normalized.relativePath,
+    ]);
+    const status = parseGitStatusPorcelain(output).get(normalized.relativePath);
+
+    return {
+      path: normalized.relativePath,
+      gitStatus: status?.code || "  ",
+      indexStatus: status?.indexStatus || " ",
+      worktreeStatus: status?.worktreeStatus || " ",
+    };
+  }
+
+  async function readGitDiff(requestedPath) {
+    const status = await readGitStatus(requestedPath);
+    const [left, right] = await Promise.all([
+      readGitFile(status.path, "HEAD"),
+      readWorkspaceFileVersion(status.path),
+    ]);
+
+    if (!left.exists && !right.exists) {
+      throw new Error(`path not found: ${status.path}`);
+    }
+
+    return {
+      path: status.path,
+      gitStatus: status.gitStatus,
+      indexStatus: status.indexStatus,
+      worktreeStatus: status.worktreeStatus,
+      left,
+      right,
+    };
+  }
+
+  function hashBuffer(buffer) {
+    return createHash("sha256").update(buffer).digest("hex");
+  }
+
+  function defaultGitStatus(status = {}) {
+    return {
+      gitStatus: status.gitStatus || status.code || "  ",
+      indexStatus: status.indexStatus || " ",
+      worktreeStatus: status.worktreeStatus || " ",
+    };
+  }
+
+  async function captureWorkspaceSnapshotEntry(relativePath, tracked, status) {
+    const absolutePath = path.resolve(workspaceRootRealPath, relativePath);
+    const statusFields = defaultGitStatus(status);
+
+    let entryStat = null;
+    try {
+      entryStat = await fs.promises.lstat(absolutePath);
+    } catch (err) {
+      if (err && err.code !== "ENOENT") {
+        throw err;
+      }
+    }
+
+    if (!entryStat) {
+      return {
+        path: relativePath,
+        tracked,
+        exists: false,
+        kind: "missing",
+        digest: null,
+        ...statusFields,
+      };
+    }
+
+    if (entryStat.isSymbolicLink()) {
+      const resolvedPath = fs.realpathSync.native(absolutePath);
+      if (!isPathInside(workspaceRootRealPath, resolvedPath)) {
+        throw new Error(`path escapes workspace: ${relativePath}`);
+      }
+      const linkTarget = await fs.promises.readlink(absolutePath, "utf8");
+      return {
+        path: relativePath,
+        tracked,
+        exists: true,
+        kind: "symlink",
+        digest: hashBuffer(Buffer.from(linkTarget, "utf8")),
+        ...statusFields,
+      };
+    }
+
+    const resolvedPath = fs.realpathSync.native(absolutePath);
+    if (!isPathInside(workspaceRootRealPath, resolvedPath)) {
+      throw new Error(`path escapes workspace: ${relativePath}`);
+    }
+
+    const resolvedStat = await fs.promises.stat(resolvedPath);
+    if (resolvedStat.isFile()) {
+      const buffer = await fs.promises.readFile(resolvedPath);
+      return {
+        path: relativePath,
+        tracked,
+        exists: true,
+        kind: "file",
+        digest: hashBuffer(buffer),
+        ...statusFields,
+      };
+    }
+
+    return {
+      path: relativePath,
+      tracked,
+      exists: true,
+      kind: "other",
+      digest: hashBuffer(Buffer.from(`${entryStat.mode}:${resolvedStat.size}`)),
+      ...statusFields,
+    };
+  }
+
+  async function captureWorkspaceSnapshot() {
+    const [trackedOutput, statusOutput] = await Promise.all([
+      runGit(["ls-files", "-z", "--cached"]),
+      runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
+    ]);
+
+    const statuses = parseGitStatusPorcelain(statusOutput);
+    const trackedPaths = new Set(trackedOutput.split("\0").filter(Boolean));
+    const snapshotPaths = new Set([...trackedPaths, ...statuses.keys()]);
+    const sortedPaths = Array.from(snapshotPaths).sort((left, right) => left.localeCompare(right));
+
+    const entries = await Promise.all(
+      sortedPaths.map((relativePath) => captureWorkspaceSnapshotEntry(
+        relativePath,
+        trackedPaths.has(relativePath),
+        statuses.get(relativePath),
+      )),
+    );
+
+    return new Map(entries.map((entry) => [entry.path, entry]));
+  }
+
+  return {
+    captureWorkspaceSnapshot,
+    listWorkspaceCatalog,
+    listWorkspaceFiles,
+    listWorkspaceTree,
+    readGitDiff,
+    readGitFile,
+    readWorkspaceFile,
+  };
+}
+
+module.exports = {
+  createWorkspaceService,
+};

--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -1,9 +1,8 @@
 const http = require("node:http");
 const path = require("node:path");
 const fs = require("node:fs");
-const { spawn, execFile } = require("node:child_process");
-const { randomUUID, createHash } = require("node:crypto");
-const { promisify } = require("node:util");
+const { spawn } = require("node:child_process");
+const { randomUUID } = require("node:crypto");
 const { openSseStream, writeSse } = require("./server/sse");
 const {
   approvalDefaultResult,
@@ -14,6 +13,8 @@ const {
   serializeSessionSnapshot,
 } = require("./server/session-store");
 const { createSessionRuntime } = require("./server/session-runtime");
+const { createTurnChangeService } = require("./server/turn-changes");
+const { createWorkspaceService } = require("./server/workspace-service");
 
 const PORT = Number(process.env.PORT || 8080);
 const HOST = process.env.HOST || "0.0.0.0";
@@ -28,7 +29,6 @@ const CODEX_DEFAULT_APPROVAL_POLICY = process.env.CODEX_DEFAULT_APPROVAL_POLICY 
 const CODEX_DEFAULT_SANDBOX = process.env.CODEX_DEFAULT_SANDBOX || "read-only";
 const STATIC_DIR = path.join(__dirname, "public");
 const MAX_FILE_BYTES = Number(process.env.MAX_FILE_BYTES || 256 * 1024);
-const execFileAsync = promisify(execFile);
 
 const VALID_APPROVAL_POLICIES = new Set(["untrusted", "on-failure", "on-request", "never"]);
 const VALID_SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
@@ -93,632 +93,18 @@ function assertNoUnsafeOverrides(source, blockedKeys, endpointPath) {
   }
 }
 
-function isPathInside(parentPath, childPath) {
-  const relativePath = path.relative(parentPath, childPath);
-  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
-}
-
-function resolveWorkspacePath(requestedPath) {
-  const rawPath = String(requestedPath || "").trim();
-  if (!rawPath) {
-    throw new Error("path is required");
-  }
-
-  const candidatePath = path.resolve(WORKSPACE_ROOT_REALPATH, rawPath);
-  let resolvedPath;
-  try {
-    resolvedPath = fs.realpathSync.native(candidatePath);
-  } catch (err) {
-    if (err && err.code === "ENOENT") {
-      throw new Error(`path not found: ${rawPath}`);
-    }
-    throw err;
-  }
-
-  if (!isPathInside(WORKSPACE_ROOT_REALPATH, resolvedPath)) {
-    throw new Error(`path escapes workspace: ${rawPath}`);
-  }
-
-  return {
-    rawPath,
-    absolutePath: resolvedPath,
-    relativePath: path.relative(WORKSPACE_ROOT_REALPATH, resolvedPath).split(path.sep).join("/"),
-  };
-}
-
-function normalizeRepoRelativePath(requestedPath) {
-  const rawPath = String(requestedPath || "").trim();
-  if (!rawPath) {
-    throw new Error("path is required");
-  }
-
-  const candidatePath = path.resolve(WORKSPACE_ROOT_REALPATH, rawPath);
-  if (!isPathInside(WORKSPACE_ROOT_REALPATH, candidatePath)) {
-    throw new Error(`path escapes workspace: ${rawPath}`);
-  }
-
-  const relativePath = path.relative(WORKSPACE_ROOT_REALPATH, candidatePath).split(path.sep).join("/");
-  if (!relativePath || relativePath === ".") {
-    throw new Error("path must point to a file");
-  }
-
-  return {
-    rawPath,
-    absolutePath: candidatePath,
-    relativePath,
-  };
-}
-
-async function runGit(args) {
-  const { stdout } = await execFileAsync("git", ["-C", WORKSPACE_ROOT_REALPATH, ...args], {
-    encoding: "utf8",
-    maxBuffer: 8 * 1024 * 1024,
-  });
-  return stdout;
-}
-
-async function runGitBuffer(args) {
-  const { stdout } = await execFileAsync("git", ["-C", WORKSPACE_ROOT_REALPATH, ...args], {
-    encoding: "buffer",
-    maxBuffer: 8 * 1024 * 1024,
-  });
-  return stdout;
-}
-
-function isGitMissingObjectError(err) {
-  if (typeof err?.stderr !== "string") {
-    return false;
-  }
-  return (
-    err.stderr.includes("exists on disk, but not in") ||
-    err.stderr.includes("pathspec") ||
-    err.stderr.includes("Not a valid object name") ||
-    err.stderr.includes("invalid object name") ||
-    err.stderr.includes("does not exist in")
-  );
-}
-
-function parseGitStatusPorcelain(output) {
-  const statuses = new Map();
-  const records = output.split("\0");
-
-  for (let index = 0; index < records.length; index += 1) {
-    const record = records[index];
-    if (!record) {
-      continue;
-    }
-
-    const code = record.slice(0, 2);
-    const currentPath = record.slice(3);
-    if (!currentPath) {
-      continue;
-    }
-
-    if (code.includes("R") || code.includes("C")) {
-      index += 1;
-    }
-
-    statuses.set(currentPath, {
-      code,
-      indexStatus: code[0],
-      worktreeStatus: code[1],
-      isUntracked: code === "??",
-    });
-  }
-
-  return statuses;
-}
-
-function createDirectoryNode(name, nodePath) {
-  return {
-    type: "directory",
-    name,
-    path: nodePath,
-    children: [],
-  };
-}
-
-function createFileNode(name, nodePath, metadata) {
-  return {
-    type: "file",
-    name,
-    path: nodePath,
-    tracked: metadata.tracked,
-    gitStatus: metadata.gitStatus,
-    indexStatus: metadata.indexStatus,
-    worktreeStatus: metadata.worktreeStatus,
-  };
-}
-
-function sortTreeNodes(nodes) {
-  nodes.sort((left, right) => {
-    if (left.type !== right.type) {
-      return left.type === "directory" ? -1 : 1;
-    }
-    return left.name.localeCompare(right.name);
-  });
-
-  for (const node of nodes) {
-    if (node.type === "directory") {
-      sortTreeNodes(node.children);
-    }
-  }
-}
-
-function buildFileTree(fileEntries) {
-  const root = [];
-  const directories = new Map([["", { children: root }]]);
-
-  for (const entry of fileEntries) {
-    const parts = entry.path.split("/").filter(Boolean);
-    let parentPath = "";
-    let parentNode = directories.get(parentPath);
-
-    for (let index = 0; index < parts.length; index += 1) {
-      const name = parts[index];
-      const nodePath = parentPath ? `${parentPath}/${name}` : name;
-      const isLeaf = index === parts.length - 1;
-
-      if (isLeaf) {
-        parentNode.children.push(createFileNode(name, nodePath, entry));
-        continue;
-      }
-
-      let directoryNode = directories.get(nodePath);
-      if (!directoryNode) {
-        directoryNode = createDirectoryNode(name, nodePath);
-        directories.set(nodePath, directoryNode);
-        parentNode.children.push(directoryNode);
-      }
-
-      parentPath = nodePath;
-      parentNode = directoryNode;
-    }
-  }
-
-  sortTreeNodes(root);
-  return root;
-}
-
-function ensureTextFile(buffer, requestedPath) {
-  if (buffer.includes(0)) {
-    throw new Error(`binary files are not supported: ${requestedPath}`);
-  }
-}
-
-function toTextPayload(pathname, ref, exists, buffer) {
-  if (!exists) {
-    return {
-      path: pathname,
-      ref,
-      exists: false,
-      size: 0,
-      content: "",
-    };
-  }
-
-  if (buffer.length > MAX_FILE_BYTES) {
-    throw new Error(`file is too large: ${pathname}`);
-  }
-  ensureTextFile(buffer, pathname);
-
-  return {
-    path: pathname,
-    ref,
-    exists: true,
-    size: buffer.length,
-    content: buffer.toString("utf8"),
-  };
-}
-
-async function listWorkspaceFiles() {
-  const [trackedOutput, statusOutput] = await Promise.all([
-    runGit(["ls-files", "-z", "--cached"]),
-    runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
-  ]);
-
-  const statuses = parseGitStatusPorcelain(statusOutput);
-  const entries = new Map();
-
-  for (const trackedPath of trackedOutput.split("\0")) {
-    if (!trackedPath) {
-      continue;
-    }
-
-    entries.set(trackedPath, {
-      path: trackedPath,
-      tracked: true,
-      gitStatus: statuses.get(trackedPath)?.code || "  ",
-      indexStatus: statuses.get(trackedPath)?.indexStatus || " ",
-      worktreeStatus: statuses.get(trackedPath)?.worktreeStatus || " ",
-    });
-  }
-
-  for (const [filePath, status] of statuses.entries()) {
-    if (!status.isUntracked) {
-      continue;
-    }
-
-    entries.set(filePath, {
-      path: filePath,
-      tracked: false,
-      gitStatus: status.code,
-      indexStatus: status.indexStatus,
-      worktreeStatus: status.worktreeStatus,
-    });
-  }
-
-  const visibleEntries = [];
-  for (const entry of entries.values()) {
-    const absolutePath = path.resolve(WORKSPACE_ROOT_REALPATH, entry.path);
-    if (!fs.existsSync(absolutePath)) {
-      continue;
-    }
-
-    let stat;
-    try {
-      const resolvedPath = fs.realpathSync.native(absolutePath);
-      if (!isPathInside(WORKSPACE_ROOT_REALPATH, resolvedPath)) {
-        continue;
-      }
-      stat = fs.statSync(resolvedPath);
-    } catch {
-      continue;
-    }
-
-    if (!stat.isFile()) {
-      continue;
-    }
-
-    visibleEntries.push(entry);
-  }
-
-  visibleEntries.sort((left, right) => left.path.localeCompare(right.path));
-  return visibleEntries;
-}
-
-async function readWorkspaceFile(requestedPath) {
-  const resolved = resolveWorkspacePath(requestedPath);
-  const stat = await fs.promises.stat(resolved.absolutePath);
-
-  if (!stat.isFile()) {
-    throw new Error(`path is not a file: ${requestedPath}`);
-  }
-  if (stat.size > MAX_FILE_BYTES) {
-    throw new Error(`file is too large: ${requestedPath}`);
-  }
-
-  const buffer = await fs.promises.readFile(resolved.absolutePath);
-  ensureTextFile(buffer, requestedPath);
-
-  return {
-    path: resolved.relativePath,
-    size: buffer.length,
-    content: buffer.toString("utf8"),
-  };
-}
-
-async function gitObjectExists(ref, relativePath) {
-  try {
-    await runGit(["cat-file", "-e", `${ref}:${relativePath}`]);
-    return true;
-  } catch (err) {
-    if (typeof err?.code === "number" && isGitMissingObjectError(err)) {
-      return false;
-    }
-    throw err;
-  }
-}
-
-async function assertGitRefExists(ref) {
-  try {
-    await runGit(["rev-parse", "--verify", "--quiet", `${ref}^{object}`]);
-  } catch (err) {
-    if (typeof err?.code === "number") {
-      throw new Error(`invalid ref: ${ref}`);
-    }
-    throw err;
-  }
-}
-
-async function gitObjectType(ref, relativePath) {
-  const output = await runGit(["cat-file", "-t", `${ref}:${relativePath}`]);
-  return output.trim();
-}
-
-async function readGitFile(requestedPath, ref = "HEAD") {
-  const normalized = normalizeRepoRelativePath(requestedPath);
-  await assertGitRefExists(ref);
-  const exists = await gitObjectExists(ref, normalized.relativePath);
-  if (!exists) {
-    return toTextPayload(normalized.relativePath, ref, false, Buffer.alloc(0));
-  }
-
-  const objectType = await gitObjectType(ref, normalized.relativePath);
-  if (objectType !== "blob") {
-    throw new Error(`path is not a file: ${requestedPath}`);
-  }
-
-  const buffer = await runGitBuffer(["show", `${ref}:${normalized.relativePath}`]);
-  return toTextPayload(normalized.relativePath, ref, true, buffer);
-}
-
-async function readWorkspaceFileVersion(requestedPath) {
-  const normalized = normalizeRepoRelativePath(requestedPath);
-  if (!fs.existsSync(normalized.absolutePath)) {
-    return toTextPayload(normalized.relativePath, "WORKTREE", false, Buffer.alloc(0));
-  }
-
-  const entryStat = await fs.promises.lstat(normalized.absolutePath);
-  if (entryStat.isSymbolicLink()) {
-    const resolvedPath = fs.realpathSync.native(normalized.absolutePath);
-    if (!isPathInside(WORKSPACE_ROOT_REALPATH, resolvedPath)) {
-      throw new Error(`path escapes workspace: ${requestedPath}`);
-    }
-    const linkTarget = await fs.promises.readlink(normalized.absolutePath, "utf8");
-    return toTextPayload(normalized.relativePath, "WORKTREE", true, Buffer.from(linkTarget, "utf8"));
-  }
-
-  const resolved = resolveWorkspacePath(normalized.relativePath);
-  const stat = await fs.promises.stat(resolved.absolutePath);
-  if (!stat.isFile()) {
-    throw new Error(`path is not a file: ${requestedPath}`);
-  }
-
-  const buffer = await fs.promises.readFile(resolved.absolutePath);
-  return toTextPayload(normalized.relativePath, "WORKTREE", true, buffer);
-}
-
-async function readGitStatus(requestedPath) {
-  const normalized = normalizeRepoRelativePath(requestedPath);
-  const output = await runGit([
-    "status",
-    "--porcelain=v1",
-    "-z",
-    "--untracked-files=all",
-    "--",
-    normalized.relativePath,
-  ]);
-  const status = parseGitStatusPorcelain(output).get(normalized.relativePath);
-
-  return {
-    path: normalized.relativePath,
-    gitStatus: status?.code || "  ",
-    indexStatus: status?.indexStatus || " ",
-    worktreeStatus: status?.worktreeStatus || " ",
-  };
-}
-
-async function readGitDiff(requestedPath) {
-  const status = await readGitStatus(requestedPath);
-  const [left, right] = await Promise.all([
-    readGitFile(status.path, "HEAD"),
-    readWorkspaceFileVersion(status.path),
-  ]);
-
-  if (!left.exists && !right.exists) {
-    throw new Error(`path not found: ${status.path}`);
-  }
-
-  return {
-    path: status.path,
-    gitStatus: status.gitStatus,
-    indexStatus: status.indexStatus,
-    worktreeStatus: status.worktreeStatus,
-    left,
-    right,
-  };
-}
-
-function hashBuffer(buffer) {
-  return createHash("sha256").update(buffer).digest("hex");
-}
-
-function defaultGitStatus(status = {}) {
-  return {
-    gitStatus: status.gitStatus || status.code || "  ",
-    indexStatus: status.indexStatus || " ",
-    worktreeStatus: status.worktreeStatus || " ",
-  };
-}
-
-async function captureWorkspaceSnapshotEntry(relativePath, tracked, status) {
-  const absolutePath = path.resolve(WORKSPACE_ROOT_REALPATH, relativePath);
-  const statusFields = defaultGitStatus(status);
-
-  let entryStat = null;
-  try {
-    entryStat = await fs.promises.lstat(absolutePath);
-  } catch (err) {
-    if (err && err.code !== "ENOENT") {
-      throw err;
-    }
-  }
-
-  if (!entryStat) {
-    return {
-      path: relativePath,
-      tracked,
-      exists: false,
-      kind: "missing",
-      digest: null,
-      ...statusFields,
-    };
-  }
-
-  if (entryStat.isSymbolicLink()) {
-    const resolvedPath = fs.realpathSync.native(absolutePath);
-    if (!isPathInside(WORKSPACE_ROOT_REALPATH, resolvedPath)) {
-      throw new Error(`path escapes workspace: ${relativePath}`);
-    }
-    const linkTarget = await fs.promises.readlink(absolutePath, "utf8");
-    return {
-      path: relativePath,
-      tracked,
-      exists: true,
-      kind: "symlink",
-      digest: hashBuffer(Buffer.from(linkTarget, "utf8")),
-      ...statusFields,
-    };
-  }
-
-  const resolvedPath = fs.realpathSync.native(absolutePath);
-  if (!isPathInside(WORKSPACE_ROOT_REALPATH, resolvedPath)) {
-    throw new Error(`path escapes workspace: ${relativePath}`);
-  }
-
-  const resolvedStat = await fs.promises.stat(resolvedPath);
-  if (resolvedStat.isFile()) {
-    const buffer = await fs.promises.readFile(resolvedPath);
-    return {
-      path: relativePath,
-      tracked,
-      exists: true,
-      kind: "file",
-      digest: hashBuffer(buffer),
-      ...statusFields,
-    };
-  }
-
-  return {
-    path: relativePath,
-    tracked,
-    exists: true,
-    kind: "other",
-    digest: hashBuffer(Buffer.from(`${entryStat.mode}:${resolvedStat.size}`)),
-    ...statusFields,
-  };
-}
-
-async function captureWorkspaceSnapshot() {
-  const [trackedOutput, statusOutput] = await Promise.all([
-    runGit(["ls-files", "-z", "--cached"]),
-    runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
-  ]);
-
-  const statuses = parseGitStatusPorcelain(statusOutput);
-  const trackedPaths = new Set(trackedOutput.split("\0").filter(Boolean));
-  const snapshotPaths = new Set([...trackedPaths, ...statuses.keys()]);
-  const sortedPaths = Array.from(snapshotPaths).sort((left, right) => left.localeCompare(right));
-
-  const entries = await Promise.all(
-    sortedPaths.map((relativePath) => captureWorkspaceSnapshotEntry(
-      relativePath,
-      trackedPaths.has(relativePath),
-      statuses.get(relativePath),
-    )),
-  );
-
-  return new Map(entries.map((entry) => [entry.path, entry]));
-}
-
-function virtualSnapshotEntry(pathname) {
-  return {
-    path: pathname,
-    tracked: false,
-    exists: false,
-    kind: "missing",
-    digest: null,
-    gitStatus: "  ",
-    indexStatus: " ",
-    worktreeStatus: " ",
-  };
-}
-
-function snapshotEntriesEqual(left, right) {
-  return (
-    left.tracked === right.tracked &&
-    left.exists === right.exists &&
-    left.kind === right.kind &&
-    left.digest === right.digest &&
-    left.gitStatus === right.gitStatus &&
-    left.indexStatus === right.indexStatus &&
-    left.worktreeStatus === right.worktreeStatus
-  );
-}
-
-function serializeSnapshotEntry(entry) {
-  return {
-    exists: entry.exists,
-    kind: entry.kind,
-    tracked: entry.tracked,
-    gitStatus: entry.gitStatus,
-    indexStatus: entry.indexStatus,
-    worktreeStatus: entry.worktreeStatus,
-  };
-}
-
-function determineTurnFileChangeType(beforeEntry, afterEntry) {
-  if (!beforeEntry.exists && afterEntry.exists) {
-    return "created";
-  }
-  if (beforeEntry.exists && !afterEntry.exists) {
-    return "deleted";
-  }
-  return "updated";
-}
-
-function diffWorkspaceSnapshots(beforeSnapshot, afterSnapshot) {
-  const changedFiles = [];
-  const paths = new Set([...beforeSnapshot.keys(), ...afterSnapshot.keys()]);
-
-  for (const pathname of Array.from(paths).sort((left, right) => left.localeCompare(right))) {
-    const beforeEntry = beforeSnapshot.get(pathname) || virtualSnapshotEntry(pathname);
-    const afterEntry = afterSnapshot.get(pathname) || virtualSnapshotEntry(pathname);
-
-    if (snapshotEntriesEqual(beforeEntry, afterEntry)) {
-      continue;
-    }
-
-    changedFiles.push({
-      path: pathname,
-      changeType: determineTurnFileChangeType(beforeEntry, afterEntry),
-      before: serializeSnapshotEntry(beforeEntry),
-      after: serializeSnapshotEntry(afterEntry),
-    });
-  }
-
-  return changedFiles;
-}
-
-function rememberCompletedTurnChanges(session, turnChanges) {
-  session.completedTurnChanges.set(turnChanges.turnId, turnChanges);
-  while (session.completedTurnChanges.size > 20) {
-    const oldestTurnId = session.completedTurnChanges.keys().next().value;
-    session.completedTurnChanges.delete(oldestTurnId);
-  }
-}
-
-async function finalizeTurnChanges(session, params) {
-  const turnId = String(params?.turn?.id || "").trim();
-  if (!turnId) {
-    return;
-  }
-
-  const activeTurn = session.activeTurnSnapshots.get(turnId);
-  if (!activeTurn) {
-    return;
-  }
-
-  try {
-    const completedSnapshot = await captureWorkspaceSnapshot();
-    const turnChanges = {
-      turnId,
-      threadId: String(params?.threadId || activeTurn.threadId || session.threadId || "").trim() || null,
-      startedAt: activeTurn.startedAt,
-      completedAt: nowMs(),
-      changedFiles: diffWorkspaceSnapshots(activeTurn.snapshot, completedSnapshot),
-    };
-    session.activeTurnSnapshots.delete(turnId);
-    rememberCompletedTurnChanges(session, turnChanges);
-  } catch (err) {
-    session.activeTurnSnapshots.delete(turnId);
-    emitSessionEvent(session, "turn/changes_error", {
-      turnId,
-      error: normalizeError(err),
-    });
-  }
-}
+const workspaceService = createWorkspaceService({
+  maxFileBytes: MAX_FILE_BYTES,
+  workspaceRootRealPath: WORKSPACE_ROOT_REALPATH,
+});
+
+const {
+  captureWorkspaceSnapshot,
+  listWorkspaceCatalog,
+  readGitDiff,
+  readGitFile,
+  readWorkspaceFile,
+} = workspaceService;
 
 const sessionStore = createSessionStore({
   randomUUID,
@@ -733,6 +119,19 @@ const {
   shutdownSession,
   touchSession,
 } = sessionStore;
+
+const turnChangeService = createTurnChangeService({
+  captureWorkspaceSnapshot,
+  emitSessionEvent,
+  normalizeError,
+  nowMs,
+});
+
+const {
+  finalizeTurnChanges,
+  getCompletedTurnChanges,
+  rememberActiveTurnSnapshot,
+} = turnChangeService;
 
 const {
   resolveApproval,
@@ -890,7 +289,7 @@ async function handleTurnStartRoute(req, res, body, pathname) {
   const result = await rpcRequest(session, "turn/start", params);
   const turnId = String(result?.turn?.id || "").trim();
   if (turnId) {
-    session.activeTurnSnapshots.set(turnId, {
+    rememberActiveTurnSnapshot(session, {
       turnId,
       threadId: String(params.threadId || session.threadId || "").trim() || null,
       startedAt: turnStartedAt,
@@ -1134,7 +533,7 @@ async function handleTurnChangesRoute(req, res, searchParams) {
     throw new Error("turnId is required");
   }
 
-  const turnChanges = session.completedTurnChanges.get(turnId);
+  const turnChanges = getCompletedTurnChanges(session, turnId);
   if (!turnChanges) {
     throw new Error(`turn changes not found: ${turnId}`);
   }
@@ -1146,12 +545,12 @@ async function handleTurnChangesRoute(req, res, searchParams) {
 }
 
 async function handleFsTreeRoute(req, res) {
-  const entries = await listWorkspaceFiles();
+  const { entries, tree } = await listWorkspaceCatalog();
   sendJson(res, 200, {
     ok: true,
     rootPath: ".",
     entries,
-    tree: buildFileTree(entries),
+    tree,
   });
 }
 

--- a/tasks/archived/2026-03-07-issue-32-workspace-services/design.md
+++ b/tasks/archived/2026-03-07-issue-32-workspace-services/design.md
@@ -1,0 +1,30 @@
+# Issue 32 Design
+
+## Goal
+Move workspace, Git, and turn-snapshot behavior into explicit backend services so `webui-server.js` keeps HTTP concerns while behavior-heavy logic lives in focused modules.
+
+## Proposed Structure
+- `codexbox/server/workspace-service.js`
+  - workspace path normalization
+  - Git porcelain parsing
+  - workspace tree listing
+  - workspace file reads
+  - Git show/diff reads
+- `codexbox/server/turn-changes.js`
+  - workspace snapshot capture
+  - snapshot diffing
+  - completed turn change retention/finalization
+- `codexbox/webui-server.js`
+  - instantiate services with repository-local configuration
+  - keep route serialization and session orchestration only
+
+## Boundary Notes
+- The workspace service should return data structures that route handlers serialize without changing the API contract.
+- The turn change service should depend on a snapshot capture function and injected session-event hooks so it does not own session lifecycle concerns.
+
+## Risks
+- Path normalization or Git error handling drift if helper extraction changes exception messages.
+- Turn snapshot extraction can regress dirty/untracked/deleted baseline behavior if the diff logic is altered during the move.
+
+## Validation Focus
+- Existing backend tests already cover fs/file/git/turn-changes behavior; they should remain the primary regression net.

--- a/tasks/archived/2026-03-07-issue-32-workspace-services/plan.md
+++ b/tasks/archived/2026-03-07-issue-32-workspace-services/plan.md
@@ -1,0 +1,21 @@
+# Issue 32 Plan
+
+## TDD
+- TDD: no
+- Rationale: this task is a structural extraction with an already comprehensive backend regression suite around the affected routes.
+
+## Steps
+- [x] Extract workspace and Git helpers into a dedicated backend service module.
+- [x] Extract turn snapshot/change derivation into a dedicated backend service module.
+- [x] Rewire `webui-server.js` to use the services without changing route contracts.
+- [x] Run backend and combined validation.
+- [ ] Create PR, merge, close the issue, and archive task artifacts.
+
+## Validation Notes
+- Primary: `node --test codexbox/webui-server.test.js`
+- Secondary: `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`
+- Result: both commands passed on 2026-03-07 after extracting workspace-service and turn-changes modules.
+
+## Merge and Issue Closeout Method
+- Merge path: PR to `main`.
+- Issue closeout: include `Closes #32` in the PR description.

--- a/tasks/archived/2026-03-07-issue-32-workspace-services/requirements.md
+++ b/tasks/archived/2026-03-07-issue-32-workspace-services/requirements.md
@@ -1,0 +1,26 @@
+# Issue 32 Requirements
+
+## Scope Assessment
+- Change size: medium.
+- Reasoning: the refactor spans backend filesystem/Git helpers, turn-snapshot derivation, and route wiring while preserving shipped API behavior.
+
+## In Scope
+- Extract workspace file tree/file readers and Git-backed readers from `codexbox/webui-server.js` into dedicated backend services.
+- Extract turn snapshot capture/diff/finalization logic into a dedicated backend service.
+- Preserve the current `/api/fs/*`, `/api/git/*`, and `/api/turn/changes` contracts.
+- Keep backend and combined validation green.
+
+## Out of Scope
+- Route table or session runtime refactors already handled elsewhere.
+- Frontend changes for turn-local changes.
+- API response shape changes.
+
+## Acceptance Criteria
+- Workspace/Git read logic is no longer embedded in the top-level server file.
+- Turn snapshot/change derivation is isolated behind an internal service boundary.
+- Route handlers remain behaviorally compatible.
+- Validation covers the extracted services through the shipped API surface.
+
+## Validation Targets
+- `node --test codexbox/webui-server.test.js`
+- `node --test codexbox/webui-server.test.js codexbox/public/app.test.js`


### PR DESCRIPTION
## Summary
- extract workspace and Git readers into a dedicated backend service module
- extract turn snapshot/change derivation into a dedicated backend service module
- keep the existing fs/git/turn-changes API contracts intact while reducing top-level server responsibilities

## Testing
- node --test codexbox/webui-server.test.js
- node --test codexbox/webui-server.test.js codexbox/public/app.test.js

Closes #32