### PR TITLE
docs: align skill workflow ownership and worktree flow

### DIFF
--- a/.agents/skills/codex-webui-execution-orchestrator/SKILL.md
+++ b/.agents/skills/codex-webui-execution-orchestrator/SKILL.md
@@ -108,9 +108,9 @@ If tracking drift exists, prioritize drift correction before new execution. Exam
 If no drift blocks progress, route to one of these skills:
 
 - `codex-webui-work-packages` when local task package state must be created, resumed, reconciled, or archived
-- `codex-webui-work-packages` when the active worktree must be created, corrected, or documented
+- `codex-webui-work-packages` when the active worktree must be created, corrected, or documented, or when package-linked Issue `Execution` metadata must move with the package lifecycle
 - `codex-webui-sprint-cycle` when one bounded sprint slice is ready to execute for the chosen Issue
-- `codex-webui-github-projects` when Project or Issue tracking state, PR merge, parent-checkout sync, or worktree cleanup must be corrected
+- `codex-webui-github-projects` when Project state, broader Issue tracking state, PR merge, parent-checkout sync, worktree cleanup, or final completion tracking must be corrected
 
 Do not recommend multiple competing handoffs in the same result.
 

--- a/.agents/skills/codex-webui-github-projects/SKILL.md
+++ b/.agents/skills/codex-webui-github-projects/SKILL.md
@@ -9,13 +9,14 @@ description: Manage GitHub Projects for this `codex-webui` repository using the 
 
 Use GitHub Projects as the execution layer for this repository, not as the source of truth. Keep maintained requirements, specifications, and roadmap decisions in `docs/`; keep active work packages in `tasks/`; keep evidence in `artifacts/`.
 
-This skill owns GitHub-side execution tracking. If the user needs to create, update, or archive a local task package under `tasks/`, use `codex-webui-work-packages` for that part and keep this skill focused on Issues, Project items, fields, and workflow state.
+This skill owns GitHub-side execution tracking. If the user needs to create, update, or archive a local task package under `tasks/`, use `codex-webui-work-packages` for that part and keep this skill focused on Issues, Project items, fields, PR merge/completion flow, and workflow state that is not part of in-flight package maintenance.
 
 ## Build Context
 
 Read these files before changing the Project shape or roadmap items:
 
 - `README.md`
+- `AGENTS.md`
 - `docs/README.md`
 - `tasks/README.md`
 - `docs/codex_webui_mvp_roadmap_v0_1.md`
@@ -134,13 +135,14 @@ When an Issue also uses a local task package:
 
 1. Read `tasks/README.md` and check the linked package state.
 2. Check the Issue `Execution` section for the active branch, active worktree, and active PR when they exist.
-3. Keep only a short `Execution` section and branch/worktree/PR/package links in the Issue.
+3. When this skill updates the Issue `Execution` section during merge/completion transitions, keep it short and limited to branch/worktree/PR/package links.
 4. Let `codex-webui-work-packages` handle package creation, README updates, and archive moves.
-5. For normal branch/PR work, own PR `squash merge`, parent-checkout `main` sync, worktree cleanup, and final completion tracking.
-6. Before closing an Issue or setting Project `Status` to `Done`, verify the work is reachable on `main`: merged PR to `main` for the default workflow, or pushed commits on `origin/main` for an approved direct-to-`main` exception.
-7. If the PR remains open, the branch is not yet on `main`, the active worktree still exists, or the local repo state is dirty, keep the Issue and Project in execution rather than `Done`.
-8. If the current slice is merged and cleaned up but the Issue still has remaining work, clear the active branch, active worktree, and active PR from the Issue `Execution` section and return the Project item to `Todo` until the next slice starts.
-9. Only when the full Issue scope is complete should this skill close the Issue and set Project `Status` to `Done`.
+5. Let `codex-webui-work-packages` own package creation, archive moves, and package-linked `Execution` updates while the slice is in flight.
+6. For normal branch/PR work, own PR `squash merge`, parent-checkout `main` sync, worktree cleanup, and final completion tracking.
+7. Before closing an Issue or setting Project `Status` to `Done`, verify the work is reachable on `main`: merged PR to `main` for the default workflow, or pushed commits on `origin/main` for an approved direct-to-`main` exception.
+8. If the PR remains open, the branch is not yet on `main`, the active worktree still exists, or the local repo state is dirty, keep the Issue and Project in execution rather than `Done`.
+9. If the current slice is merged and cleaned up but the Issue still has remaining work, clear the active branch, active worktree, and active PR from the Issue `Execution` section and return the Project item to `Todo` until the next slice starts.
+10. Only when the full Issue scope is complete should this skill close the Issue and set Project `Status` to `Done`.
 
 Typical parent-checkout commands for the default branch/PR completion flow are:
 
