### PR TITLE
feat(frontend): add shared webui type contracts

### DIFF
--- a/codexbox/frontend/src/App.tsx
+++ b/codexbox/frontend/src/App.tsx
@@ -1,4 +1,6 @@
-const migrationSteps = [
+import type { BridgeIssueStep } from './types';
+
+const migrationSteps: BridgeIssueStep[] = [
   { issue: '#43', title: 'Define typed frontend contracts and shared state models' },
   { issue: '#44', title: 'Port current WebUI shell and layout to Preact components' },
   { issue: '#45', title: 'Port interactive session, approval, and file-inspection flows' },

--- a/codexbox/frontend/src/types/contracts.ts
+++ b/codexbox/frontend/src/types/contracts.ts
@@ -1,0 +1,230 @@
+export type ApprovalDecision = 'allow' | 'deny' | 'cancel';
+export type PaneId = 'chat' | 'files' | 'diff';
+
+export interface ApiErrorResponse {
+  ok: false;
+  error: string;
+}
+
+export interface ApiOkResponse {
+  ok: true;
+}
+
+export interface ApiEnvelope<T> {
+  ok: true;
+  result: T;
+}
+
+export interface SessionStartResponse extends ApiOkResponse {
+  sessionId: string;
+  initResult?: unknown;
+  idleTimeoutMs: number;
+  approvalTimeoutMs: number;
+  userInputTimeoutMs: number;
+}
+
+export interface SessionReconnectResponse extends ApiOkResponse {
+  sessionId: string;
+  threadId: string | null;
+  pendingApprovals: ApprovalRequest[];
+  pendingUserInputs: UserInputRequest[];
+}
+
+export interface ThreadSummary {
+  id?: string;
+}
+
+export interface ThreadStartResult {
+  thread?: ThreadSummary;
+}
+
+export interface ThreadStartResponse extends ApiEnvelope<ThreadStartResult> {}
+
+export interface ThreadReadResponse extends ApiEnvelope<{
+  thread?: ThreadRecord | null;
+}> {}
+
+export interface TurnStartResponse extends ApiOkResponse {}
+
+export interface QuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface UserInputQuestion {
+  id?: string;
+  header?: string;
+  question?: string;
+  options?: QuestionOption[];
+}
+
+export interface ApprovalRequest {
+  requestId: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface UserInputRequest {
+  requestId: string;
+  method: string;
+  params?: {
+    questions?: UserInputQuestion[];
+  };
+}
+
+export interface SessionSnapshotPayload {
+  threadId?: string | null;
+  pendingApprovals?: ApprovalRequest[];
+  pendingUserInputs?: UserInputRequest[];
+}
+
+export interface SessionSnapshotResponse extends ApiOkResponse, SessionSnapshotPayload {}
+
+export interface WorkspaceEntry {
+  type: 'file' | 'directory';
+  name: string;
+  path: string;
+  tracked?: boolean;
+  gitStatus?: string;
+  indexStatus?: string;
+  worktreeStatus?: string;
+  children?: WorkspaceEntry[];
+}
+
+export interface WorkspaceTreeResponse extends ApiOkResponse {
+  tree: WorkspaceEntry[];
+}
+
+export interface WorkspaceFile {
+  path: string;
+  content: string;
+  size: number;
+}
+
+export interface WorkspaceFileResponse extends ApiOkResponse {
+  file: WorkspaceFile;
+}
+
+export interface GitDiffSide {
+  exists: boolean;
+  ref: string;
+  content: string;
+}
+
+export interface GitDiffRecord {
+  path: string;
+  gitStatus: string;
+  left: GitDiffSide;
+  right: GitDiffSide;
+}
+
+export interface GitDiffResponse extends ApiOkResponse {
+  diff: GitDiffRecord;
+}
+
+export interface TextContentPart {
+  type: 'text';
+  text: string;
+}
+
+export interface UserMessageItem {
+  id?: string;
+  type: 'userMessage';
+  content?: TextContentPart[];
+}
+
+export interface AgentMessageItem {
+  id?: string;
+  type: 'agentMessage';
+  text?: string;
+}
+
+export interface UnknownThreadItem {
+  id?: string;
+  type: string;
+  [key: string]: unknown;
+}
+
+export type ThreadItem = UserMessageItem | AgentMessageItem | UnknownThreadItem;
+
+export interface ThreadTurn {
+  id?: string;
+  items?: ThreadItem[];
+}
+
+export interface ThreadRecord {
+  id?: string;
+  turns?: ThreadTurn[];
+}
+
+export interface ThreadStartedNotification {
+  method: 'thread/started';
+  params?: {
+    thread?: {
+      id?: string;
+    };
+  };
+}
+
+export interface AgentMessageStartedNotification {
+  method: 'item/started';
+  params?: {
+    item?: {
+      id?: string;
+      type?: string;
+    };
+  };
+}
+
+export interface AgentMessageCompletedNotification {
+  method: 'item/completed';
+  params?: {
+    item?: {
+      id?: string;
+      type?: string;
+      text?: string;
+    };
+  };
+}
+
+export interface TurnCompletedNotification {
+  method: 'turn/completed';
+  params?: Record<string, never>;
+}
+
+export interface UnknownRpcNotification {
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export type RpcNotification =
+  | ThreadStartedNotification
+  | AgentMessageStartedNotification
+  | AgentMessageCompletedNotification
+  | TurnCompletedNotification
+  | UnknownRpcNotification;
+
+export interface RpcNotificationEvent {
+  message: RpcNotification | null;
+}
+
+export interface ChatDeltaPayload {
+  itemId?: string;
+  delta?: string;
+}
+
+export interface ChatDeltaEvent {
+  params?: ChatDeltaPayload;
+}
+
+export interface ApprovalEvent {
+  approval?: ApprovalRequest;
+}
+
+export interface UserInputEvent {
+  request?: UserInputRequest;
+}
+
+export interface SessionClosedEvent {
+  reason?: string;
+}

--- a/codexbox/frontend/src/types/index.ts
+++ b/codexbox/frontend/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './contracts';
+export * from './state';

--- a/codexbox/frontend/src/types/state.ts
+++ b/codexbox/frontend/src/types/state.ts
@@ -1,0 +1,55 @@
+import type {
+  ApprovalRequest,
+  GitDiffRecord,
+  PaneId,
+  UserInputRequest,
+  WorkspaceEntry,
+  WorkspaceFile,
+} from './contracts';
+
+export type MessageRole = 'user' | 'assistant' | 'system';
+
+export interface TranscriptMessage {
+  id?: string;
+  role: MessageRole;
+  text: string;
+}
+
+export type PendingRequestMap<T> = Map<string, T>;
+
+export interface SessionRuntimeState {
+  sessionId: string | null;
+  threadId: string | null;
+  sending: boolean;
+  activePane: PaneId;
+  statusText: string;
+}
+
+export interface WorkspaceInspectorState {
+  tree: WorkspaceEntry[];
+  selectedPath: string | null;
+  selectedEntry: WorkspaceEntry | null;
+  selectedFile: WorkspaceFile | null;
+  selectedDiff: GitDiffRecord | null;
+  filePreviewError: string;
+  diffError: string;
+  loadingWorkspaceTree: boolean;
+  loadingSelection: boolean;
+}
+
+export interface PendingInteractionState {
+  approvals: PendingRequestMap<ApprovalRequest>;
+  userInputs: PendingRequestMap<UserInputRequest>;
+}
+
+export interface AppState {
+  session: SessionRuntimeState;
+  transcript: TranscriptMessage[];
+  pending: PendingInteractionState;
+  workspace: WorkspaceInspectorState;
+}
+
+export interface BridgeIssueStep {
+  issue: string;
+  title: string;
+}

--- a/tasks/archived/2026-03-07-issue-43-frontend-types/design.md
+++ b/tasks/archived/2026-03-07-issue-43-frontend-types/design.md
@@ -1,0 +1,28 @@
+# Issue #43 Design
+
+## Overview
+Add a typed frontend contract layer under `codexbox/frontend/src/types/`. Split it into `contracts.ts` for backend-facing payloads and `state.ts` for frontend state models. Export reusable aliases for later components and controller code.
+
+## Module Design
+- `types/contracts.ts`
+  - API response and payload types for session, thread, workspace, Git diff, approvals, user input, and health endpoints.
+  - SSE event payload types for the events consumed by the frontend.
+  - Notification item shapes needed for transcript rebuild and live updates.
+- `types/state.ts`
+  - Typed session, transcript, workspace, inspector, and pending-action state.
+  - UI-facing message and pane identifiers.
+- `types/index.ts`
+  - Barrel export for later imports.
+
+## Modeling Choices
+- Model only the fields currently consumed by the frontend, not the full backend surface.
+- Keep unions shallow and practical so later code can narrow them with ordinary property checks.
+- Use frontend-oriented aliases such as `TranscriptMessage` and `WorkspaceSelectionState` to avoid leaking raw backend payload shapes everywhere.
+
+## Validation
+- Compile with `npm run check`.
+- Ensure `npm run build` still works with the new type modules present.
+
+## Risks
+- The backend contracts are still unvalidated at runtime; this issue improves compile-time clarity only.
+- If later issues need more payload fields, they must extend the shared contract files instead of creating local ad hoc interfaces.

--- a/tasks/archived/2026-03-07-issue-43-frontend-types/plan.md
+++ b/tasks/archived/2026-03-07-issue-43-frontend-types/plan.md
@@ -1,0 +1,19 @@
+# Issue #43 Plan
+
+## Review Status
+- Requirements review: pass
+- Design review: pass
+
+## TDD Decision
+- TDD: no
+- Rationale: this issue is primarily type-structure work. Validation is by strict compilation and build success rather than behavior-first tests.
+
+## Steps
+1. Add shared contract types for the frontend-consumed API responses and SSE payloads.
+   - Validation: `npm run check`.
+2. Add shared state types for session, transcript, approvals, user input, workspace tree, and file inspection.
+   - Validation: `npm run check`.
+3. Add a barrel export and integrate the types into the current Preact source where practical.
+   - Validation: `npm run check` and `npm run build`.
+4. Self-review against the issue acceptance criteria, archive task artifacts, and close out through PR/merge.
+   - Validation: PR includes `Closes #43`.

--- a/tasks/archived/2026-03-07-issue-43-frontend-types/requirements.md
+++ b/tasks/archived/2026-03-07-issue-43-frontend-types/requirements.md
@@ -1,0 +1,38 @@
+# Issue #43 Requirements
+
+## Goal
+Define reusable TypeScript contracts for frontend-consumed API responses, SSE payloads, and shared UI state so later Preact component work does not re-derive ad hoc object shapes.
+
+## Scope
+- Add TypeScript types for the frontend-consumed HTTP API responses.
+- Add TypeScript types for the session SSE event payloads used by the frontend.
+- Add shared state types for session, transcript, approvals, user input, workspace tree, file preview, and diff preview.
+- Organize the types for reuse by later issues.
+
+## Out of Scope
+- Backend API shape changes.
+- Full Preact component migration.
+- Server-side schema validation.
+
+## Consumers and Workflows
+- Session start and reconnect.
+- Thread transcript resync.
+- Turn send and live transcript updates.
+- Approval and user input flows.
+- Workspace tree, file preview, and diff preview.
+
+## Constraints and Assumptions
+- Existing backend contracts remain the source behavior; this issue only types the frontend side.
+- Types should be broad enough to cover current payloads but narrow enough to prevent new ad hoc shapes.
+- The new types must work with strict TypeScript compilation.
+
+## Acceptance Criteria
+- API response shapes currently consumed by the frontend are represented by explicit TypeScript types.
+- SSE events currently consumed by the frontend are represented by explicit TypeScript types.
+- Shared app state has reusable TypeScript types instead of being re-inferred inside components.
+- The type modules are organized so later UI work can import them directly.
+
+## Edge Cases and Error Handling
+- Optional fields that are truly absent in current payloads must stay optional instead of being treated as always present.
+- Union-like notification and event payloads should model the fields actually relied on by the frontend.
+- State types should allow empty or unloaded states without using `any`.


### PR DESCRIPTION
## Summary
- add reusable TypeScript contracts for the frontend-consumed HTTP and SSE payloads
- add shared state types for session, transcript, pending interactions, and workspace inspection
- archive the issue-local task artifacts for #43

## Validation
- npm run check
- npm run build

Closes #43