### PR TITLE
fix: serve split frontend assets

### DIFF
--- a/codexbox/webui-server.js
+++ b/codexbox/webui-server.js
@@ -202,6 +202,46 @@ function serveStaticFile(res, filePath, contentType) {
   });
 }
 
+function staticContentTypeFor(filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".html") {
+    return "text/html; charset=utf-8";
+  }
+  if (extension === ".js") {
+    return "text/javascript; charset=utf-8";
+  }
+  if (extension === ".css") {
+    return "text/css; charset=utf-8";
+  }
+  return null;
+}
+
+function servePublicAsset(res, requestPath) {
+  const relativePath = String(requestPath || "").replace(/^\/static\//, "");
+  if (!relativePath) {
+    sendText(res, 404, "Not found");
+    return;
+  }
+
+  const assetPath = path.resolve(STATIC_DIR, relativePath);
+  const relativeAssetPath = path.relative(STATIC_DIR, assetPath);
+  if (
+    relativeAssetPath.startsWith("..") ||
+    path.isAbsolute(relativeAssetPath)
+  ) {
+    sendText(res, 404, "Not found");
+    return;
+  }
+
+  const contentType = staticContentTypeFor(assetPath);
+  if (!contentType) {
+    sendText(res, 404, "Not found");
+    return;
+  }
+
+  serveStaticFile(res, assetPath, contentType);
+}
+
 async function handleSessionStartRoute(req, res) {
   const session = makeSession();
   try {
@@ -633,17 +673,12 @@ const server = http.createServer(async (req, res) => {
 
   try {
     if (method === "GET" && pathname === "/") {
-      serveStaticFile(res, path.join(STATIC_DIR, "index.html"), "text/html; charset=utf-8");
+      servePublicAsset(res, "/static/index.html");
       return;
     }
 
-    if (method === "GET" && pathname === "/static/app.js") {
-      serveStaticFile(res, path.join(STATIC_DIR, "app.js"), "text/javascript; charset=utf-8");
-      return;
-    }
-
-    if (method === "GET" && pathname === "/static/styles.css") {
-      serveStaticFile(res, path.join(STATIC_DIR, "styles.css"), "text/css; charset=utf-8");
+    if (method === "GET" && pathname.startsWith("/static/")) {
+      servePublicAsset(res, pathname);
       return;
     }
 

--- a/codexbox/webui-server.test.js
+++ b/codexbox/webui-server.test.js
@@ -39,6 +39,23 @@ test("GET /api/fs/tree returns tracked files", async (t) => {
   assert.ok(body.entries.some((entry) => entry.path === "README.md"));
 });
 
+test("GET /static serves split frontend assets", async (t) => {
+  const { port } = await startServer(t);
+
+  const indexResponse = await fetch(`http://127.0.0.1:${port}/`);
+  assert.equal(indexResponse.status, 200);
+  const indexHtml = await indexResponse.text();
+  assert.match(indexHtml, /\/static\/app-transport\.js/);
+  assert.match(indexHtml, /\/static\/app-session\.js/);
+  assert.match(indexHtml, /\/static\/app-render\.js/);
+
+  const scriptResponse = await fetch(`http://127.0.0.1:${port}/static/app-transport.js`);
+  assert.equal(scriptResponse.status, 200);
+  assert.match(scriptResponse.headers.get("content-type") || "", /text\/javascript/);
+  const scriptBody = await scriptResponse.text();
+  assert.match(scriptBody, /createApiClient/);
+});
+
 test("GET /api/fs/file returns text content for a workspace file", async (t) => {
   const { port } = await startServer(t);
   const response = await fetch(


### PR DESCRIPTION
## Summary
- generalize static asset serving for files under `codexbox/public`
- serve the newly split frontend scripts so browser startup no longer stalls at Booting session
- add regression coverage for the split frontend assets

## Testing
- node --test codexbox/webui-server.test.js
- node --test codexbox/webui-server.test.js codexbox/public/app.test.js