### PR TITLE
feat(runtime): finish phase 3c messaging flow

### DIFF
--- a/apps/codex-runtime/src/db/database.ts
+++ b/apps/codex-runtime/src/db/database.ts
@@ -39,9 +39,27 @@ CREATE TABLE IF NOT EXISTS sessions (
   last_message_at TEXT,
   active_approval_id TEXT,
   current_turn_id TEXT,
+  pending_assistant_message_id TEXT,
   app_session_overlay_state TEXT NOT NULL,
   FOREIGN KEY (workspace_id) REFERENCES workspaces (workspace_id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS messages (
+  message_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  source_item_type TEXT NOT NULL,
+  client_message_id TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions (session_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS messages_session_id_message_id_idx
+ON messages (session_id, message_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS messages_session_id_client_message_id_idx
+ON messages (session_id, client_message_id);
 `;
 
 export function openRuntimeDatabase(databasePath: string) {

--- a/apps/codex-runtime/src/db/schema.ts
+++ b/apps/codex-runtime/src/db/schema.ts
@@ -44,6 +44,7 @@ export const sessions = sqliteTable(
     lastMessageAt: text("last_message_at"),
     activeApprovalId: text("active_approval_id"),
     currentTurnId: text("current_turn_id"),
+    pendingAssistantMessageId: text("pending_assistant_message_id"),
     appSessionOverlayState: text("app_session_overlay_state").notNull(),
   },
   (table) => ({
@@ -51,5 +52,31 @@ export const sessions = sqliteTable(
   }),
 );
 
+export const messages = sqliteTable(
+  "messages",
+  {
+    messageId: text("message_id").primaryKey(),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.sessionId, { onDelete: "cascade" }),
+    role: text("role").notNull(),
+    content: text("content").notNull(),
+    createdAt: text("created_at").notNull(),
+    sourceItemType: text("source_item_type").notNull(),
+    clientMessageId: text("client_message_id"),
+  },
+  (table) => ({
+    sessionCreatedAtIndex: uniqueIndex("messages_session_id_message_id_idx").on(
+      table.sessionId,
+      table.messageId,
+    ),
+    sessionClientMessageIndex: uniqueIndex("messages_session_id_client_message_id_idx").on(
+      table.sessionId,
+      table.clientMessageId,
+    ),
+  }),
+);
+
 export type WorkspaceRow = typeof workspaces.$inferSelect;
 export type SessionRow = typeof sessions.$inferSelect;
+export type MessageRow = typeof messages.$inferSelect;

--- a/apps/codex-runtime/src/domain/sessions/message-input.ts
+++ b/apps/codex-runtime/src/domain/sessions/message-input.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const acceptMessageSchema = z.object({
+  client_message_id: z.string().trim().min(1, "client message id is required"),
+  content: z.string().trim().min(1, "message content must be a non-empty string"),
+});
+
+const assistantEventSchema = z.discriminatedUnion("event_type", [
+  z.object({
+    event_type: z.literal("message.assistant.delta"),
+    turn_id: z.string().trim().min(1, "turn id is required"),
+    delta: z.string().trim().min(1, "assistant delta must be a non-empty string"),
+  }),
+  z.object({
+    event_type: z.literal("message.assistant.completed"),
+    turn_id: z.string().trim().min(1, "turn id is required"),
+    content: z.string().trim().min(1, "assistant content must be a non-empty string"),
+  }),
+]);
+
+export function parseAcceptMessageInput(input: unknown) {
+  return acceptMessageSchema.parse(input);
+}
+
+export function parseAssistantEventInput(input: unknown) {
+  return assistantEventSchema.parse(input);
+}

--- a/apps/codex-runtime/src/domain/sessions/native-session-gateway.ts
+++ b/apps/codex-runtime/src/domain/sessions/native-session-gateway.ts
@@ -6,8 +6,16 @@ export interface CreateNativeSessionInput {
   title: string;
 }
 
+export interface SendNativeSessionMessageInput {
+  sessionId: string;
+  content: string;
+}
+
 export interface NativeSessionGateway {
   createSession(input: CreateNativeSessionInput): Promise<{ sessionId: string }>;
+  sendUserMessage(input: SendNativeSessionMessageInput): Promise<{
+    turnId: string;
+  }>;
   interruptSessionTurn(input: { sessionId: string; turnId: string }): Promise<void>;
 }
 
@@ -15,6 +23,12 @@ export class SyntheticNativeSessionGateway implements NativeSessionGateway {
   async createSession(_input: CreateNativeSessionInput) {
     return {
       sessionId: `thread_${crypto.randomUUID().replaceAll("-", "")}`,
+    };
+  }
+
+  async sendUserMessage(input: SendNativeSessionMessageInput) {
+    return {
+      turnId: `turn_${crypto.randomUUID().replaceAll("-", "")}`,
     };
   }
 

--- a/apps/codex-runtime/src/domain/sessions/session-service.ts
+++ b/apps/codex-runtime/src/domain/sessions/session-service.ts
@@ -1,8 +1,10 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import crypto from "node:crypto";
+
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 
 import { RuntimeError } from "../../errors.js";
 import type { RuntimeDatabase } from "../../db/database.js";
-import { sessions, workspaces } from "../../db/schema.js";
+import { messages, sessions, workspaces } from "../../db/schema.js";
 import { WorkspaceRegistry } from "../workspaces/workspace-registry.js";
 import { WorkspaceFilesystem } from "../workspaces/workspace-filesystem.js";
 import {
@@ -11,6 +13,9 @@ import {
 } from "./native-session-gateway.js";
 import type {
   AppSessionOverlayState,
+  MessageProjection,
+  MessageRole,
+  MessageSourceItemType,
   SessionStatus,
   SessionStopResult,
   SessionSummary,
@@ -38,6 +43,31 @@ function mapSessionSummary(record: typeof sessions.$inferSelect): SessionSummary
     current_turn_id: record.currentTurnId,
     app_session_overlay_state: record.appSessionOverlayState as AppSessionOverlayState,
   };
+}
+
+function generateMessageId(role: MessageRole) {
+  const prefix = role === "user" ? "msg_user" : "msg_assistant";
+  return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+function mapMessageProjection(record: typeof messages.$inferSelect): MessageProjection {
+  return {
+    message_id: record.messageId,
+    session_id: record.sessionId,
+    role: record.role as MessageRole,
+    content: record.content,
+    created_at: record.createdAt,
+    source_item_type: record.sourceItemType as MessageSourceItemType,
+  };
+}
+
+function firstRequiredRow<T>(rows: T[], notFound: () => never) {
+  const row = firstRow(rows);
+  if (!row) {
+    notFound();
+  }
+
+  return row;
 }
 
 export class SessionService {
@@ -251,5 +281,305 @@ export class SessionService {
       .all();
 
     return new Map(rows.map((row) => [row.sessionId, mapSessionSummary(row)]));
+  }
+
+  async listMessages(
+    sessionId: string,
+    options: {
+      limit?: number;
+      sort?: "created_at" | "-created_at";
+    } = {},
+  ) {
+    await this.getSession(sessionId);
+
+    const limit = Math.max(1, Math.min(options.limit ?? 100, 100));
+    const sort = options.sort ?? "created_at";
+    const orderBy =
+      sort === "-created_at"
+        ? [desc(messages.createdAt), desc(messages.messageId)]
+        : [asc(messages.createdAt), asc(messages.messageId)];
+
+    const rows = this.database.db
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, sessionId))
+      .orderBy(...orderBy)
+      .limit(limit)
+      .all();
+
+    return {
+      items: rows.map(mapMessageProjection),
+      next_cursor: null,
+      has_more: false,
+    };
+  }
+
+  async acceptMessage(
+    sessionId: string,
+    input: {
+      client_message_id: string;
+      content: string;
+    },
+  ) {
+    const existing = firstRow(
+      this.database.db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.sessionId, sessionId),
+            eq(messages.clientMessageId, input.client_message_id),
+          ),
+        )
+        .limit(1)
+        .all(),
+    );
+
+    if (existing) {
+      if (existing.content !== input.content) {
+        throw new RuntimeError(
+          409,
+          "message_idempotency_conflict",
+          "client message id conflicts with a different message payload",
+          {
+            session_id: sessionId,
+            client_message_id: input.client_message_id,
+          },
+        );
+      }
+
+      return mapMessageProjection(existing);
+    }
+
+    const session = await this.getSession(sessionId);
+
+    if (session.status !== "waiting_input") {
+      throw new RuntimeError(
+        409,
+        "session_invalid_state",
+        "session is not ready to accept messages",
+        {
+          session_id: sessionId,
+          current_status: session.status,
+        },
+      );
+    }
+
+    const workspace = await this.workspaceRegistry.getWorkspace(session.workspace_id);
+    if (
+      workspace.active_session_id !== null &&
+      workspace.active_session_id !== session.session_id
+    ) {
+      throw new RuntimeError(
+        409,
+        "session_conflict_active_exists",
+        "another active session already exists in this workspace",
+        {
+          workspace_id: session.workspace_id,
+          active_session_id: workspace.active_session_id,
+        },
+      );
+    }
+
+    const nativeTurn = await this.nativeSessionGateway.sendUserMessage({
+      sessionId,
+      content: input.content,
+    });
+    const userMessageId = generateMessageId("user");
+    const userCreatedAt = toIsoString(this.now());
+
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .insert(messages)
+        .values({
+          messageId: userMessageId,
+          sessionId,
+          role: "user",
+          content: input.content,
+          createdAt: userCreatedAt,
+          sourceItemType: "user_message",
+          clientMessageId: input.client_message_id,
+        })
+        .run();
+
+      this.database.db
+        .update(sessions)
+        .set({
+          status: "running",
+          updatedAt: userCreatedAt,
+          lastMessageAt: userCreatedAt,
+          currentTurnId: nativeTurn.turnId,
+          pendingAssistantMessageId: null,
+          appSessionOverlayState: "open",
+        })
+        .where(eq(sessions.sessionId, sessionId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          activeSessionId: sessionId,
+          updatedAt: userCreatedAt,
+        })
+        .where(eq(workspaces.workspaceId, session.workspace_id))
+        .run();
+    })();
+
+    return {
+      message_id: userMessageId,
+      session_id: sessionId,
+      role: "user",
+      content: input.content,
+      created_at: userCreatedAt,
+      source_item_type: "user_message",
+    } satisfies MessageProjection;
+  }
+
+  async ingestAssistantDelta(
+    sessionId: string,
+    input: {
+      turn_id: string;
+      delta: string;
+    },
+  ) {
+    const session = firstRequiredRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, sessionId))
+        .limit(1)
+        .all(),
+      () => {
+        throw new RuntimeError(404, "session_not_found", "session was not found", {
+          session_id: sessionId,
+        });
+      },
+    );
+
+    if (session.status !== "running" || session.currentTurnId !== input.turn_id) {
+      throw new RuntimeError(
+        409,
+        "session_invalid_state",
+        "session is not ready to ingest assistant events",
+        {
+          session_id: sessionId,
+          current_status: session.status,
+          current_turn_id: session.currentTurnId,
+          requested_turn_id: input.turn_id,
+        },
+      );
+    }
+
+    const assistantMessageId =
+      session.pendingAssistantMessageId ?? generateMessageId("assistant");
+    const updatedAt = toIsoString(this.now());
+
+    this.database.db
+      .update(sessions)
+      .set({
+        updatedAt,
+        pendingAssistantMessageId: assistantMessageId,
+      })
+      .where(eq(sessions.sessionId, sessionId))
+      .run();
+
+    return {
+      message_id: assistantMessageId,
+      session_id: sessionId,
+      event_type: "message.assistant.delta" as const,
+      turn_id: input.turn_id,
+      delta: input.delta,
+    };
+  }
+
+  async applyAssistantMessageCompletion(
+    sessionId: string,
+    input: {
+      turn_id: string;
+      content: string;
+    },
+  ) {
+    const session = firstRequiredRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, sessionId))
+        .limit(1)
+        .all(),
+      () => {
+        throw new RuntimeError(404, "session_not_found", "session was not found", {
+          session_id: sessionId,
+        });
+      },
+    );
+
+    if (session.status !== "running" || session.currentTurnId !== input.turn_id) {
+      throw new RuntimeError(
+        409,
+        "session_invalid_state",
+        "session is not ready to ingest assistant events",
+        {
+          session_id: sessionId,
+          current_status: session.status,
+          current_turn_id: session.currentTurnId,
+          requested_turn_id: input.turn_id,
+        },
+      );
+    }
+
+    const assistantMessageId =
+      session.pendingAssistantMessageId ?? generateMessageId("assistant");
+    const assistantCreatedAt = toIsoString(this.now());
+
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .insert(messages)
+        .values({
+          messageId: assistantMessageId,
+          sessionId,
+          role: "assistant",
+          content: input.content,
+          createdAt: assistantCreatedAt,
+          sourceItemType: "agent_message",
+          clientMessageId: null,
+        })
+        .run();
+
+      this.database.db
+        .update(sessions)
+        .set({
+          status: "waiting_input",
+          updatedAt: assistantCreatedAt,
+          lastMessageAt: assistantCreatedAt,
+          currentTurnId: null,
+          pendingAssistantMessageId: null,
+          appSessionOverlayState: "open",
+        })
+        .where(eq(sessions.sessionId, sessionId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          activeSessionId: null,
+          updatedAt: assistantCreatedAt,
+        })
+        .where(
+          and(
+            eq(workspaces.workspaceId, session.workspaceId),
+            eq(workspaces.activeSessionId, sessionId),
+          ),
+        )
+        .run();
+    })();
+
+    return {
+      message_id: assistantMessageId,
+      session_id: sessionId,
+      role: "assistant",
+      content: input.content,
+      created_at: assistantCreatedAt,
+      source_item_type: "agent_message",
+    } satisfies MessageProjection;
   }
 }

--- a/apps/codex-runtime/src/domain/sessions/types.ts
+++ b/apps/codex-runtime/src/domain/sessions/types.ts
@@ -27,3 +27,16 @@ export interface SessionStopResult {
   session: SessionSummary;
   canceled_approval: null;
 }
+
+export type MessageRole = "user" | "assistant";
+
+export type MessageSourceItemType = "user_message" | "agent_message";
+
+export interface MessageProjection {
+  message_id: string;
+  session_id: string;
+  role: MessageRole;
+  content: string;
+  created_at: string;
+  source_item_type: MessageSourceItemType;
+}

--- a/apps/codex-runtime/src/routes/sessions.ts
+++ b/apps/codex-runtime/src/routes/sessions.ts
@@ -2,6 +2,10 @@ import type { FastifyInstance } from "fastify";
 import { ZodError } from "zod";
 
 import { RuntimeError } from "../errors.js";
+import {
+  parseAcceptMessageInput,
+  parseAssistantEventInput,
+} from "../domain/sessions/message-input.js";
 import { parseCreateSessionInput } from "../domain/sessions/session-title.js";
 import { SessionService } from "../domain/sessions/session-service.js";
 
@@ -51,9 +55,82 @@ export async function registerSessionRoutes(
     return sessionService.getSession(params.sessionId);
   });
 
+  app.get("/api/v1/sessions/:sessionId/messages", async (request) => {
+    const params = request.params as { sessionId: string };
+    const query = request.query as {
+      limit?: number | string;
+      sort?: "created_at" | "-created_at";
+    };
+    const limit =
+      typeof query.limit === "string"
+        ? Number.parseInt(query.limit, 10)
+        : query.limit;
+
+    return sessionService.listMessages(params.sessionId, {
+      limit: Number.isFinite(limit) ? limit : undefined,
+      sort: query.sort,
+    });
+  });
+
   app.post("/api/v1/sessions/:sessionId/start", async (request) => {
     const params = request.params as { sessionId: string };
     return sessionService.startSession(params.sessionId);
+  });
+
+  app.post("/api/v1/sessions/:sessionId/messages", async (request, reply) => {
+    const params = request.params as { sessionId: string };
+    let payload;
+
+    try {
+      payload = parseAcceptMessageInput(request.body);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw new RuntimeError(
+          422,
+          "message_content_invalid",
+          "message request is invalid",
+          {
+            issues: error.issues,
+          },
+        );
+      }
+
+      throw error;
+    }
+
+    const message = await sessionService.acceptMessage(params.sessionId, payload);
+    reply.code(202);
+    return message;
+  });
+
+  app.post("/api/v1/sessions/:sessionId/assistant-events", async (request, reply) => {
+    const params = request.params as { sessionId: string };
+    let payload;
+
+    try {
+      payload = parseAssistantEventInput(request.body);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw new RuntimeError(
+          422,
+          "message_content_invalid",
+          "assistant event request is invalid",
+          {
+            issues: error.issues,
+          },
+        );
+      }
+
+      throw error;
+    }
+
+    const result =
+      payload.event_type === "message.assistant.delta"
+        ? await sessionService.ingestAssistantDelta(params.sessionId, payload)
+        : await sessionService.applyAssistantMessageCompletion(params.sessionId, payload);
+
+    reply.code(202);
+    return result;
   });
 
   app.post("/api/v1/sessions/:sessionId/stop", async (request) => {

--- a/apps/codex-runtime/tests/session-routes.test.ts
+++ b/apps/codex-runtime/tests/session-routes.test.ts
@@ -1,10 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { buildApp } from "../src/app.js";
 import type { NativeSessionGateway } from "../src/domain/sessions/native-session-gateway.js";
+import { sessions, workspaces } from "../src/db/schema.js";
 import { createTempDatabase, createTempWorkspaceRoot } from "./helpers.js";
 
 const cleanupPaths: string[] = [];
@@ -12,7 +14,9 @@ const cleanupPaths: string[] = [];
 class StubNativeSessionGateway implements NativeSessionGateway {
   constructor(
     private readonly sessionIds: string[],
+    private readonly turnIds: string[] = [],
     readonly interrupts: Array<{ sessionId: string; turnId: string }> = [],
+    readonly sentMessages: Array<{ sessionId: string; content: string }> = [],
   ) {}
 
   async createSession() {
@@ -24,9 +28,64 @@ class StubNativeSessionGateway implements NativeSessionGateway {
     return { sessionId };
   }
 
+  async sendUserMessage(input: { sessionId: string; content: string }) {
+    this.sentMessages.push(input);
+
+    return {
+      turnId:
+        this.turnIds.shift() ?? `turn_${this.sentMessages.length.toString().padStart(3, "0")}`,
+    };
+  }
+
   async interruptSessionTurn(input: { sessionId: string; turnId: string }) {
     this.interrupts.push(input);
   }
+}
+
+function seedWaitingInputSession(
+  database: Awaited<ReturnType<typeof createTempDatabase>>,
+  options: {
+    workspaceId?: string;
+    sessionId?: string;
+    title?: string;
+    activeSessionId?: string | null;
+  } = {},
+) {
+  const workspaceId = options.workspaceId ?? "ws_alpha";
+  const sessionId = options.sessionId ?? "thread_001";
+  const now = "2026-04-04T12:00:00.000Z";
+
+  database.db
+    .insert(workspaces)
+    .values({
+      workspaceId,
+      workspaceName: "alpha",
+      directoryName: "alpha",
+      createdAt: now,
+      updatedAt: now,
+      activeSessionId: options.activeSessionId ?? sessionId,
+      pendingApprovalCount: 0,
+    })
+    .run();
+
+  database.db
+    .insert(sessions)
+    .values({
+      sessionId,
+      workspaceId,
+      title: options.title ?? "Fix build error",
+      status: "waiting_input",
+      createdAt: now,
+      updatedAt: now,
+      startedAt: now,
+      lastMessageAt: null,
+      activeApprovalId: null,
+      currentTurnId: null,
+      appSessionOverlayState: "open",
+    })
+    .run();
+
+  return { workspaceId, sessionId };
 }
 
 afterEach(async () => {
@@ -334,6 +393,545 @@ describe("session routes", () => {
           status: "created",
         },
       },
+    });
+
+    await app.close();
+  });
+
+  it("accepts a message, keeps the session running, and lists projected user history", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    const sendResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    expect(sendResponse.statusCode).toBe(202);
+    expect(sendResponse.json()).toEqual({
+      message_id: expect.stringMatching(/^msg_user_/),
+      session_id: sessionId,
+      role: "user",
+      content: "Please explain the diff.",
+      created_at: expect.any(String),
+      source_item_type: "user_message",
+    });
+    expect(nativeSessionGateway.sentMessages).toEqual([
+      {
+        sessionId,
+        content: "Please explain the diff.",
+      },
+    ]);
+
+    const sessionResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}`,
+    });
+
+    expect(sessionResponse.statusCode).toBe(200);
+    expect(sessionResponse.json()).toMatchObject({
+      session_id: sessionId,
+      status: "running",
+      current_turn_id: "turn_001",
+      last_message_at: expect.any(String),
+    });
+
+    const workspaceResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha",
+    });
+
+    expect(workspaceResponse.statusCode).toBe(200);
+    expect(workspaceResponse.json()).toMatchObject({
+      active_session_id: sessionId,
+      active_session_summary: {
+        session_id: sessionId,
+        status: "running",
+      },
+    });
+
+    const listResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.json()).toEqual({
+      items: [
+        {
+          message_id: expect.stringMatching(/^msg_user_/),
+          session_id: sessionId,
+          role: "user",
+          content: "Please explain the diff.",
+          created_at: expect.any(String),
+          source_item_type: "user_message",
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+
+    await app.close();
+  });
+
+  it("ingests assistant delta and completed events with a stable assistant message id", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    const sendResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const deltaResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/assistant-events`,
+      payload: {
+        event_type: "message.assistant.delta",
+        turn_id: "turn_001",
+        delta: "I checked the diff",
+      },
+    });
+
+    expect(deltaResponse.statusCode).toBe(202);
+    expect(deltaResponse.json()).toEqual({
+      message_id: expect.stringMatching(/^msg_assistant_/),
+      session_id: sessionId,
+      event_type: "message.assistant.delta",
+      turn_id: "turn_001",
+      delta: "I checked the diff",
+    });
+
+    const assistantMessageResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/assistant-events`,
+      payload: {
+        event_type: "message.assistant.completed",
+        turn_id: "turn_001",
+        content: "I checked the diff and summarized the changes.",
+      },
+    });
+
+    const assistantMessage = assistantMessageResponse.json();
+
+    expect(assistantMessageResponse.statusCode).toBe(202);
+    expect(assistantMessage).toEqual({
+      message_id: deltaResponse.json().message_id,
+      session_id: sessionId,
+      role: "assistant",
+      content: "I checked the diff and summarized the changes.",
+      created_at: expect.any(String),
+      source_item_type: "agent_message",
+    });
+
+    const sessionResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}`,
+    });
+
+    expect(sessionResponse.statusCode).toBe(200);
+    expect(sessionResponse.json()).toMatchObject({
+      session_id: sessionId,
+      status: "waiting_input",
+      current_turn_id: null,
+      last_message_at: assistantMessage.created_at,
+    });
+
+    const workspaceResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha",
+    });
+
+    expect(workspaceResponse.statusCode).toBe(200);
+    expect(workspaceResponse.json()).toMatchObject({
+      active_session_id: null,
+      active_session_summary: null,
+    });
+
+    const listResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+    });
+
+    const expectedItems = [sendResponse.json(), assistantMessage].sort((left, right) => {
+      if (left.created_at === right.created_at) {
+        return left.message_id.localeCompare(right.message_id);
+      }
+
+      return left.created_at.localeCompare(right.created_at);
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.json()).toEqual({
+      items: expectedItems,
+      next_cursor: null,
+      has_more: false,
+    });
+
+    await app.close();
+  });
+
+  it("rejects assistant events when the session is not running", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway: new StubNativeSessionGateway([]),
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/assistant-events`,
+      payload: {
+        event_type: "message.assistant.delta",
+        turn_id: "turn_001",
+        delta: "I checked the diff",
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: "session_invalid_state",
+        message: "session is not ready to ingest assistant events",
+        details: {
+          session_id: sessionId,
+          current_status: "waiting_input",
+          current_turn_id: null,
+          requested_turn_id: "turn_001",
+        },
+      },
+    });
+
+    await app.close();
+  });
+
+  it("rejects assistant events when the incoming turn does not match the active turn", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway: new StubNativeSessionGateway([], ["turn_001"]),
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/assistant-events`,
+      payload: {
+        event_type: "message.assistant.completed",
+        turn_id: "turn_999",
+        content: "I checked the diff and summarized the changes.",
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: "session_invalid_state",
+        message: "session is not ready to ingest assistant events",
+        details: {
+          session_id: sessionId,
+          current_status: "running",
+          current_turn_id: "turn_001",
+          requested_turn_id: "turn_999",
+        },
+      },
+    });
+
+    await app.close();
+  });
+
+  it("returns the existing projected user message for idempotent retries", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    const firstResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+    const retryResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    expect(firstResponse.statusCode).toBe(202);
+    expect(retryResponse.statusCode).toBe(202);
+    expect(retryResponse.json()).toEqual(firstResponse.json());
+    expect(nativeSessionGateway.sentMessages).toHaveLength(1);
+
+    const listResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+    });
+
+    expect(listResponse.json().items).toHaveLength(1);
+
+    await app.close();
+  });
+
+  it("rejects conflicting retries that reuse a client message id with different content", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const conflictResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please summarize the diff.",
+      },
+    });
+
+    expect(conflictResponse.statusCode).toBe(409);
+    expect(conflictResponse.json()).toEqual({
+      error: {
+        code: "message_idempotency_conflict",
+        message: "client message id conflicts with a different message payload",
+        details: {
+          session_id: sessionId,
+          client_message_id: "msgclient_001",
+        },
+      },
+    });
+
+    await app.close();
+  });
+
+  it("lists projected messages with stable created_at sorting and limit handling", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway: new StubNativeSessionGateway([]),
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database, {
+      activeSessionId: null,
+    });
+
+    database.db.insert(sessions).values({
+      sessionId: "thread_002",
+      workspaceId: "ws_alpha",
+      title: "Background session",
+      status: "created",
+      createdAt: "2026-04-04T12:05:00.000Z",
+      updatedAt: "2026-04-04T12:05:00.000Z",
+      startedAt: null,
+      lastMessageAt: null,
+      activeApprovalId: null,
+      currentTurnId: null,
+      appSessionOverlayState: "open",
+    }).run();
+
+    database.sqlite
+      .prepare(
+        `
+          INSERT INTO messages (
+            message_id,
+            session_id,
+            role,
+            content,
+            created_at,
+            source_item_type,
+            client_message_id
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .run("msg_user_001", sessionId, "user", "first", "2026-04-04T12:00:01.000Z", "user_message", "msgclient_001");
+    database.sqlite
+      .prepare(
+        `
+          INSERT INTO messages (
+            message_id,
+            session_id,
+            role,
+            content,
+            created_at,
+            source_item_type,
+            client_message_id
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .run("msg_assistant_001", sessionId, "assistant", "second", "2026-04-04T12:00:02.000Z", "agent_message", null);
+    database.sqlite
+      .prepare(
+        `
+          INSERT INTO messages (
+            message_id,
+            session_id,
+            role,
+            content,
+            created_at,
+            source_item_type,
+            client_message_id
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .run("msg_user_002", sessionId, "user", "third", "2026-04-04T12:00:03.000Z", "user_message", "msgclient_002");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}/messages?sort=-created_at&limit=2`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      items: [
+        {
+          message_id: "msg_user_002",
+          session_id: sessionId,
+          role: "user",
+          content: "third",
+          created_at: "2026-04-04T12:00:03.000Z",
+          source_item_type: "user_message",
+        },
+        {
+          message_id: "msg_assistant_001",
+          session_id: sessionId,
+          role: "assistant",
+          content: "second",
+          created_at: "2026-04-04T12:00:02.000Z",
+          source_item_type: "agent_message",
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
     });
 
     await app.close();

--- a/tasks/archive/issue-66-phase-3c-messaging/README.md
+++ b/tasks/archive/issue-66-phase-3c-messaging/README.md
@@ -1,0 +1,53 @@
+# Issue 66 Phase 3C Messaging
+
+## Purpose
+
+- Execute the Phase 3C runtime slice for message send flow, idempotency, and message projection under Issue #66.
+
+## Primary issue
+
+- Issue: `#66 https://github.com/tsukushibito/codex-webui/issues/66`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_internal_api_v0_8.md`
+- `docs/specs/codex_webui_common_spec_v0_8.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Add the runtime contract needed to accept a user message while a session is `waiting_input`.
+- Add app-owned user message projection and the asynchronous turn-start state transition needed before downstream assistant event ingestion.
+- Add idempotency handling keyed by `client_message_id`.
+- Add the tests required to prove the slice is ready for downstream assistant event, approval, and sequence work.
+
+## Exit criteria
+
+- Runtime exposes the internal message-send behavior required by the maintained specs.
+- Duplicate `client_message_id` submissions are idempotent.
+- User messages are projected with stable app-owned identifiers, and accepted sends leave assistant projection to downstream native event ingestion.
+- Tests cover the main messaging state transitions and projection behavior.
+
+## Work plan
+
+- Review the maintained messaging contract and current runtime/session implementation boundaries.
+- Implement persistence and service changes for message submission, idempotency, and projection.
+- Add or extend runtime routes and tests for the messaging flow.
+- Run the relevant runtime test suite and capture any follow-up risk in handoff notes.
+
+## Artifacts / evidence
+
+- Validation: `npm test -- --run tests/session-routes.test.ts`
+- Validation: `npm test`
+- Validation: `npm run build`
+- Evidence: `apps/codex-runtime/tests/session-routes.test.ts`
+
+## Status / handoff notes
+
+- Status: `ready to archive`
+- Notes: `Implemented internal GET/POST /api/v1/sessions/{session_id}/messages and POST /api/v1/sessions/{session_id}/assistant-events with SQLite-backed message projection persistence, client_message_id idempotency, stable assistant message identity across delta/completed ingestion, and the waiting_input -> running -> waiting_input turn flow. Validated with npm test -- --run tests/session-routes.test.ts and npm run build. Retrospective: bounded planner/worker/evaluator slices converged on the runtime work, but worker design-only/no-op returns delayed execution; sprint-cycle guidance was tightened on main in commit 4c9dc24 so implementation-requested sprints treat those returns as incomplete rather than complete. Remaining follow-up is package archive, PR/merge/completion tracking for #66, then resuming parent issue #60 through #67/#68/#69.`
+
+## Archive conditions
+
+- Archive this package when the messaging slice exit criteria are met, the handoff notes are updated, and the package is ready to move under `tasks/archive/issue-66-phase-3c-messaging/`.


### PR DESCRIPTION
## Summary
- finish the Phase 3C runtime messaging flow for Issue #66
- add route-based assistant delta/completed ingestion with stable assistant message identity
- archive the completed local task package for this slice

## Validation
- npm test -- --run tests/session-routes.test.ts
- npm run build

Closes #66
