### PR TITLE
docs: tighten skill workflow inputs and resume flow

### DIFF
--- a/.agents/skills/codex-webui-sprint-cycle/SKILL.md
+++ b/.agents/skills/codex-webui-sprint-cycle/SKILL.md
@@ -22,6 +22,10 @@ Read these files before running the workflow:
 
 - `README.md`
 - `AGENTS.md`
+- `docs/README.md` when source-of-truth docs define the sprint slice
+- `tasks/README.md` when the sprint is tied to a tracked Issue or active task package
+
+Before planning or implementation for a tracked Issue, read the active task package `README.md` and the source-of-truth docs it links so planner, worker, and evaluator use the same package scope and exit criteria.
 
 If the sprint touches a documented area such as `docs/`, `tasks/`, or `artifacts/`, read the nearest relevant `README.md` in that area before implementation.
 
@@ -41,7 +45,7 @@ Do not use this skill when:
 
 ## Workflow
 
-1. Spawn `planner` first and explicitly tell it that it is read-only, must not edit files, and must not run mutating commands; ask it to return a plan only with the planner sections, not an implementation summary, patch description, or completion report.
+1. Read the active task package and linked source-of-truth docs when the sprint is tied to a tracked Issue, then spawn `planner` and explicitly tell it that it is read-only, must not edit files, and must not run mutating commands; ask it to return a plan only with the planner sections, not an implementation summary, patch description, or completion report.
 2. Review the planner output locally. If the sprint slice is still too large or unclear, or if the result is implementation-shaped instead of plan-only, ask `planner` to tighten it before implementation starts.
 3. If `planner` violates the read-only instruction and mutates files anyway, do not ask it to continue editing. Treat the resulting worktree state as the effective `worker` output for this sprint and pass that implementation candidate to `evaluator`.
 4. Otherwise, spawn `worker` to execute only that sprint slice in the active worktree for normal branch/PR work, or in the parent checkout only for an approved direct-to-`main` exception.

--- a/.agents/skills/codex-webui-work-packages/SKILL.md
+++ b/.agents/skills/codex-webui-work-packages/SKILL.md
@@ -135,8 +135,11 @@ After the worktree is created, create or edit the task-package files from that w
 ### Resume work on an existing Issue
 
 1. Leave old archived packages in place
-2. Create a new active package with a new `<work_id>`
-3. Update the Issue `Execution` section so only the new package is marked active
+2. Choose a new `<work_id>` for the new execution slice; do not reactivate an archived package directory
+3. For normal branch/PR work, sync the parent checkout to the current `main` and create a new branch `issue-<number>-<work_id>` with worktree `.worktrees/issue-<number>-<work_id>`
+4. Only when the user explicitly approved a direct-to-`main` exception, use the parent checkout instead and record `Active worktree: .`
+5. Create a new active package with the new `<work_id>` in the active worktree for the new slice
+6. Update the Issue `Execution` section so only the new package is marked active and its branch/worktree entries match the new slice
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- require sprint-cycle to read active task-package and linked source docs for tracked issues
- clarify resumed work-package slices must create a new branch/worktree for the new work_id

## Validation
- git diff --check