### PR TITLE
feat(runtime): implement phase 3e eventing flow

### DIFF
--- a/apps/codex-runtime/src/db/database.ts
+++ b/apps/codex-runtime/src/db/database.ts
@@ -81,6 +81,23 @@ CREATE TABLE IF NOT EXISTS approvals (
 
 CREATE UNIQUE INDEX IF NOT EXISTS approvals_session_id_approval_id_idx
 ON approvals (session_id, approval_id);
+
+CREATE TABLE IF NOT EXISTS session_events (
+  event_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  sequence INTEGER NOT NULL,
+  occurred_at TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  native_event_name TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions (session_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS session_events_session_id_event_id_idx
+ON session_events (session_id, event_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS session_events_session_id_sequence_idx
+ON session_events (session_id, sequence);
 `;
 
 export function openRuntimeDatabase(databasePath: string) {

--- a/apps/codex-runtime/src/db/schema.ts
+++ b/apps/codex-runtime/src/db/schema.ts
@@ -106,7 +106,33 @@ export const approvals = sqliteTable(
   }),
 );
 
+export const sessionEvents = sqliteTable(
+  "session_events",
+  {
+    eventId: text("event_id").primaryKey(),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.sessionId, { onDelete: "cascade" }),
+    eventType: text("event_type").notNull(),
+    sequence: integer("sequence").notNull(),
+    occurredAt: text("occurred_at").notNull(),
+    payload: text("payload").notNull(),
+    nativeEventName: text("native_event_name"),
+  },
+  (table) => ({
+    sessionEventIdIndex: uniqueIndex("session_events_session_id_event_id_idx").on(
+      table.sessionId,
+      table.eventId,
+    ),
+    sessionSequenceIndex: uniqueIndex("session_events_session_id_sequence_idx").on(
+      table.sessionId,
+      table.sequence,
+    ),
+  }),
+);
+
 export type WorkspaceRow = typeof workspaces.$inferSelect;
 export type SessionRow = typeof sessions.$inferSelect;
 export type MessageRow = typeof messages.$inferSelect;
 export type ApprovalRow = typeof approvals.$inferSelect;
+export type SessionEventRow = typeof sessionEvents.$inferSelect;

--- a/apps/codex-runtime/src/domain/sessions/session-service.ts
+++ b/apps/codex-runtime/src/domain/sessions/session-service.ts
@@ -4,7 +4,13 @@ import { and, asc, desc, eq, inArray } from "drizzle-orm";
 
 import { RuntimeError } from "../../errors.js";
 import type { RuntimeDatabase } from "../../db/database.js";
-import { approvals, messages, sessions, workspaces } from "../../db/schema.js";
+import {
+  approvals,
+  messages,
+  sessionEvents,
+  sessions,
+  workspaces,
+} from "../../db/schema.js";
 import type {
   ApprovalProjection,
   ApprovalSummary,
@@ -19,10 +25,13 @@ import {
   resolveWorkspaceSessionCwd,
 } from "./native-session-gateway.js";
 import type {
+  ApprovalStreamEventProjection,
   AppSessionOverlayState,
   MessageProjection,
   MessageRole,
   MessageSourceItemType,
+  SessionEventProjection,
+  SessionEventType,
   SessionStatus,
   SessionStopResult,
   SessionSummary,
@@ -98,6 +107,28 @@ function generateApprovalId() {
   return `apr_${crypto.randomUUID().replaceAll("-", "")}`;
 }
 
+function generateEventId() {
+  return `evt_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+function parseEventPayload(value: string) {
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+function mapSessionEventProjection(
+  record: typeof sessionEvents.$inferSelect,
+): SessionEventProjection {
+  return {
+    event_id: record.eventId,
+    session_id: record.sessionId,
+    event_type: record.eventType as SessionEventType,
+    sequence: record.sequence,
+    occurred_at: record.occurredAt,
+    payload: parseEventPayload(record.payload),
+    native_event_name: record.nativeEventName,
+  };
+}
+
 function firstRequiredRow<T>(rows: T[], notFound: () => never) {
   const row = firstRow(rows);
   if (!row) {
@@ -108,6 +139,15 @@ function firstRequiredRow<T>(rows: T[], notFound: () => never) {
 }
 
 export class SessionService {
+  private readonly sessionEventListeners = new Map<
+    string,
+    Set<(event: SessionEventProjection) => void>
+  >();
+
+  private readonly approvalEventListeners = new Set<
+    (event: ApprovalStreamEventProjection) => void
+  >();
+
   constructor(
     private readonly database: RuntimeDatabase,
     private readonly workspaceRegistry: WorkspaceRegistry,
@@ -115,6 +155,113 @@ export class SessionService {
     private readonly nativeSessionGateway: NativeSessionGateway,
     private readonly now: () => Date = () => new Date(),
   ) {}
+
+  subscribeSessionEvents(
+    sessionId: string,
+    listener: (event: SessionEventProjection) => void,
+  ) {
+    const listeners = this.sessionEventListeners.get(sessionId) ?? new Set();
+    listeners.add(listener);
+    this.sessionEventListeners.set(sessionId, listeners);
+
+    return () => {
+      listeners.delete(listener);
+
+      if (listeners.size === 0) {
+        this.sessionEventListeners.delete(sessionId);
+      }
+    };
+  }
+
+  subscribeApprovalEvents(listener: (event: ApprovalStreamEventProjection) => void) {
+    this.approvalEventListeners.add(listener);
+
+    return () => {
+      this.approvalEventListeners.delete(listener);
+    };
+  }
+
+  private appendSessionEvent(input: {
+    sessionId: string;
+    eventType: SessionEventType;
+    occurredAt: string;
+    payload: Record<string, unknown>;
+    nativeEventName?: string | null;
+  }) {
+    const latestEvent = firstRow(
+      this.database.db
+        .select()
+        .from(sessionEvents)
+        .where(eq(sessionEvents.sessionId, input.sessionId))
+        .orderBy(desc(sessionEvents.sequence), desc(sessionEvents.eventId))
+        .limit(1)
+        .all(),
+    );
+    const nextSequence = (latestEvent?.sequence ?? 0) + 1;
+
+    const eventId = generateEventId();
+
+    this.database.db
+      .insert(sessionEvents)
+      .values({
+        eventId,
+        sessionId: input.sessionId,
+        eventType: input.eventType,
+        sequence: nextSequence,
+        occurredAt: input.occurredAt,
+        payload: JSON.stringify(input.payload),
+        nativeEventName: input.nativeEventName ?? null,
+      })
+      .run();
+
+    const event = mapSessionEventProjection({
+      eventId,
+      sessionId: input.sessionId,
+      eventType: input.eventType,
+      sequence: nextSequence,
+      occurredAt: input.occurredAt,
+      payload: JSON.stringify(input.payload),
+      nativeEventName: input.nativeEventName ?? null,
+    });
+
+    const sessionListeners = this.sessionEventListeners.get(input.sessionId);
+    sessionListeners?.forEach((listener) => listener(event));
+
+    if (
+      event.event_type === "approval.requested" ||
+      event.event_type === "approval.resolved"
+    ) {
+      const approvalEvent: ApprovalStreamEventProjection = {
+        event_id: event.event_id,
+        session_id: event.session_id,
+        event_type: event.event_type,
+        occurred_at: event.occurred_at,
+        payload: event.payload,
+        native_event_name: event.native_event_name,
+      };
+
+      this.approvalEventListeners.forEach((listener) => listener(approvalEvent));
+    }
+  }
+
+  private appendSessionStatusChangedEvent(input: {
+    sessionId: string;
+    occurredAt: string;
+    fromStatus: SessionStatus;
+    toStatus: SessionStatus;
+    nativeEventName?: string | null;
+  }) {
+    this.appendSessionEvent({
+      sessionId: input.sessionId,
+      eventType: "session.status_changed",
+      occurredAt: input.occurredAt,
+      payload: {
+        from_status: input.fromStatus,
+        to_status: input.toStatus,
+      },
+      nativeEventName: input.nativeEventName,
+    });
+  }
 
   async listSessions(workspaceId: string) {
     await this.workspaceRegistry.getWorkspace(workspaceId);
@@ -276,42 +423,13 @@ export class SessionService {
     const now = toIsoString(this.now());
     let canceledApproval: ApprovalProjection | null = null;
 
-    if (session.status === "waiting_approval" && session.active_approval_id !== null) {
-      const approval = firstRequiredRow(
-        this.database.db
-          .select()
-          .from(approvals)
-          .where(eq(approvals.approvalId, session.active_approval_id))
-          .limit(1)
-          .all(),
-        () => {
-          throw new RuntimeError(
-            404,
-            "approval_not_found",
-            "approval was not found",
-            {
-              approval_id: session.active_approval_id,
-            },
-          );
-        },
-      );
-
-      if (approval.status === "pending") {
-        this.database.db
-          .update(approvals)
-          .set({
-            status: "canceled",
-            resolution: "canceled",
-            resolvedAt: now,
-          })
-          .where(eq(approvals.approvalId, approval.approvalId))
-          .run();
-
-        const updatedApproval = firstRequiredRow(
+    this.database.sqlite.transaction(() => {
+      if (session.status === "waiting_approval" && session.active_approval_id !== null) {
+        const approval = firstRequiredRow(
           this.database.db
             .select()
             .from(approvals)
-            .where(eq(approvals.approvalId, approval.approvalId))
+            .where(eq(approvals.approvalId, session.active_approval_id))
             .limit(1)
             .all(),
           () => {
@@ -320,45 +438,96 @@ export class SessionService {
               "approval_not_found",
               "approval was not found",
               {
-                approval_id: approval.approvalId,
+                approval_id: session.active_approval_id,
               },
             );
           },
         );
-        canceledApproval = mapApprovalProjection(updatedApproval);
+
+        if (approval.status === "pending") {
+          this.database.db
+            .update(approvals)
+            .set({
+              status: "canceled",
+              resolution: "canceled",
+              resolvedAt: now,
+            })
+            .where(eq(approvals.approvalId, approval.approvalId))
+            .run();
+
+          const updatedApproval = firstRequiredRow(
+            this.database.db
+              .select()
+              .from(approvals)
+              .where(eq(approvals.approvalId, approval.approvalId))
+              .limit(1)
+              .all(),
+            () => {
+              throw new RuntimeError(
+                404,
+                "approval_not_found",
+                "approval was not found",
+                {
+                  approval_id: approval.approvalId,
+                },
+              );
+            },
+          );
+          canceledApproval = mapApprovalProjection(updatedApproval);
+
+          this.appendSessionEvent({
+            sessionId,
+            eventType: "approval.resolved",
+            occurredAt: now,
+            payload: {
+              approval_id: approval.approvalId,
+              workspace_id: approval.workspaceId,
+              approval_category: approval.approvalCategory,
+              summary: approval.summary,
+              resolution: "canceled",
+            },
+          });
+        }
       }
-    }
 
-    this.database.db
-      .update(sessions)
-      .set({
-        status: "stopped",
-        updatedAt: now,
-        currentTurnId: null,
-        activeApprovalId: null,
-        pendingAssistantMessageId: null,
-        appSessionOverlayState: "closed",
-      })
-      .where(eq(sessions.sessionId, sessionId))
-      .run();
+      this.database.db
+        .update(sessions)
+        .set({
+          status: "stopped",
+          updatedAt: now,
+          currentTurnId: null,
+          activeApprovalId: null,
+          pendingAssistantMessageId: null,
+          appSessionOverlayState: "closed",
+        })
+        .where(eq(sessions.sessionId, sessionId))
+        .run();
 
-    this.database.db
-      .update(workspaces)
-      .set({
-        activeSessionId: null,
-        updatedAt: now,
-        pendingApprovalCount:
-          session.status === "waiting_approval" && canceledApproval !== null
-            ? Math.max(0, workspace.pending_approval_count - 1)
-            : workspace.pending_approval_count,
-      })
-      .where(
-        and(
-          eq(workspaces.workspaceId, session.workspace_id),
-          eq(workspaces.activeSessionId, sessionId),
-        ),
-      )
-      .run();
+      this.database.db
+        .update(workspaces)
+        .set({
+          activeSessionId: null,
+          updatedAt: now,
+          pendingApprovalCount:
+            session.status === "waiting_approval" && canceledApproval !== null
+              ? Math.max(0, workspace.pending_approval_count - 1)
+              : workspace.pending_approval_count,
+        })
+        .where(
+          and(
+            eq(workspaces.workspaceId, session.workspace_id),
+            eq(workspaces.activeSessionId, sessionId),
+          ),
+        )
+        .run();
+
+      this.appendSessionStatusChangedEvent({
+        sessionId,
+        occurredAt: now,
+        fromStatus: session.status,
+        toStatus: "stopped",
+      });
+    })();
 
     return {
       session: await this.getSession(sessionId),
@@ -406,6 +575,45 @@ export class SessionService {
 
     return {
       items: rows.map(mapMessageProjection),
+      next_cursor: null,
+      has_more: false,
+    };
+  }
+
+  async listSessionEvents(
+    sessionId: string,
+    options: {
+      limit?: number;
+      sort?: "occurred_at" | "-occurred_at";
+    } = {},
+  ) {
+    await this.getSession(sessionId);
+
+    const limit = Math.max(1, Math.min(options.limit ?? 100, 100));
+    const sort = options.sort ?? "occurred_at";
+    const orderBy =
+      sort === "-occurred_at"
+        ? [
+            desc(sessionEvents.occurredAt),
+            desc(sessionEvents.sequence),
+            desc(sessionEvents.eventId),
+          ]
+        : [
+            asc(sessionEvents.occurredAt),
+            asc(sessionEvents.sequence),
+            asc(sessionEvents.eventId),
+          ];
+
+    const rows = this.database.db
+      .select()
+      .from(sessionEvents)
+      .where(eq(sessionEvents.sessionId, sessionId))
+      .orderBy(...orderBy)
+      .limit(limit)
+      .all();
+
+    return {
+      items: rows.map(mapSessionEventProjection),
       next_cursor: null,
       has_more: false,
     };
@@ -569,6 +777,26 @@ export class SessionService {
         })
         .where(eq(workspaces.workspaceId, approval.workspaceId))
         .run();
+
+      this.appendSessionEvent({
+        sessionId: approval.sessionId,
+        eventType: "approval.resolved",
+        occurredAt: resolvedAt,
+        payload: {
+          approval_id: approvalId,
+          workspace_id: approval.workspaceId,
+          approval_category: approval.approvalCategory,
+          summary: approval.summary,
+          resolution: input.resolution,
+        },
+      });
+
+      this.appendSessionStatusChangedEvent({
+        sessionId: approval.sessionId,
+        occurredAt: resolvedAt,
+        fromStatus: session.status as SessionStatus,
+        toStatus: nextSessionStatus,
+      });
     })();
 
     return {
@@ -679,6 +907,16 @@ export class SessionService {
         })
         .run();
 
+      this.appendSessionEvent({
+        sessionId,
+        eventType: "message.user",
+        occurredAt: userCreatedAt,
+        payload: {
+          message_id: userMessageId,
+          content: input.content,
+        },
+      });
+
       this.database.db
         .update(sessions)
         .set({
@@ -700,6 +938,13 @@ export class SessionService {
         })
         .where(eq(workspaces.workspaceId, session.workspace_id))
         .run();
+
+      this.appendSessionStatusChangedEvent({
+        sessionId,
+        occurredAt: userCreatedAt,
+        fromStatus: session.status,
+        toStatus: "running",
+      });
     })();
 
     return {
@@ -799,6 +1044,26 @@ export class SessionService {
         })
         .where(eq(workspaces.workspaceId, session.workspaceId))
         .run();
+
+      this.appendSessionEvent({
+        sessionId,
+        eventType: "approval.requested",
+        occurredAt: createdAt,
+        payload: {
+          approval_id: approvalId,
+          workspace_id: session.workspaceId,
+          approval_category: input.approval_category,
+          summary: input.summary,
+        },
+        nativeEventName: "request/started",
+      });
+
+      this.appendSessionStatusChangedEvent({
+        sessionId,
+        occurredAt: createdAt,
+        fromStatus: session.status as SessionStatus,
+        toStatus: "waiting_approval",
+      });
     })();
 
     return this.getApproval(approvalId);
@@ -843,14 +1108,28 @@ export class SessionService {
       session.pendingAssistantMessageId ?? generateMessageId("assistant");
     const updatedAt = toIsoString(this.now());
 
-    this.database.db
-      .update(sessions)
-      .set({
-        updatedAt,
-        pendingAssistantMessageId: assistantMessageId,
-      })
-      .where(eq(sessions.sessionId, sessionId))
-      .run();
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .update(sessions)
+        .set({
+          updatedAt,
+          pendingAssistantMessageId: assistantMessageId,
+        })
+        .where(eq(sessions.sessionId, sessionId))
+        .run();
+
+      this.appendSessionEvent({
+        sessionId,
+        eventType: "message.assistant.delta",
+        occurredAt: updatedAt,
+        payload: {
+          message_id: assistantMessageId,
+          turn_id: input.turn_id,
+          delta: input.delta,
+        },
+        nativeEventName: "item/agent_message/delta",
+      });
+    })();
 
     return {
       message_id: assistantMessageId,
@@ -914,6 +1193,18 @@ export class SessionService {
         })
         .run();
 
+      this.appendSessionEvent({
+        sessionId,
+        eventType: "message.assistant.completed",
+        occurredAt: assistantCreatedAt,
+        payload: {
+          message_id: assistantMessageId,
+          turn_id: input.turn_id,
+          content: input.content,
+        },
+        nativeEventName: "item/agent_message/completed",
+      });
+
       this.database.db
         .update(sessions)
         .set({
@@ -940,6 +1231,13 @@ export class SessionService {
           ),
         )
         .run();
+
+      this.appendSessionStatusChangedEvent({
+        sessionId,
+        occurredAt: assistantCreatedAt,
+        fromStatus: session.status as SessionStatus,
+        toStatus: "waiting_input",
+      });
     })();
 
     return {

--- a/apps/codex-runtime/src/domain/sessions/types.ts
+++ b/apps/codex-runtime/src/domain/sessions/types.ts
@@ -42,3 +42,30 @@ export interface MessageProjection {
   created_at: string;
   source_item_type: MessageSourceItemType;
 }
+
+export type SessionEventType =
+  | "session.status_changed"
+  | "message.user"
+  | "message.assistant.delta"
+  | "message.assistant.completed"
+  | "approval.requested"
+  | "approval.resolved";
+
+export interface SessionEventProjection {
+  event_id: string;
+  session_id: string;
+  event_type: SessionEventType;
+  sequence: number;
+  occurred_at: string;
+  payload: Record<string, unknown>;
+  native_event_name: string | null;
+}
+
+export interface ApprovalStreamEventProjection {
+  event_id: string;
+  session_id: string;
+  event_type: Extract<SessionEventType, "approval.requested" | "approval.resolved">;
+  occurred_at: string;
+  payload: Record<string, unknown>;
+  native_event_name: string | null;
+}

--- a/apps/codex-runtime/src/routes/approvals.ts
+++ b/apps/codex-runtime/src/routes/approvals.ts
@@ -9,6 +9,25 @@ export async function registerApprovalRoutes(
   app: FastifyInstance,
   sessionService: SessionService,
 ) {
+  app.get("/api/v1/approvals/stream", async (request, reply) => {
+    reply.hijack();
+    reply.raw.writeHead(200, {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+    });
+    reply.raw.write(": connected\n\n");
+
+    const unsubscribe = sessionService.subscribeApprovalEvents((event) => {
+      reply.raw.write(`data: ${JSON.stringify(event)}\n\n`);
+    });
+
+    request.raw.on("close", () => {
+      unsubscribe();
+      reply.raw.end();
+    });
+  });
+
   app.get("/api/v1/approvals/summary", async () => {
     return sessionService.getApprovalSummary();
   });

--- a/apps/codex-runtime/src/routes/sessions.ts
+++ b/apps/codex-runtime/src/routes/sessions.ts
@@ -73,6 +73,45 @@ export async function registerSessionRoutes(
     });
   });
 
+  app.get("/api/v1/sessions/:sessionId/events", async (request) => {
+    const params = request.params as { sessionId: string };
+    const query = request.query as {
+      limit?: number | string;
+      sort?: "occurred_at" | "-occurred_at";
+    };
+    const limit =
+      typeof query.limit === "string"
+        ? Number.parseInt(query.limit, 10)
+        : query.limit;
+
+    return sessionService.listSessionEvents(params.sessionId, {
+      limit: Number.isFinite(limit) ? limit : undefined,
+      sort: query.sort,
+    });
+  });
+
+  app.get("/api/v1/sessions/:sessionId/stream", async (request, reply) => {
+    const params = request.params as { sessionId: string };
+    await sessionService.getSession(params.sessionId);
+
+    reply.hijack();
+    reply.raw.writeHead(200, {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+    });
+    reply.raw.write(": connected\n\n");
+
+    const unsubscribe = sessionService.subscribeSessionEvents(params.sessionId, (event) => {
+      reply.raw.write(`data: ${JSON.stringify(event)}\n\n`);
+    });
+
+    request.raw.on("close", () => {
+      unsubscribe();
+      reply.raw.end();
+    });
+  });
+
   app.post("/api/v1/sessions/:sessionId/start", async (request) => {
     const params = request.params as { sessionId: string };
     return sessionService.startSession(params.sessionId);

--- a/apps/codex-runtime/tests/session-routes.test.ts
+++ b/apps/codex-runtime/tests/session-routes.test.ts
@@ -101,6 +101,60 @@ function seedWaitingInputSession(
   return { workspaceId, sessionId };
 }
 
+async function listSessionEvents(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  sessionId: string,
+  query = "",
+) {
+  const response = await app.inject({
+    method: "GET",
+    url: `/api/v1/sessions/${sessionId}/events${query}`,
+  });
+
+  expect(response.statusCode).toBe(200);
+  return response.json();
+}
+
+function resolveBaseUrl(app: Awaited<ReturnType<typeof buildApp>>) {
+  const address = app.server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("app server address is not available");
+  }
+
+  return `http://127.0.0.1:${address.port.toString()}`;
+}
+
+function createSseReader(response: Response) {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("response body is not readable");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  return async function nextEvent() {
+    while (true) {
+      const separatorIndex = buffer.indexOf("\n\n");
+      if (separatorIndex >= 0) {
+        const chunk = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + 2);
+
+        if (chunk.startsWith("data: ")) {
+          return JSON.parse(chunk.slice(6)) as Record<string, unknown>;
+        }
+      }
+
+      const { done, value } = await reader.read();
+      if (done) {
+        throw new Error("sse stream ended before the next data event was received");
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+    }
+  };
+}
+
 afterEach(async () => {
   await Promise.all(
     cleanupPaths.splice(0).map((entryPath) =>
@@ -623,6 +677,174 @@ describe("session routes", () => {
       has_more: false,
     });
 
+    const eventsResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}/events`,
+    });
+
+    expect(eventsResponse.statusCode).toBe(200);
+    expect(eventsResponse.json()).toEqual({
+      items: [
+        {
+          event_id: expect.stringMatching(/^evt_/),
+          session_id: sessionId,
+          event_type: "message.user",
+          sequence: 1,
+          occurred_at: sendResponse.json().created_at,
+          payload: {
+            message_id: sendResponse.json().message_id,
+            content: "Please explain the diff.",
+          },
+          native_event_name: null,
+        },
+        {
+          event_id: expect.stringMatching(/^evt_/),
+          session_id: sessionId,
+          event_type: "session.status_changed",
+          sequence: 2,
+          occurred_at: sendResponse.json().created_at,
+          payload: {
+            from_status: "waiting_input",
+            to_status: "running",
+          },
+          native_event_name: null,
+        },
+        {
+          event_id: expect.stringMatching(/^evt_/),
+          session_id: sessionId,
+          event_type: "message.assistant.delta",
+          sequence: 3,
+          occurred_at: expect.any(String),
+          payload: {
+            message_id: deltaResponse.json().message_id,
+            turn_id: "turn_001",
+            delta: "I checked the diff",
+          },
+          native_event_name: "item/agent_message/delta",
+        },
+        {
+          event_id: expect.stringMatching(/^evt_/),
+          session_id: sessionId,
+          event_type: "message.assistant.completed",
+          sequence: 4,
+          occurred_at: assistantMessage.created_at,
+          payload: {
+            message_id: deltaResponse.json().message_id,
+            turn_id: "turn_001",
+            content: "I checked the diff and summarized the changes.",
+          },
+          native_event_name: "item/agent_message/completed",
+        },
+        {
+          event_id: expect.stringMatching(/^evt_/),
+          session_id: sessionId,
+          event_type: "session.status_changed",
+          sequence: 5,
+          occurred_at: assistantMessage.created_at,
+          payload: {
+            from_status: "running",
+            to_status: "waiting_input",
+          },
+          native_event_name: null,
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+
+    const reversedEventsResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}/events?sort=-occurred_at&limit=2`,
+    });
+
+    expect(reversedEventsResponse.statusCode).toBe(200);
+    expect(reversedEventsResponse.json()).toEqual({
+      items: [
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "session.status_changed",
+          sequence: 5,
+          occurred_at: assistantMessage.created_at,
+          payload: {
+            from_status: "running",
+            to_status: "waiting_input",
+          },
+          native_event_name: null,
+        },
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "message.assistant.completed",
+          sequence: 4,
+          occurred_at: assistantMessage.created_at,
+          payload: {
+            message_id: deltaResponse.json().message_id,
+            turn_id: "turn_001",
+            content: "I checked the diff and summarized the changes.",
+          },
+          native_event_name: "item/agent_message/completed",
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+
+    await app.close();
+  });
+
+  it("opens the session stream route and publishes canonical session events", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+    await app.listen({ port: 0, host: "127.0.0.1" });
+
+    const controller = new AbortController();
+    const response = await fetch(`${resolveBaseUrl(app)}/api/v1/sessions/${sessionId}/stream`, {
+      signal: controller.signal,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const nextEvent = createSseReader(response);
+
+    const sendResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_stream_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    expect(sendResponse.statusCode).toBe(202);
+    await expect(nextEvent()).resolves.toMatchObject({
+      session_id: sessionId,
+      event_type: "message.user",
+      payload: {
+        message_id: sendResponse.json().message_id,
+        content: "Please explain the diff.",
+      },
+    });
+
+    controller.abort();
     await app.close();
   });
 
@@ -855,6 +1077,39 @@ describe("session routes", () => {
       updated_at: approval.created_at,
     });
 
+    expect(await listSessionEvents(app, sessionId, "?sort=-occurred_at&limit=2")).toEqual({
+      items: [
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "session.status_changed",
+          sequence: 4,
+          occurred_at: approval.created_at,
+          payload: {
+            from_status: "running",
+            to_status: "waiting_approval",
+          },
+          native_event_name: null,
+        },
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "approval.requested",
+          sequence: 3,
+          occurred_at: approval.created_at,
+          payload: {
+            approval_id: approval.approval_id,
+            workspace_id: "ws_alpha",
+            approval_category: "external_side_effect",
+            summary: "Run git push",
+          },
+          native_event_name: "request/started",
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+
     await app.close();
   });
 
@@ -954,6 +1209,40 @@ describe("session routes", () => {
       status: "canceled",
       resolution: "canceled",
       resolved_at: expect.any(String),
+    });
+
+    expect(await listSessionEvents(app, sessionId, "?sort=-occurred_at&limit=2")).toEqual({
+      items: [
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "session.status_changed",
+          sequence: 6,
+          occurred_at: stopResponse.json().session.updated_at,
+          payload: {
+            from_status: "waiting_approval",
+            to_status: "stopped",
+          },
+          native_event_name: null,
+        },
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "approval.resolved",
+          sequence: 5,
+          occurred_at: stopResponse.json().session.updated_at,
+          payload: {
+            approval_id: approval.approval_id,
+            workspace_id: "ws_alpha",
+            approval_category: "external_side_effect",
+            summary: "Run git push",
+            resolution: "canceled",
+          },
+          native_event_name: null,
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
     });
 
     await app.close();
@@ -1056,6 +1345,40 @@ describe("session routes", () => {
       },
     });
 
+    expect(await listSessionEvents(app, sessionId, "?sort=-occurred_at&limit=2")).toEqual({
+      items: [
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "session.status_changed",
+          sequence: 6,
+          occurred_at: resolveResponse.json().session.updated_at,
+          payload: {
+            from_status: "waiting_approval",
+            to_status: "running",
+          },
+          native_event_name: null,
+        },
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "approval.resolved",
+          sequence: 5,
+          occurred_at: resolveResponse.json().session.updated_at,
+          payload: {
+            approval_id: approval.approval_id,
+            workspace_id: "ws_alpha",
+            approval_category: "external_side_effect",
+            summary: "Run git push",
+            resolution: "approved",
+          },
+          native_event_name: null,
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+
     await app.close();
   });
 
@@ -1153,6 +1476,40 @@ describe("session routes", () => {
       active_session_summary: null,
     });
 
+    expect(await listSessionEvents(app, sessionId, "?sort=-occurred_at&limit=2")).toEqual({
+      items: [
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "session.status_changed",
+          sequence: 6,
+          occurred_at: resolveResponse.json().session.updated_at,
+          payload: {
+            from_status: "waiting_approval",
+            to_status: "waiting_input",
+          },
+          native_event_name: null,
+        },
+        {
+          event_id: expect.any(String),
+          session_id: sessionId,
+          event_type: "approval.resolved",
+          sequence: 5,
+          occurred_at: resolveResponse.json().session.updated_at,
+          payload: {
+            approval_id: approval.approval_id,
+            workspace_id: "ws_alpha",
+            approval_category: "external_side_effect",
+            summary: "Run git push",
+            resolution: "denied",
+          },
+          native_event_name: null,
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+
     await app.close();
   });
 
@@ -1237,6 +1594,76 @@ describe("session routes", () => {
       },
     });
 
+    await app.close();
+  });
+
+  it("opens the approvals stream route and publishes approval events", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_approval_stream_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    await app.listen({ port: 0, host: "127.0.0.1" });
+
+    const controller = new AbortController();
+    const response = await fetch(`${resolveBaseUrl(app)}/api/v1/approvals/stream`, {
+      signal: controller.signal,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const nextEvent = createSseReader(response);
+
+    const approvalResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/approval-requests`,
+      payload: {
+        turn_id: "turn_001",
+        approval_category: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        native_request_kind: "approval_request",
+      },
+    });
+
+    expect(approvalResponse.statusCode).toBe(202);
+    await expect(nextEvent()).resolves.toMatchObject({
+      session_id: sessionId,
+      event_type: "approval.requested",
+      payload: {
+        approval_id: approvalResponse.json().approval_id,
+        workspace_id: "ws_alpha",
+        approval_category: "external_side_effect",
+        summary: "Run git push",
+      },
+      native_event_name: "request/started",
+    });
+
+    controller.abort();
     await app.close();
   });
 

--- a/tasks/archive/issue-68-phase-3e-events/README.md
+++ b/tasks/archive/issue-68-phase-3e-events/README.md
@@ -1,0 +1,62 @@
+# Issue 68 Phase 3E Events
+
+## Purpose
+
+- Execute the Phase 3E runtime slice for canonical event projection and sequence streams under Issue #68.
+
+## Primary issue
+
+- Issue: `#68 https://github.com/tsukushibito/codex-webui/issues/68`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_internal_api_v0_8.md`
+- `docs/specs/codex_webui_common_spec_v0_8.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Add the runtime contract needed to persist canonical session events with stable event IDs and session-scoped sequence numbers.
+- Add the session and approval event projection paths needed to back the maintained internal event resources.
+- Add the event list and stream-adjacent runtime surfaces required before the BFF SSE relay work in Phase 4.
+- Add the tests required to prove canonical ordering and event/resource integration for this slice.
+
+## Exit criteria
+
+- Runtime emits canonical events with stable app-owned event IDs and session sequence ordering.
+- Session and approval stream source data is available from the runtime in the maintained shape.
+- Event projection stays aligned with the maintained public/internal mapping decisions.
+- Tests cover event append ordering and the main runtime event-resource integrations for this slice.
+
+## Work plan
+
+- Review the maintained event and sequence contract and current runtime/session/approval implementation boundaries.
+- Implement persistence and service changes for canonical event append and sequence numbering.
+- Add or extend runtime routes and tests for session events and approval stream source data.
+- Run the relevant runtime test suite and capture follow-up risk in handoff notes.
+
+## Artifacts / evidence
+
+- Validation: `npm test -- --run tests/session-routes.test.ts`
+- Validation: `npm test`
+- Validation: `npm run build`
+- Evidence: `apps/codex-runtime/tests/session-routes.test.ts`
+
+## Status / handoff notes
+
+- Status: `completed locally`
+- Notes: `Sprint 1 added canonical session event persistence, session-scoped sequence numbering, and GET /api/v1/sessions/{session_id}/events for message/user-assistant flows. Sprint 2 extended the same event log with approval.requested / approval.resolved plus matching session.status_changed transitions for approve, deny, and stop-cancel paths, then added GET /api/v1/sessions/{session_id}/stream and GET /api/v1/approvals/stream with focused route-level tests. Local validation passed with npm test -- --run tests/session-routes.test.ts, npm test, and npm run build.`
+
+### Completion retrospective
+
+- Completion boundary: `Issue #68 package reached local completion and is ready for PR / merge / cleanup tracking.`
+- What worked: `Using bounded sprints kept the eventing slice small enough to land in two passes, and the new sprint-cycle no-op guard prevented an analysis-only worker result from being accepted as progress.`
+- Workflow problems: `The intake / planner agents were slow to return and needed interrupt-driven result collection, and the second worker pass expanded into stream routes without rerunning validation until prompted.`
+- Improvements to adopt: `Keep worker prompts scoped to concrete routes, tests, and validation commands, and treat any scope expansion as requiring fresh validation before evaluator review.`
+- Skill candidates or skill updates: `None. The sprint-cycle worker completion hardening already captured the durable fix discovered during this work.`
+- Follow-up updates: `Create PR, merge to main, sync parent checkout, remove the worktree, then close Issue #68 and update Project status.`
+
+## Archive conditions
+
+- Archive this package when the eventing slice exit criteria are met and the handoff notes are updated.


### PR DESCRIPTION
## Summary
- add canonical session event persistence and sequence-backed session event resources
- append approval-side canonical events and expose session/approval stream source routes
- archive the Issue #68 task package with retrospective notes

## Validation
- npm test -- --run tests/session-routes.test.ts
- npm test
- npm run build

Closes #68