@@ -158,6 +160,7 @@ git status --short --branch
 - Do not silently replace field semantics in an existing Project.
 - Do not duplicate detailed acceptance criteria from `docs/` into many issue bodies unless the user asks for that granularity.
 - Do not move completed evidence into `tasks/`; keep `tasks/` for active work only.
+- Do not take over active package-lifecycle maintenance that belongs to `codex-webui-work-packages`; use this skill for Project state, broader Issue tracking, merge/completion flow, and post-merge cleanup.
 - Do not mark an Issue or Project item as complete while a PR remains open, the execution branch is not yet on `main`, the active worktree still exists, an approved direct-to-`main` exception is unpushed, or the local repo state is dirty.
 - Do not delete old Projects, issues, or items without an explicit user instruction.
 

--- a/.agents/skills/codex-webui-work-intake/SKILL.md
+++ b/.agents/skills/codex-webui-work-intake/SKILL.md
@@ -127,8 +127,8 @@ If execution-tracking evidence is incomplete, state that in `Tracking alignment`
 
 This skill does not edit the tracking layers itself.
 
-- Use `codex-webui-github-projects` when Project fields, items, or Issue execution state should be created or updated
-- Use `codex-webui-work-packages` when a local task package should be created, updated, reconciled, or archived
+- Use `codex-webui-github-projects` when Project fields/items, broader Issue tracking state, PR merge, or final completion tracking should be created or updated
+- Use `codex-webui-work-packages` when a local task package should be created, updated, reconciled, or archived, or when package-linked Issue `Execution` state should move with that package
 - Use `codex-webui-sprint-cycle` only after the next execution slice has been chosen
 
 ## Guardrails

--- a/.agents/skills/codex-webui-work-packages/SKILL.md
+++ b/.agents/skills/codex-webui-work-packages/SKILL.md
@@ -16,7 +16,7 @@ Treat responsibilities as follows:
 - `tasks/` holds the active local work package for an Issue that is currently being executed
 - `artifacts/` holds evidence such as logs, outputs, and judgment notes
 
-This skill owns the local `tasks/` workflow. If the user also needs GitHub Issue or Project edits, use `codex-webui-github-projects` for that part.
+This skill owns the local `tasks/` workflow and the package-lifecycle updates to the linked Issue `Execution` section. Use `codex-webui-github-projects` for Project fields, broader Issue tracking changes, PR merge/completion work, and final execution-state cleanup after the work reaches `main`.
 
 When `codex-webui-execution-orchestrator` selects task-package creation, resumption, reconciliation, or archive work as the next step, this skill is the required path for that package-state change.
 
@@ -25,6 +25,7 @@ When `codex-webui-execution-orchestrator` selects task-package creation, resumpt
 Read these files before changing work packages:
 
 - `README.md`
+- `AGENTS.md`
 - `docs/README.md`
 - `tasks/README.md`
 - `docs/codex_webui_mvp_roadmap_v0_1.md` when roadmap alignment matters
