### PR TITLE
feat(runtime): implement phase 3d approval flow

### DIFF
--- a/apps/codex-runtime/src/app.ts
+++ b/apps/codex-runtime/src/app.ts
@@ -14,6 +14,7 @@ import {
 import { SessionService } from "./domain/sessions/session-service.js";
 import { WorkspaceFilesystem } from "./domain/workspaces/workspace-filesystem.js";
 import { WorkspaceRegistry } from "./domain/workspaces/workspace-registry.js";
+import { registerApprovalRoutes } from "./routes/approvals.js";
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 
@@ -84,6 +85,7 @@ export async function buildApp(options: BuildAppOptions = {}) {
     reply.status(statusCode).send(body);
   });
 
+  await registerApprovalRoutes(app, sessionService);
   await registerWorkspaceRoutes(app, workspaceRegistry);
   await registerSessionRoutes(app, sessionService);
 

--- a/apps/codex-runtime/src/db/database.ts
+++ b/apps/codex-runtime/src/db/database.ts
@@ -60,6 +60,27 @@ ON messages (session_id, message_id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS messages_session_id_client_message_id_idx
 ON messages (session_id, client_message_id);
+
+CREATE TABLE IF NOT EXISTS approvals (
+  approval_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  resolution TEXT,
+  approval_category TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  operation_summary TEXT,
+  context TEXT,
+  created_at TEXT NOT NULL,
+  resolved_at TEXT,
+  native_request_kind TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions (session_id) ON DELETE CASCADE,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces (workspace_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS approvals_session_id_approval_id_idx
+ON approvals (session_id, approval_id);
 `;
 
 export function openRuntimeDatabase(databasePath: string) {

--- a/apps/codex-runtime/src/db/schema.ts
+++ b/apps/codex-runtime/src/db/schema.ts
@@ -77,6 +77,36 @@ export const messages = sqliteTable(
   }),
 );
 
+export const approvals = sqliteTable(
+  "approvals",
+  {
+    approvalId: text("approval_id").primaryKey(),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.sessionId, { onDelete: "cascade" }),
+    workspaceId: text("workspace_id")
+      .notNull()
+      .references(() => workspaces.workspaceId, { onDelete: "cascade" }),
+    status: text("status").notNull(),
+    resolution: text("resolution"),
+    approvalCategory: text("approval_category").notNull(),
+    summary: text("summary").notNull(),
+    reason: text("reason").notNull(),
+    operationSummary: text("operation_summary"),
+    context: text("context"),
+    createdAt: text("created_at").notNull(),
+    resolvedAt: text("resolved_at"),
+    nativeRequestKind: text("native_request_kind").notNull(),
+  },
+  (table) => ({
+    sessionCreatedAtIndex: uniqueIndex("approvals_session_id_approval_id_idx").on(
+      table.sessionId,
+      table.approvalId,
+    ),
+  }),
+);
+
 export type WorkspaceRow = typeof workspaces.$inferSelect;
 export type SessionRow = typeof sessions.$inferSelect;
 export type MessageRow = typeof messages.$inferSelect;
+export type ApprovalRow = typeof approvals.$inferSelect;

--- a/apps/codex-runtime/src/domain/approvals/approval-input.ts
+++ b/apps/codex-runtime/src/domain/approvals/approval-input.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+const approvalCategorySchema = z.enum([
+  "destructive_change",
+  "external_side_effect",
+  "network_access",
+  "privileged_execution",
+]);
+
+const ingestApprovalRequestSchema = z.object({
+  turn_id: z.string().trim().min(1, "turn id is required"),
+  approval_category: approvalCategorySchema,
+  summary: z.string().trim().min(1, "approval summary is required"),
+  reason: z.string().trim().min(1, "approval reason is required"),
+  operation_summary: z
+    .string()
+    .trim()
+    .min(1, "approval operation summary must be a non-empty string")
+    .optional(),
+  context: z.record(z.string(), z.unknown()).optional(),
+  native_request_kind: z
+    .string()
+    .trim()
+    .min(1, "native request kind is required")
+    .default("approval_request"),
+});
+
+const resolveApprovalSchema = z.object({
+  resolution: z.enum(["approved", "denied"]),
+});
+
+export function parseIngestApprovalRequestInput(input: unknown) {
+  return ingestApprovalRequestSchema.parse(input);
+}
+
+export function parseResolveApprovalInput(input: unknown) {
+  return resolveApprovalSchema.parse(input);
+}

--- a/apps/codex-runtime/src/domain/approvals/types.ts
+++ b/apps/codex-runtime/src/domain/approvals/types.ts
@@ -1,0 +1,30 @@
+export type ApprovalStatus = "pending" | "approved" | "denied" | "canceled";
+
+export type ApprovalResolution = "approved" | "denied" | "canceled";
+
+export type ApprovalCategory =
+  | "destructive_change"
+  | "external_side_effect"
+  | "network_access"
+  | "privileged_execution";
+
+export interface ApprovalProjection {
+  approval_id: string;
+  session_id: string;
+  workspace_id: string;
+  status: ApprovalStatus;
+  resolution: ApprovalResolution | null;
+  approval_category: ApprovalCategory;
+  summary: string;
+  reason: string;
+  operation_summary: string | null;
+  context: Record<string, unknown> | null;
+  created_at: string;
+  resolved_at: string | null;
+  native_request_kind: string;
+}
+
+export interface ApprovalSummary {
+  pending_approval_count: number;
+  updated_at: string;
+}

--- a/apps/codex-runtime/src/domain/sessions/native-session-gateway.ts
+++ b/apps/codex-runtime/src/domain/sessions/native-session-gateway.ts
@@ -16,6 +16,11 @@ export interface NativeSessionGateway {
   sendUserMessage(input: SendNativeSessionMessageInput): Promise<{
     turnId: string;
   }>;
+  resolveApproval(input: {
+    sessionId: string;
+    approvalId: string;
+    resolution: "approved" | "denied";
+  }): Promise<void>;
   interruptSessionTurn(input: { sessionId: string; turnId: string }): Promise<void>;
 }
 
@@ -30,6 +35,14 @@ export class SyntheticNativeSessionGateway implements NativeSessionGateway {
     return {
       turnId: `turn_${crypto.randomUUID().replaceAll("-", "")}`,
     };
+  }
+
+  async resolveApproval(_input: {
+    sessionId: string;
+    approvalId: string;
+    resolution: "approved" | "denied";
+  }) {
+    return;
   }
 
   async interruptSessionTurn(_input: { sessionId: string; turnId: string }) {

--- a/apps/codex-runtime/src/domain/sessions/session-service.ts
+++ b/apps/codex-runtime/src/domain/sessions/session-service.ts
@@ -4,7 +4,14 @@ import { and, asc, desc, eq, inArray } from "drizzle-orm";
 
 import { RuntimeError } from "../../errors.js";
 import type { RuntimeDatabase } from "../../db/database.js";
-import { messages, sessions, workspaces } from "../../db/schema.js";
+import { approvals, messages, sessions, workspaces } from "../../db/schema.js";
+import type {
+  ApprovalProjection,
+  ApprovalSummary,
+  ApprovalCategory,
+  ApprovalResolution,
+  ApprovalStatus,
+} from "../approvals/types.js";
 import { WorkspaceRegistry } from "../workspaces/workspace-registry.js";
 import { WorkspaceFilesystem } from "../workspaces/workspace-filesystem.js";
 import {
@@ -59,6 +66,36 @@ function mapMessageProjection(record: typeof messages.$inferSelect): MessageProj
     created_at: record.createdAt,
     source_item_type: record.sourceItemType as MessageSourceItemType,
   };
+}
+
+function parseApprovalContext(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+function mapApprovalProjection(record: typeof approvals.$inferSelect): ApprovalProjection {
+  return {
+    approval_id: record.approvalId,
+    session_id: record.sessionId,
+    workspace_id: record.workspaceId,
+    status: record.status as ApprovalStatus,
+    resolution: (record.resolution ?? null) as ApprovalResolution | null,
+    approval_category: record.approvalCategory as ApprovalCategory,
+    summary: record.summary,
+    reason: record.reason,
+    operation_summary: record.operationSummary,
+    context: parseApprovalContext(record.context),
+    created_at: record.createdAt,
+    resolved_at: record.resolvedAt,
+    native_request_kind: record.nativeRequestKind,
+  };
+}
+
+function generateApprovalId() {
+  return `apr_${crypto.randomUUID().replaceAll("-", "")}`;
 }
 
 function firstRequiredRow<T>(rows: T[], notFound: () => never) {
@@ -209,6 +246,7 @@ export class SessionService {
 
   async stopSession(sessionId: string): Promise<SessionStopResult> {
     const session = await this.getSession(sessionId);
+    const workspace = await this.workspaceRegistry.getWorkspace(session.workspace_id);
 
     if (session.status === "stopped") {
       return {
@@ -236,6 +274,60 @@ export class SessionService {
     }
 
     const now = toIsoString(this.now());
+    let canceledApproval: ApprovalProjection | null = null;
+
+    if (session.status === "waiting_approval" && session.active_approval_id !== null) {
+      const approval = firstRequiredRow(
+        this.database.db
+          .select()
+          .from(approvals)
+          .where(eq(approvals.approvalId, session.active_approval_id))
+          .limit(1)
+          .all(),
+        () => {
+          throw new RuntimeError(
+            404,
+            "approval_not_found",
+            "approval was not found",
+            {
+              approval_id: session.active_approval_id,
+            },
+          );
+        },
+      );
+
+      if (approval.status === "pending") {
+        this.database.db
+          .update(approvals)
+          .set({
+            status: "canceled",
+            resolution: "canceled",
+            resolvedAt: now,
+          })
+          .where(eq(approvals.approvalId, approval.approvalId))
+          .run();
+
+        const updatedApproval = firstRequiredRow(
+          this.database.db
+            .select()
+            .from(approvals)
+            .where(eq(approvals.approvalId, approval.approvalId))
+            .limit(1)
+            .all(),
+          () => {
+            throw new RuntimeError(
+              404,
+              "approval_not_found",
+              "approval was not found",
+              {
+                approval_id: approval.approvalId,
+              },
+            );
+          },
+        );
+        canceledApproval = mapApprovalProjection(updatedApproval);
+      }
+    }
 
     this.database.db
       .update(sessions)
@@ -244,6 +336,7 @@ export class SessionService {
         updatedAt: now,
         currentTurnId: null,
         activeApprovalId: null,
+        pendingAssistantMessageId: null,
         appSessionOverlayState: "closed",
       })
       .where(eq(sessions.sessionId, sessionId))
@@ -254,6 +347,10 @@ export class SessionService {
       .set({
         activeSessionId: null,
         updatedAt: now,
+        pendingApprovalCount:
+          session.status === "waiting_approval" && canceledApproval !== null
+            ? Math.max(0, workspace.pending_approval_count - 1)
+            : workspace.pending_approval_count,
       })
       .where(
         and(
@@ -265,7 +362,7 @@ export class SessionService {
 
     return {
       session: await this.getSession(sessionId),
-      canceled_approval: null,
+      canceled_approval: canceledApproval,
     };
   }
 
@@ -311,6 +408,186 @@ export class SessionService {
       items: rows.map(mapMessageProjection),
       next_cursor: null,
       has_more: false,
+    };
+  }
+
+  async listApprovals(
+    options: {
+      status?: ApprovalStatus;
+      workspace_id?: string;
+      limit?: number;
+      sort?: "created_at" | "-created_at";
+    } = {},
+  ) {
+    const limit = Math.max(1, Math.min(options.limit ?? 50, 100));
+    const sort = options.sort ?? "-created_at";
+    const conditions = [];
+
+    if (options.status) {
+      conditions.push(eq(approvals.status, options.status));
+    } else {
+      conditions.push(eq(approvals.status, "pending"));
+    }
+
+    if (options.workspace_id) {
+      conditions.push(eq(approvals.workspaceId, options.workspace_id));
+    }
+
+    const orderBy =
+      sort === "created_at"
+        ? [asc(approvals.createdAt), asc(approvals.approvalId)]
+        : [desc(approvals.createdAt), desc(approvals.approvalId)];
+
+    const rows = this.database.db
+      .select()
+      .from(approvals)
+      .where(conditions.length > 1 ? and(...conditions) : conditions[0]!)
+      .orderBy(...orderBy)
+      .limit(limit)
+      .all();
+
+    return {
+      items: rows.map(mapApprovalProjection),
+      next_cursor: null,
+      has_more: false,
+    };
+  }
+
+  async getApproval(approvalId: string) {
+    const row = firstRequiredRow(
+      this.database.db
+        .select()
+        .from(approvals)
+        .where(eq(approvals.approvalId, approvalId))
+        .limit(1)
+        .all(),
+      () => {
+        throw new RuntimeError(404, "approval_not_found", "approval was not found", {
+          approval_id: approvalId,
+        });
+      },
+    );
+
+    return mapApprovalProjection(row);
+  }
+
+  async resolveApproval(
+    approvalId: string,
+    input: {
+      resolution: Extract<ApprovalResolution, "approved" | "denied">;
+    },
+  ) {
+    const approval = firstRequiredRow(
+      this.database.db
+        .select()
+        .from(approvals)
+        .where(eq(approvals.approvalId, approvalId))
+        .limit(1)
+        .all(),
+      () => {
+        throw new RuntimeError(404, "approval_not_found", "approval was not found", {
+          approval_id: approvalId,
+        });
+      },
+    );
+
+    if (approval.status !== "pending") {
+      if (approval.resolution === input.resolution) {
+        return {
+          approval: mapApprovalProjection(approval),
+          session: await this.getSession(approval.sessionId),
+        };
+      }
+
+      throw new RuntimeError(
+        409,
+        "approval_not_pending",
+        "approval is not pending",
+        {
+          approval_id: approvalId,
+          status: approval.status,
+        },
+      );
+    }
+
+    const session = firstRequiredRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, approval.sessionId))
+        .limit(1)
+        .all(),
+      () => {
+        throw new RuntimeError(404, "session_not_found", "session was not found", {
+          session_id: approval.sessionId,
+        });
+      },
+    );
+    const workspace = await this.workspaceRegistry.getWorkspace(approval.workspaceId);
+    const resolvedAt = toIsoString(this.now());
+    const nextSessionStatus = input.resolution === "approved" ? "running" : "waiting_input";
+    const nextTurnId = input.resolution === "approved" ? session.currentTurnId : null;
+    const nextWorkspaceActiveSessionId =
+      input.resolution === "approved" ? approval.sessionId : null;
+
+    await this.nativeSessionGateway.resolveApproval({
+      sessionId: approval.sessionId,
+      approvalId,
+      resolution: input.resolution,
+    });
+
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .update(approvals)
+        .set({
+          status: input.resolution,
+          resolution: input.resolution,
+          resolvedAt,
+        })
+        .where(eq(approvals.approvalId, approvalId))
+        .run();
+
+      this.database.db
+        .update(sessions)
+        .set({
+          status: nextSessionStatus,
+          updatedAt: resolvedAt,
+          activeApprovalId: null,
+          currentTurnId: nextTurnId,
+          pendingAssistantMessageId:
+            input.resolution === "approved" ? session.pendingAssistantMessageId : null,
+        })
+        .where(eq(sessions.sessionId, approval.sessionId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          activeSessionId: nextWorkspaceActiveSessionId,
+          updatedAt: resolvedAt,
+          pendingApprovalCount: Math.max(0, workspace.pending_approval_count - 1),
+        })
+        .where(eq(workspaces.workspaceId, approval.workspaceId))
+        .run();
+    })();
+
+    return {
+      approval: await this.getApproval(approvalId),
+      session: await this.getSession(approval.sessionId),
+    };
+  }
+
+  async getApprovalSummary(): Promise<ApprovalSummary> {
+    const rows = this.database.db.select().from(approvals).all();
+    const pendingApprovalCount = rows.filter((row) => row.status === "pending").length;
+    const updatedAt =
+      rows
+        .map((row) => row.resolvedAt ?? row.createdAt)
+        .sort((left, right) => right.localeCompare(left))[0] ?? toIsoString(this.now());
+
+    return {
+      pending_approval_count: pendingApprovalCount,
+      updated_at: updatedAt,
     };
   }
 
@@ -433,6 +710,98 @@ export class SessionService {
       created_at: userCreatedAt,
       source_item_type: "user_message",
     } satisfies MessageProjection;
+  }
+
+  async ingestApprovalRequest(
+    sessionId: string,
+    input: {
+      turn_id: string;
+      approval_category: ApprovalCategory;
+      summary: string;
+      reason: string;
+      operation_summary?: string;
+      context?: Record<string, unknown>;
+      native_request_kind: string;
+    },
+  ) {
+    const session = firstRequiredRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, sessionId))
+        .limit(1)
+        .all(),
+      () => {
+        throw new RuntimeError(404, "session_not_found", "session was not found", {
+          session_id: sessionId,
+        });
+      },
+    );
+
+    if (
+      session.status !== "running" ||
+      session.currentTurnId !== input.turn_id ||
+      session.activeApprovalId !== null
+    ) {
+      throw new RuntimeError(
+        409,
+        "session_invalid_state",
+        "session is not ready to ingest approval requests",
+        {
+          session_id: sessionId,
+          current_status: session.status,
+          current_turn_id: session.currentTurnId,
+          active_approval_id: session.activeApprovalId,
+          requested_turn_id: input.turn_id,
+        },
+      );
+    }
+
+    const workspace = await this.workspaceRegistry.getWorkspace(session.workspaceId);
+    const approvalId = generateApprovalId();
+    const createdAt = toIsoString(this.now());
+
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .insert(approvals)
+        .values({
+          approvalId,
+          sessionId,
+          workspaceId: session.workspaceId,
+          status: "pending",
+          resolution: null,
+          approvalCategory: input.approval_category,
+          summary: input.summary,
+          reason: input.reason,
+          operationSummary: input.operation_summary ?? null,
+          context: input.context ? JSON.stringify(input.context) : null,
+          createdAt,
+          resolvedAt: null,
+          nativeRequestKind: input.native_request_kind,
+        })
+        .run();
+
+      this.database.db
+        .update(sessions)
+        .set({
+          status: "waiting_approval",
+          updatedAt: createdAt,
+          activeApprovalId: approvalId,
+        })
+        .where(eq(sessions.sessionId, sessionId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          pendingApprovalCount: workspace.pending_approval_count + 1,
+          updatedAt: createdAt,
+        })
+        .where(eq(workspaces.workspaceId, session.workspaceId))
+        .run();
+    })();
+
+    return this.getApproval(approvalId);
   }
 
   async ingestAssistantDelta(

--- a/apps/codex-runtime/src/domain/sessions/types.ts
+++ b/apps/codex-runtime/src/domain/sessions/types.ts
@@ -1,3 +1,5 @@
+import type { ApprovalProjection } from "../approvals/types.js";
+
 export type SessionStatus =
   | "created"
   | "running"
@@ -25,7 +27,7 @@ export interface SessionSummary {
 
 export interface SessionStopResult {
   session: SessionSummary;
-  canceled_approval: null;
+  canceled_approval: ApprovalProjection | null;
 }
 
 export type MessageRole = "user" | "assistant";

--- a/apps/codex-runtime/src/routes/approvals.ts
+++ b/apps/codex-runtime/src/routes/approvals.ts
@@ -1,0 +1,64 @@
+import type { FastifyInstance } from "fastify";
+import { ZodError } from "zod";
+
+import { parseResolveApprovalInput } from "../domain/approvals/approval-input.js";
+import { RuntimeError } from "../errors.js";
+import { SessionService } from "../domain/sessions/session-service.js";
+
+export async function registerApprovalRoutes(
+  app: FastifyInstance,
+  sessionService: SessionService,
+) {
+  app.get("/api/v1/approvals/summary", async () => {
+    return sessionService.getApprovalSummary();
+  });
+
+  app.get("/api/v1/approvals", async (request) => {
+    const query = request.query as {
+      status?: "pending" | "approved" | "denied" | "canceled";
+      workspace_id?: string;
+      limit?: number | string;
+      sort?: "created_at" | "-created_at";
+    };
+    const limit =
+      typeof query.limit === "string"
+        ? Number.parseInt(query.limit, 10)
+        : query.limit;
+
+    return sessionService.listApprovals({
+      status: query.status,
+      workspace_id: query.workspace_id,
+      limit: Number.isFinite(limit) ? limit : undefined,
+      sort: query.sort,
+    });
+  });
+
+  app.get("/api/v1/approvals/:approvalId", async (request) => {
+    const params = request.params as { approvalId: string };
+    return sessionService.getApproval(params.approvalId);
+  });
+
+  app.post("/api/v1/approvals/:approvalId/resolve", async (request) => {
+    const params = request.params as { approvalId: string };
+    let payload;
+
+    try {
+      payload = parseResolveApprovalInput(request.body);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw new RuntimeError(
+          422,
+          "approval_resolution_invalid",
+          "approval resolution is invalid",
+          {
+            issues: error.issues,
+          },
+        );
+      }
+
+      throw error;
+    }
+
+    return sessionService.resolveApproval(params.approvalId, payload);
+  });
+}

--- a/apps/codex-runtime/src/routes/sessions.ts
+++ b/apps/codex-runtime/src/routes/sessions.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { ZodError } from "zod";
 
+import { parseIngestApprovalRequestInput } from "../domain/approvals/approval-input.js";
 import { RuntimeError } from "../errors.js";
 import {
   parseAcceptMessageInput,
@@ -131,6 +132,32 @@ export async function registerSessionRoutes(
 
     reply.code(202);
     return result;
+  });
+
+  app.post("/api/v1/sessions/:sessionId/approval-requests", async (request, reply) => {
+    const params = request.params as { sessionId: string };
+    let payload;
+
+    try {
+      payload = parseIngestApprovalRequestInput(request.body);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw new RuntimeError(
+          422,
+          "approval_request_invalid",
+          "approval request is invalid",
+          {
+            issues: error.issues,
+          },
+        );
+      }
+
+      throw error;
+    }
+
+    const approval = await sessionService.ingestApprovalRequest(params.sessionId, payload);
+    reply.code(202);
+    return approval;
   });
 
   app.post("/api/v1/sessions/:sessionId/stop", async (request) => {

--- a/apps/codex-runtime/tests/session-routes.test.ts
+++ b/apps/codex-runtime/tests/session-routes.test.ts
@@ -17,6 +17,11 @@ class StubNativeSessionGateway implements NativeSessionGateway {
     private readonly turnIds: string[] = [],
     readonly interrupts: Array<{ sessionId: string; turnId: string }> = [],
     readonly sentMessages: Array<{ sessionId: string; content: string }> = [],
+    readonly resolvedApprovals: Array<{
+      sessionId: string;
+      approvalId: string;
+      resolution: "approved" | "denied";
+    }> = [],
   ) {}
 
   async createSession() {
@@ -35,6 +40,14 @@ class StubNativeSessionGateway implements NativeSessionGateway {
       turnId:
         this.turnIds.shift() ?? `turn_${this.sentMessages.length.toString().padStart(3, "0")}`,
     };
+  }
+
+  async resolveApproval(input: {
+    sessionId: string;
+    approvalId: string;
+    resolution: "approved" | "denied";
+  }) {
+    this.resolvedApprovals.push(input);
   }
 
   async interruptSessionTurn(input: { sessionId: string; turnId: string }) {
@@ -708,6 +721,577 @@ describe("session routes", () => {
           session_id: sessionId,
           current_status: "running",
           current_turn_id: "turn_001",
+          requested_turn_id: "turn_999",
+        },
+      },
+    });
+
+    await app.close();
+  });
+
+  it("ingests approval requests and exposes approval projections", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const ingestResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/approval-requests`,
+      payload: {
+        turn_id: "turn_001",
+        approval_category: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        operation_summary: "git push origin main",
+        context: {
+          command: "git push origin main",
+        },
+        native_request_kind: "approval_request",
+      },
+    });
+
+    const approval = ingestResponse.json();
+
+    expect(ingestResponse.statusCode).toBe(202);
+    expect(approval).toEqual({
+      approval_id: expect.stringMatching(/^apr_/),
+      session_id: sessionId,
+      workspace_id: "ws_alpha",
+      status: "pending",
+      resolution: null,
+      approval_category: "external_side_effect",
+      summary: "Run git push",
+      reason: "Codex requests permission to push changes to remote.",
+      operation_summary: "git push origin main",
+      context: {
+        command: "git push origin main",
+      },
+      created_at: expect.any(String),
+      resolved_at: null,
+      native_request_kind: "approval_request",
+    });
+
+    const sessionResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}`,
+    });
+
+    expect(sessionResponse.statusCode).toBe(200);
+    expect(sessionResponse.json()).toMatchObject({
+      session_id: sessionId,
+      status: "waiting_approval",
+      active_approval_id: approval.approval_id,
+      current_turn_id: "turn_001",
+    });
+
+    const workspaceResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha",
+    });
+
+    expect(workspaceResponse.statusCode).toBe(200);
+    expect(workspaceResponse.json()).toMatchObject({
+      active_session_id: sessionId,
+      pending_approval_count: 1,
+      active_session_summary: {
+        session_id: sessionId,
+        status: "waiting_approval",
+      },
+    });
+
+    const listResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/approvals",
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.json()).toEqual({
+      items: [approval],
+      next_cursor: null,
+      has_more: false,
+    });
+
+    const detailResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/approvals/${approval.approval_id}`,
+    });
+
+    expect(detailResponse.statusCode).toBe(200);
+    expect(detailResponse.json()).toEqual(approval);
+
+    const summaryResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/approvals/summary",
+    });
+
+    expect(summaryResponse.statusCode).toBe(200);
+    expect(summaryResponse.json()).toEqual({
+      pending_approval_count: 1,
+      updated_at: approval.created_at,
+    });
+
+    await app.close();
+  });
+
+  it("cancels a pending approval when the session is stopped", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const approvalResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/approval-requests`,
+      payload: {
+        turn_id: "turn_001",
+        approval_category: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        native_request_kind: "approval_request",
+      },
+    });
+
+    const approval = approvalResponse.json();
+
+    const stopResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/stop`,
+      payload: {},
+    });
+
+    expect(stopResponse.statusCode).toBe(200);
+    expect(stopResponse.json()).toEqual({
+      session: {
+        session_id: sessionId,
+        workspace_id: "ws_alpha",
+        title: "Fix build error",
+        status: "stopped",
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+        started_at: expect.any(String),
+        last_message_at: expect.any(String),
+        active_approval_id: null,
+        current_turn_id: null,
+        app_session_overlay_state: "closed",
+      },
+      canceled_approval: {
+        ...approval,
+        status: "canceled",
+        resolution: "canceled",
+        resolved_at: expect.any(String),
+      },
+    });
+
+    const workspaceResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha",
+    });
+
+    expect(workspaceResponse.statusCode).toBe(200);
+    expect(workspaceResponse.json()).toMatchObject({
+      active_session_id: null,
+      pending_approval_count: 0,
+      active_session_summary: null,
+    });
+
+    const detailResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/approvals/${approval.approval_id}`,
+    });
+
+    expect(detailResponse.statusCode).toBe(200);
+    expect(detailResponse.json()).toMatchObject({
+      approval_id: approval.approval_id,
+      status: "canceled",
+      resolution: "canceled",
+      resolved_at: expect.any(String),
+    });
+
+    await app.close();
+  });
+
+  it("resolves approvals with approved and keeps the session running", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const approvalResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/approval-requests`,
+      payload: {
+        turn_id: "turn_001",
+        approval_category: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        native_request_kind: "approval_request",
+      },
+    });
+
+    const approval = approvalResponse.json();
+
+    const resolveResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/approvals/${approval.approval_id}/resolve`,
+      payload: {
+        resolution: "approved",
+      },
+    });
+
+    expect(resolveResponse.statusCode).toBe(200);
+    expect(resolveResponse.json()).toEqual({
+      approval: {
+        ...approval,
+        status: "approved",
+        resolution: "approved",
+        resolved_at: expect.any(String),
+      },
+      session: {
+        session_id: sessionId,
+        workspace_id: "ws_alpha",
+        title: "Fix build error",
+        status: "running",
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+        started_at: expect.any(String),
+        last_message_at: expect.any(String),
+        active_approval_id: null,
+        current_turn_id: "turn_001",
+        app_session_overlay_state: "open",
+      },
+    });
+    expect(nativeSessionGateway.resolvedApprovals).toEqual([
+      {
+        sessionId,
+        approvalId: approval.approval_id,
+        resolution: "approved",
+      },
+    ]);
+
+    const workspaceResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha",
+    });
+
+    expect(workspaceResponse.statusCode).toBe(200);
+    expect(workspaceResponse.json()).toMatchObject({
+      active_session_id: sessionId,
+      pending_approval_count: 0,
+      active_session_summary: {
+        session_id: sessionId,
+        status: "running",
+      },
+    });
+
+    await app.close();
+  });
+
+  it("resolves approvals with denied and returns the session to waiting_input", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const approvalResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/approval-requests`,
+      payload: {
+        turn_id: "turn_001",
+        approval_category: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        native_request_kind: "approval_request",
+      },
+    });
+
+    const approval = approvalResponse.json();
+
+    const resolveResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/approvals/${approval.approval_id}/resolve`,
+      payload: {
+        resolution: "denied",
+      },
+    });
+
+    expect(resolveResponse.statusCode).toBe(200);
+    expect(resolveResponse.json()).toEqual({
+      approval: {
+        ...approval,
+        status: "denied",
+        resolution: "denied",
+        resolved_at: expect.any(String),
+      },
+      session: {
+        session_id: sessionId,
+        workspace_id: "ws_alpha",
+        title: "Fix build error",
+        status: "waiting_input",
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+        started_at: expect.any(String),
+        last_message_at: expect.any(String),
+        active_approval_id: null,
+        current_turn_id: null,
+        app_session_overlay_state: "open",
+      },
+    });
+    expect(nativeSessionGateway.resolvedApprovals).toEqual([
+      {
+        sessionId,
+        approvalId: approval.approval_id,
+        resolution: "denied",
+      },
+    ]);
+
+    const workspaceResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha",
+    });
+
+    expect(workspaceResponse.statusCode).toBe(200);
+    expect(workspaceResponse.json()).toMatchObject({
+      active_session_id: null,
+      pending_approval_count: 0,
+      active_session_summary: null,
+    });
+
+    await app.close();
+  });
+
+  it("returns idempotent success for the same approval resolution and rejects later changes", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const approvalResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/approval-requests`,
+      payload: {
+        turn_id: "turn_001",
+        approval_category: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        native_request_kind: "approval_request",
+      },
+    });
+
+    const approval = approvalResponse.json();
+
+    const firstResolve = await app.inject({
+      method: "POST",
+      url: `/api/v1/approvals/${approval.approval_id}/resolve`,
+      payload: {
+        resolution: "approved",
+      },
+    });
+    const idempotentResolve = await app.inject({
+      method: "POST",
+      url: `/api/v1/approvals/${approval.approval_id}/resolve`,
+      payload: {
+        resolution: "approved",
+      },
+    });
+    const conflictingResolve = await app.inject({
+      method: "POST",
+      url: `/api/v1/approvals/${approval.approval_id}/resolve`,
+      payload: {
+        resolution: "denied",
+      },
+    });
+
+    expect(firstResolve.statusCode).toBe(200);
+    expect(idempotentResolve.statusCode).toBe(200);
+    expect(idempotentResolve.json()).toEqual(firstResolve.json());
+    expect(conflictingResolve.statusCode).toBe(409);
+    expect(conflictingResolve.json()).toEqual({
+      error: {
+        code: "approval_not_pending",
+        message: "approval is not pending",
+        details: {
+          approval_id: approval.approval_id,
+          status: "approved",
+        },
+      },
+    });
+
+    await app.close();
+  });
+
+  it("rejects approval request ingestion when the session turn does not match", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/approval-requests`,
+      payload: {
+        turn_id: "turn_999",
+        approval_category: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        native_request_kind: "approval_request",
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: "session_invalid_state",
+        message: "session is not ready to ingest approval requests",
+        details: {
+          session_id: sessionId,
+          current_status: "running",
+          current_turn_id: "turn_001",
+          active_approval_id: null,
           requested_turn_id: "turn_999",
         },
       },

--- a/tasks/archive/issue-67-phase-3d-approval/README.md
+++ b/tasks/archive/issue-67-phase-3d-approval/README.md
@@ -1,0 +1,53 @@
+# Issue 67 Phase 3D Approval
+
+## Purpose
+
+- Execute the Phase 3D runtime slice for approval lifecycle, stop handling, and approval projection under Issue #67.
+
+## Primary issue
+
+- Issue: `#67 https://github.com/tsukushibito/codex-webui/issues/67`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_internal_api_v0_8.md`
+- `docs/specs/codex_webui_common_spec_v0_8.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Add the runtime contract needed to detect and project pending approvals for an active session turn.
+- Add approval resolution handling for approve, deny, and cancel flows, including `active_approval_id` updates.
+- Add the stop behavior needed when approval is pending so cancellation is distinguishable from a normal stop.
+- Add the tests required to prove the approval slice is ready for downstream event, recovery, and BFF work.
+
+## Exit criteria
+
+- Runtime can project pending approvals with stable app-owned identifiers.
+- Approve, deny, and cancel flows behave according to the maintained specs.
+- Approval state stays consistent with stop behavior and session-status transitions.
+- Tests cover the main approval lifecycle and stop interactions for this slice.
+
+## Work plan
+
+- Review the maintained approval contract and current runtime/session implementation boundaries.
+- Implement persistence and service changes for approval detection, projection, and resolution.
+- Add or extend runtime routes and tests for the approval flow.
+- Run the relevant runtime test suite and capture follow-up risk in handoff notes.
+
+## Artifacts / evidence
+
+- Validation: `npm install`
+- Validation: `npm test -- --run tests/session-routes.test.ts`
+- Validation: `npm run build`
+- Evidence: `apps/codex-runtime/tests/session-routes.test.ts`
+
+## Status / handoff notes
+
+- Status: `ready to archive`
+- Notes: `Implemented route-based approval request ingestion, approval list/detail/summary projection, approval resolution for approved/denied, and stop-time cancellation for pending approvals. Session and workspace state now cover running -> waiting_approval -> running/waiting_input/stopped with active_approval_id and pending_approval_count kept in sync. Validated with npm install, npm test -- --run tests/session-routes.test.ts, and npm run build. Retrospective: carrying the package/worktree workflow forward immediately after #66 kept tracking aligned, while the local environment hit subagent thread limits during sprint execution, so the bounded approval slices were finished locally instead of through delegated planner/evaluator passes. Remaining follow-up is package archive, PR/merge/completion tracking for #67, then resuming parent issue #60 through #68 and #69.`
+
+## Archive conditions
+
+- Archive this package when the approval slice exit criteria are met and the handoff notes are updated.


### PR DESCRIPTION
## Summary
- implement the Phase 3D runtime approval lifecycle for Issue #67
- add approval projection routes plus approve, deny, and stop-cancel handling
- archive the completed local task package for this slice

## Validation
- npm install
- npm test -- --run tests/session-routes.test.ts
- npm run build

Closes #67