@@ -38,6 +39,7 @@ If the work package is tied to a specific area, read the nearest relevant `READM
 - A single Issue may have multiple archived task packages over time, but never more than one active package at once
 - Default repo-tracked change flow is a short-lived branch and PR; direct commits to `main` are exceptions only and should happen only for urgent fixes or explicit user direction
 - For normal branch/PR work, prepare and use a dedicated git worktree under `.worktrees/<branch>` and keep the parent checkout as the control checkout
+- For normal branch/PR work, create or edit repo-tracked task-package files only from the active worktree after it exists; do not start package edits from the parent checkout
 - Approved direct-to-`main` exceptions may use the parent checkout and must record `Active worktree: .`
 - Prefer one primary Issue per task package
 - Link the task package and the Issue to each other
@@ -75,7 +77,7 @@ Use the template in `assets/task-package-template.md` unless the user has alread
 
 ## Issue Coordination
 
-When the user wants local and GitHub state kept aligned, maintain this minimum Issue execution shape:
+When the user wants local and GitHub state kept aligned, this skill maintains the package-lifecycle portion of the linked Issue `Execution` section with this minimum shape:
 
 - An `Execution` section
 - An `Active branch` entry
@@ -87,7 +89,7 @@ When the user wants local and GitHub state kept aligned, maintain this minimum I
 
 Use the template in `assets/issue-execution-template.md` when adding or normalizing the Issue section.
 
-If the user asks you to edit GitHub Issues or Project fields, hand off that part to `codex-webui-github-projects`.
+If the user asks you to edit Project fields, close or retitle Issues, or change Issue content beyond concise package-linked `Execution` updates, hand off that part to `codex-webui-github-projects`.
 
 ## Standard Workflow
 
@@ -96,11 +98,11 @@ If the user asks you to edit GitHub Issues or Project fields, hand off that part
 1. Confirm the primary Issue and the source-of-truth docs
 2. Sync the parent checkout to the current `main` before creating a new worktree
 3. Check whether the Issue already has an active package
-4. If not, create `tasks/issue-<number>-<work_id>/README.md`
-5. For normal branch/PR work, create branch `issue-<number>-<work_id>` and worktree `.worktrees/issue-<number>-<work_id>` from the parent checkout
+4. For normal branch/PR work, create branch `issue-<number>-<work_id>` and worktree `.worktrees/issue-<number>-<work_id>` from the parent checkout
+5. After the active worktree exists, switch execution into that worktree and create or update `tasks/issue-<number>-<work_id>/README.md` there
 6. Only when the user explicitly approved a direct-to-`main` exception, use the parent checkout instead and record `Active worktree: .`
 7. Fill the README with the required sections and links
-8. Add or update the Issue `Execution` section with the active branch, active worktree, active PR if one exists, and active package link
+8. Add or update the linked Issue `Execution` section with the active branch, active worktree, active PR if one exists, and active package link so the Issue reflects the current package lifecycle state
 9. If requested, use `codex-webui-github-projects` to set Project `Status` to `In Progress`
 
 Typical parent-checkout commands for the default branch/PR flow are:
@@ -110,11 +112,13 @@ git fetch origin
 git worktree add -b issue-<number>-<work_id> .worktrees/issue-<number>-<work_id> origin/main
 ```
 
+After the worktree is created, create or edit the task-package files from that worktree, not from the parent checkout.
+
 ### Update an active package
 
 1. Refresh the README sections that changed
 2. Keep `Source docs`, `Exit criteria`, and `Artifacts / evidence` current
-3. Keep the linked Issue `Execution` section current for branch, worktree, PR, and package links
+3. Keep the linked Issue `Execution` section current for package-lifecycle branch, worktree, PR, and package links
 4. Update the linked Issue only with concise execution status, not detailed task notes
 
 ### Finish an execution slice
@@ -124,7 +128,7 @@ git worktree add -b issue-<number>-<work_id> .worktrees/issue-<number>-<work_id>
 3. Move the package to `tasks/archive/issue-<number>-<work_id>/` once the slice is locally complete
 4. Replace the Issue's active-package link with an archived-package link and keep the active branch, active worktree, and active PR visible until the work reaches `main`
 5. If more work remains on the Issue, leave it open and keep Project `Status` in execution until the current slice reaches `main`
-6. Hand off PR squash merge, parent-checkout `main` sync, worktree cleanup, and final completion tracking to `codex-webui-github-projects`
+6. Hand off PR squash merge, parent-checkout `main` sync, worktree cleanup, Project-field updates, and final completion tracking to `codex-webui-github-projects`
 7. If the PR is still open, the branch is not yet on `main`, an approved direct-to-`main` exception is not yet pushed, or the required worktree cleanup is not yet complete, stop after the archive/update steps and keep GitHub tracking active
 8. Do not close the Issue or set Project `Status` to `Done` from this skill; final completion belongs to `codex-webui-github-projects`
 


### PR DESCRIPTION
## Summary
- fix the work-packages startup flow so repo-tracked task-package files are only created or edited after the active worktree exists
- clarify that work-packages owns package-lifecycle Issue Execution updates while github-projects owns broader GitHub tracking and post-merge cleanup
- align execution-orchestrator and work-intake handoff guidance with the updated ownership boundary

## Validation
- git diff --check
- targeted skill-doc consistency review against AGENTS.md and tasks/README.md