### PR TITLE
feat(runtime): add recovery reconciliation flows

### DIFF
--- a/apps/codex-runtime/src/domain/sessions/session-service.ts
+++ b/apps/codex-runtime/src/domain/sessions/session-service.ts
@@ -61,6 +61,16 @@ function mapSessionSummary(record: typeof sessions.$inferSelect): SessionSummary
   };
 }
 
+function mapSessionSummaryWithOverlay(
+  record: typeof sessions.$inferSelect,
+  overlayState: AppSessionOverlayState,
+): SessionSummary {
+  return {
+    ...mapSessionSummary(record),
+    app_session_overlay_state: overlayState,
+  };
+}
+
 function generateMessageId(role: MessageRole) {
   const prefix = role === "user" ? "msg_user" : "msg_assistant";
   return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
@@ -263,6 +273,142 @@ export class SessionService {
     });
   }
 
+  private getSessionRecord(sessionId: string) {
+    return firstRequiredRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, sessionId))
+        .limit(1)
+        .all(),
+      () => {
+        throw new RuntimeError(404, "session_not_found", "session was not found", {
+          session_id: sessionId,
+        });
+      },
+    );
+  }
+
+  private getPendingApprovalForSession(sessionId: string) {
+    return firstRow(
+      this.database.db
+        .select()
+        .from(approvals)
+        .where(and(eq(approvals.sessionId, sessionId), eq(approvals.status, "pending")))
+        .orderBy(desc(approvals.createdAt), desc(approvals.approvalId))
+        .limit(1)
+        .all(),
+    );
+  }
+
+  private getActiveApprovalRecord(session: typeof sessions.$inferSelect) {
+    if (session.activeApprovalId === null) {
+      return null;
+    }
+
+    return firstRow(
+      this.database.db
+        .select()
+        .from(approvals)
+        .where(eq(approvals.approvalId, session.activeApprovalId))
+        .limit(1)
+        .all(),
+    );
+  }
+
+  private detectApprovalRecoveryMismatch(session: typeof sessions.$inferSelect) {
+    if (session.status !== "waiting_approval") {
+      return null;
+    }
+
+    if (session.activeApprovalId === null) {
+      return {
+        kind: "missing_active_approval_id" as const,
+        approval: null,
+        pendingApproval: this.getPendingApprovalForSession(session.sessionId),
+      };
+    }
+
+    const approval = this.getActiveApprovalRecord(session);
+    if (!approval) {
+      return {
+        kind: "active_approval_missing" as const,
+        approval: null,
+        pendingApproval: this.getPendingApprovalForSession(session.sessionId),
+      };
+    }
+
+    if (approval.status !== "pending") {
+      return {
+        kind: "active_approval_resolved" as const,
+        approval,
+        pendingApproval: this.getPendingApprovalForSession(session.sessionId),
+      };
+    }
+
+    return null;
+  }
+
+  private countPendingApprovals(workspaceId: string) {
+    return this.database.db
+      .select()
+      .from(approvals)
+      .where(and(eq(approvals.workspaceId, workspaceId), eq(approvals.status, "pending")))
+      .all().length;
+  }
+
+  private detectWorkspaceRecoveryMismatch(session: typeof sessions.$inferSelect) {
+    if (session.status !== "running" && session.status !== "waiting_approval") {
+      return false;
+    }
+
+    const workspace = firstRow(
+      this.database.db
+        .select()
+        .from(workspaces)
+        .where(eq(workspaces.workspaceId, session.workspaceId))
+        .limit(1)
+        .all(),
+    );
+
+    if (!workspace) {
+      return false;
+    }
+
+    if (workspace.activeSessionId === session.sessionId) {
+      return false;
+    }
+
+    if (workspace.activeSessionId === null) {
+      return true;
+    }
+
+    const activeSession = firstRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, workspace.activeSessionId))
+        .limit(1)
+        .all(),
+    );
+
+    if (!activeSession) {
+      return true;
+    }
+
+    return activeSession.status !== "running" && activeSession.status !== "waiting_approval";
+  }
+
+  private async materializeSessionSummary(record: typeof sessions.$inferSelect) {
+    const mismatch =
+      this.detectApprovalRecoveryMismatch(record) ??
+      this.detectWorkspaceRecoveryMismatch(record);
+    return mapSessionSummaryWithOverlay(
+      record,
+      mismatch ? "recovery_pending" : (record.appSessionOverlayState as AppSessionOverlayState),
+    );
+  }
+
   async listSessions(workspaceId: string) {
     await this.workspaceRegistry.getWorkspace(workspaceId);
 
@@ -273,26 +419,11 @@ export class SessionService {
       .orderBy(desc(sessions.updatedAt), desc(sessions.sessionId))
       .all();
 
-    return rows.map(mapSessionSummary);
+    return Promise.all(rows.map((row) => this.materializeSessionSummary(row)));
   }
 
   async getSession(sessionId: string) {
-    const row = firstRow(
-      this.database.db
-        .select()
-        .from(sessions)
-        .where(eq(sessions.sessionId, sessionId))
-        .limit(1)
-        .all(),
-    );
-
-    if (!row) {
-      throw new RuntimeError(404, "session_not_found", "session was not found", {
-        session_id: sessionId,
-      });
-    }
-
-    return mapSessionSummary(row);
+    return this.materializeSessionSummary(this.getSessionRecord(sessionId));
   }
 
   async createSession(workspaceId: string, title: string) {
@@ -546,7 +677,11 @@ export class SessionService {
       .where(inArray(sessions.sessionId, sessionIds))
       .all();
 
-    return new Map(rows.map((row) => [row.sessionId, mapSessionSummary(row)]));
+    return new Map(
+      await Promise.all(
+        rows.map(async (row) => [row.sessionId, await this.materializeSessionSummary(row)] as const),
+      ),
+    );
   }
 
   async listMessages(
@@ -616,6 +751,89 @@ export class SessionService {
       items: rows.map(mapSessionEventProjection),
       next_cursor: null,
       has_more: false,
+    };
+  }
+
+  async reconcileSession(sessionId: string) {
+    const session = this.getSessionRecord(sessionId);
+    const mismatch = this.detectApprovalRecoveryMismatch(session);
+
+    if (!mismatch) {
+      return {
+        session: await this.getSession(sessionId),
+      };
+    }
+
+    const pendingApprovalCount = this.countPendingApprovals(session.workspaceId);
+    const updatedAt = toIsoString(this.now());
+    const pendingApproval = mismatch.pendingApproval;
+
+    this.database.sqlite.transaction(() => {
+      if (pendingApproval) {
+        this.database.db
+          .update(sessions)
+          .set({
+            status: "waiting_approval",
+            updatedAt,
+            activeApprovalId: pendingApproval.approvalId,
+            appSessionOverlayState: "open",
+          })
+          .where(eq(sessions.sessionId, sessionId))
+          .run();
+
+        this.database.db
+          .update(workspaces)
+          .set({
+            activeSessionId: sessionId,
+            updatedAt,
+            pendingApprovalCount,
+          })
+          .where(eq(workspaces.workspaceId, session.workspaceId))
+          .run();
+
+        return;
+      }
+
+      const resolvedApproval = mismatch.approval;
+      const nextStatus =
+        resolvedApproval?.resolution === "canceled"
+          ? "stopped"
+          : resolvedApproval?.resolution === "approved"
+            ? session.currentTurnId
+              ? "running"
+              : "waiting_input"
+            : "waiting_input";
+      const nextOverlayState =
+        nextStatus === "stopped" ? "closed" : ("open" as const);
+      const nextActiveSessionId = nextStatus === "running" ? sessionId : null;
+
+      this.database.db
+        .update(sessions)
+        .set({
+          status: nextStatus,
+          updatedAt,
+          activeApprovalId: null,
+          currentTurnId: nextStatus === "waiting_input" || nextStatus === "stopped" ? null : session.currentTurnId,
+          pendingAssistantMessageId:
+            nextStatus === "running" ? session.pendingAssistantMessageId : null,
+          appSessionOverlayState: nextOverlayState,
+        })
+        .where(eq(sessions.sessionId, sessionId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          activeSessionId: nextActiveSessionId,
+          updatedAt,
+          pendingApprovalCount,
+        })
+        .where(eq(workspaces.workspaceId, session.workspaceId))
+        .run();
+    })();
+
+    return {
+      session: await this.getSession(sessionId),
     };
   }
 

--- a/apps/codex-runtime/src/domain/sessions/types.ts
+++ b/apps/codex-runtime/src/domain/sessions/types.ts
@@ -30,6 +30,10 @@ export interface SessionStopResult {
   canceled_approval: ApprovalProjection | null;
 }
 
+export interface SessionReconcileResult {
+  session: SessionSummary;
+}
+
 export type MessageRole = "user" | "assistant";
 
 export type MessageSourceItemType = "user_message" | "agent_message";

--- a/apps/codex-runtime/src/domain/workspaces/workspace-registry.ts
+++ b/apps/codex-runtime/src/domain/workspaces/workspace-registry.ts
@@ -4,7 +4,12 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 
 import { RuntimeError } from "../../errors.js";
 import type { RuntimeDatabase } from "../../db/database.js";
-import { sessions, workspaceSessionMappings, workspaces } from "../../db/schema.js";
+import {
+  approvals,
+  sessions,
+  workspaceSessionMappings,
+  workspaces,
+} from "../../db/schema.js";
 import type { EligibleWorkspaceDirectory, WorkspaceSummary } from "./types.js";
 import { validateWorkspaceName } from "./workspace-name.js";
 import { WorkspaceFilesystem } from "./workspace-filesystem.js";
@@ -37,6 +42,10 @@ function mapWorkspaceSummary(
 
 function firstRow<T>(rows: T[]) {
   return rows[0];
+}
+
+function isActiveSessionStatus(status: string) {
+  return status === "running" || status === "waiting_approval";
 }
 
 export class WorkspaceRegistry {
@@ -258,6 +267,38 @@ export class WorkspaceRegistry {
     );
 
     return mapping?.workspaceId ?? null;
+  }
+
+  async reconcileWorkspace(workspaceId: string) {
+    await this.getWorkspace(workspaceId);
+
+    const now = toIsoString(this.now());
+    const activeSession = firstRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.workspaceId, workspaceId))
+        .orderBy(desc(sessions.updatedAt), desc(sessions.sessionId))
+        .all()
+        .filter((row) => isActiveSessionStatus(row.status)),
+    );
+    const pendingApprovalCount = this.database.db
+      .select()
+      .from(approvals)
+      .where(and(eq(approvals.workspaceId, workspaceId), eq(approvals.status, "pending")))
+      .all().length;
+
+    this.database.db
+      .update(workspaces)
+      .set({
+        activeSessionId: activeSession?.sessionId ?? null,
+        pendingApprovalCount,
+        updatedAt: now,
+      })
+      .where(eq(workspaces.workspaceId, workspaceId))
+      .run();
+
+    return this.getWorkspace(workspaceId);
   }
 
   async hasSessionLink(workspaceId: string, sessionId: string) {

--- a/apps/codex-runtime/src/routes/sessions.ts
+++ b/apps/codex-runtime/src/routes/sessions.ts
@@ -203,4 +203,9 @@ export async function registerSessionRoutes(
     const params = request.params as { sessionId: string };
     return sessionService.stopSession(params.sessionId);
   });
+
+  app.post("/api/v1/sessions/:sessionId/reconcile", async (request) => {
+    const params = request.params as { sessionId: string };
+    return sessionService.reconcileSession(params.sessionId);
+  });
 }

--- a/apps/codex-runtime/src/routes/workspaces.ts
+++ b/apps/codex-runtime/src/routes/workspaces.ts
@@ -48,4 +48,9 @@ export async function registerWorkspaceRoutes(
     const params = request.params as { workspaceId: string };
     return workspaceRegistry.getWorkspace(params.workspaceId);
   });
+
+  app.post("/api/v1/workspaces/:workspaceId/reconcile", async (request) => {
+    const params = request.params as { workspaceId: string };
+    return workspaceRegistry.reconcileWorkspace(params.workspaceId);
+  });
 }

--- a/apps/codex-runtime/tests/session-routes.test.ts
+++ b/apps/codex-runtime/tests/session-routes.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { buildApp } from "../src/app.js";
 import type { NativeSessionGateway } from "../src/domain/sessions/native-session-gateway.js";
-import { sessions, workspaces } from "../src/db/schema.js";
+import { approvals, sessions, workspaces } from "../src/db/schema.js";
 import { createTempDatabase, createTempWorkspaceRoot } from "./helpers.js";
 
 const cleanupPaths: string[] = [];
@@ -99,6 +99,173 @@ function seedWaitingInputSession(
     .run();
 
   return { workspaceId, sessionId };
+}
+
+function seedWaitingApprovalMismatchSession(
+  database: Awaited<ReturnType<typeof createTempDatabase>>,
+  options: {
+    workspaceId?: string;
+    sessionId?: string;
+    activeApprovalId?: string | null;
+    approvalStatus?: "pending" | "approved" | "denied" | "canceled";
+    approvalResolution?: "approved" | "denied" | "canceled" | null;
+    insertApproval?: boolean;
+    pendingApprovalId?: string | null;
+  } = {},
+) {
+  const workspaceId = options.workspaceId ?? "ws_alpha";
+  const sessionId = options.sessionId ?? "thread_001";
+  const activeApprovalId =
+    Object.prototype.hasOwnProperty.call(options, "activeApprovalId")
+      ? (options.activeApprovalId ?? null)
+      : "apr_stale";
+  const now = "2026-04-04T12:00:00.000Z";
+
+  database.db
+    .insert(workspaces)
+    .values({
+      workspaceId,
+      workspaceName: "alpha",
+      directoryName: "alpha",
+      createdAt: now,
+      updatedAt: now,
+      activeSessionId: sessionId,
+      pendingApprovalCount: 1,
+    })
+    .run();
+
+  database.db
+    .insert(sessions)
+    .values({
+      sessionId,
+      workspaceId,
+      title: "Fix build error",
+      status: "waiting_approval",
+      createdAt: now,
+      updatedAt: now,
+      startedAt: now,
+      lastMessageAt: now,
+      activeApprovalId,
+      currentTurnId: "turn_001",
+      pendingAssistantMessageId: null,
+      appSessionOverlayState: "open",
+    })
+    .run();
+
+  if (options.insertApproval ?? true) {
+    database.db
+      .insert(approvals)
+      .values({
+        approvalId: activeApprovalId ?? "apr_stale",
+        sessionId,
+        workspaceId,
+        status: options.approvalStatus ?? "denied",
+        resolution: options.approvalResolution ?? "denied",
+        approvalCategory: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        operationSummary: null,
+        context: null,
+        createdAt: now,
+        resolvedAt: now,
+        nativeRequestKind: "approval_request",
+      })
+      .run();
+  }
+
+  if (options.pendingApprovalId) {
+    database.db
+      .insert(approvals)
+      .values({
+        approvalId: options.pendingApprovalId,
+        sessionId,
+        workspaceId,
+        status: "pending",
+        resolution: null,
+        approvalCategory: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        operationSummary: null,
+        context: null,
+        createdAt: "2026-04-04T12:01:00.000Z",
+        resolvedAt: null,
+        nativeRequestKind: "approval_request",
+      })
+      .run();
+  }
+
+  return { workspaceId, sessionId, activeApprovalId };
+}
+
+function seedWorkspaceActiveSessionMismatch(
+  database: Awaited<ReturnType<typeof createTempDatabase>>,
+  options: {
+    workspaceId?: string;
+    staleSessionId?: string | null;
+    activeSessionId?: string;
+    activeSessionStatus?: "running" | "waiting_approval";
+  } = {},
+) {
+  const workspaceId = options.workspaceId ?? "ws_alpha";
+  const staleSessionId =
+    Object.prototype.hasOwnProperty.call(options, "staleSessionId")
+      ? (options.staleSessionId ?? null)
+      : "thread_stale";
+  const activeSessionId = options.activeSessionId ?? "thread_active";
+  const now = "2026-04-04T12:00:00.000Z";
+
+  database.db
+    .insert(workspaces)
+    .values({
+      workspaceId,
+      workspaceName: "alpha",
+      directoryName: "alpha",
+      createdAt: now,
+      updatedAt: now,
+      activeSessionId: staleSessionId,
+      pendingApprovalCount: 0,
+    })
+    .run();
+
+  if (staleSessionId) {
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: staleSessionId,
+        workspaceId,
+        title: "Stale session",
+        status: "waiting_input",
+        createdAt: now,
+        updatedAt: now,
+        startedAt: now,
+        lastMessageAt: now,
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+  }
+
+  database.db
+    .insert(sessions)
+    .values({
+      sessionId: activeSessionId,
+      workspaceId,
+      title: "Active session",
+      status: options.activeSessionStatus ?? "running",
+      createdAt: now,
+      updatedAt: "2026-04-04T12:01:00.000Z",
+      startedAt: now,
+      lastMessageAt: now,
+      activeApprovalId: null,
+      currentTurnId: "turn_001",
+      pendingAssistantMessageId: null,
+      appSessionOverlayState: "open",
+    })
+    .run();
+
+  return { workspaceId, activeSessionId };
 }
 
 async function listSessionEvents(
@@ -1664,6 +1831,226 @@ describe("session routes", () => {
     });
 
     controller.abort();
+    await app.close();
+  });
+
+  it("surfaces resolved approval mismatches as recovery_pending and reconciles them", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway: new StubNativeSessionGateway([]),
+      },
+    });
+
+    const { sessionId, activeApprovalId } = seedWaitingApprovalMismatchSession(database, {
+      approvalStatus: "denied",
+      approvalResolution: "denied",
+    });
+
+    const getResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}`,
+    });
+
+    expect(getResponse.statusCode).toBe(200);
+    expect(getResponse.json()).toMatchObject({
+      session_id: sessionId,
+      status: "waiting_approval",
+      active_approval_id: activeApprovalId,
+      app_session_overlay_state: "recovery_pending",
+    });
+
+    const listResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha/sessions",
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.json().items).toEqual([
+      expect.objectContaining({
+        session_id: sessionId,
+        app_session_overlay_state: "recovery_pending",
+      }),
+    ]);
+
+    const reconcileResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/reconcile`,
+      payload: {},
+    });
+
+    expect(reconcileResponse.statusCode).toBe(200);
+    expect(reconcileResponse.json()).toEqual({
+      session: {
+        session_id: sessionId,
+        workspace_id: "ws_alpha",
+        title: "Fix build error",
+        status: "waiting_input",
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+        started_at: expect.any(String),
+        last_message_at: expect.any(String),
+        active_approval_id: null,
+        current_turn_id: null,
+        app_session_overlay_state: "open",
+      },
+    });
+
+    const workspaceResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha",
+    });
+
+    expect(workspaceResponse.statusCode).toBe(200);
+    expect(workspaceResponse.json()).toMatchObject({
+      active_session_id: null,
+      pending_approval_count: 0,
+      active_session_summary: null,
+    });
+
+    await app.close();
+  });
+
+  it("repairs a missing active approval id by relinking the pending approval", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway: new StubNativeSessionGateway([]),
+      },
+    });
+
+    const { sessionId } = seedWaitingApprovalMismatchSession(database, {
+      activeApprovalId: null,
+      insertApproval: false,
+      pendingApprovalId: "apr_pending_001",
+    });
+
+    const getResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}`,
+    });
+
+    expect(getResponse.statusCode).toBe(200);
+    expect(getResponse.json()).toMatchObject({
+      session_id: sessionId,
+      status: "waiting_approval",
+      active_approval_id: null,
+      app_session_overlay_state: "recovery_pending",
+    });
+
+    const reconcileResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/reconcile`,
+      payload: {},
+    });
+
+    expect(reconcileResponse.statusCode).toBe(200);
+    expect(reconcileResponse.json()).toEqual({
+      session: {
+        session_id: sessionId,
+        workspace_id: "ws_alpha",
+        title: "Fix build error",
+        status: "waiting_approval",
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+        started_at: expect.any(String),
+        last_message_at: expect.any(String),
+        active_approval_id: "apr_pending_001",
+        current_turn_id: "turn_001",
+        app_session_overlay_state: "open",
+      },
+    });
+
+    const workspaceResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha",
+    });
+
+    expect(workspaceResponse.statusCode).toBe(200);
+    expect(workspaceResponse.json()).toMatchObject({
+      active_session_id: sessionId,
+      pending_approval_count: 1,
+      active_session_summary: {
+        session_id: sessionId,
+        status: "waiting_approval",
+      },
+    });
+
+    await app.close();
+  });
+
+  it("surfaces workspace active-session drift as recovery_pending and clears it after workspace reconciliation", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway: new StubNativeSessionGateway([]),
+      },
+    });
+
+    const { workspaceId, activeSessionId } = seedWorkspaceActiveSessionMismatch(database);
+
+    const beforeResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${activeSessionId}`,
+    });
+
+    expect(beforeResponse.statusCode).toBe(200);
+    expect(beforeResponse.json()).toMatchObject({
+      session_id: activeSessionId,
+      status: "running",
+      app_session_overlay_state: "recovery_pending",
+    });
+
+    const reconcileResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/workspaces/${workspaceId}/reconcile`,
+      payload: {},
+    });
+
+    expect(reconcileResponse.statusCode).toBe(200);
+
+    const afterResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${activeSessionId}`,
+    });
+
+    expect(afterResponse.statusCode).toBe(200);
+    expect(afterResponse.json()).toMatchObject({
+      session_id: activeSessionId,
+      status: "running",
+      app_session_overlay_state: "open",
+    });
+
     await app.close();
   });
 

--- a/apps/codex-runtime/tests/workspace-routes.test.ts
+++ b/apps/codex-runtime/tests/workspace-routes.test.ts
@@ -5,9 +5,105 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { buildApp } from "../src/app.js";
+import { approvals, sessions, workspaces } from "../src/db/schema.js";
 import { createTempDatabase, createTempWorkspaceRoot } from "./helpers.js";
 
 const cleanupPaths: string[] = [];
+
+function seedWorkspaceRecoveryState(
+  database: Awaited<ReturnType<typeof createTempDatabase>>,
+  options: {
+    workspaceId?: string;
+    activeSessionId?: string | null;
+    activeSessionStatus?: "running" | "waiting_approval";
+    staleSessionId?: string | null;
+    pendingApprovalCount?: number;
+    pendingApprovalForActiveSession?: boolean;
+  } = {},
+) {
+  const workspaceId = options.workspaceId ?? "ws_alpha";
+  const activeSessionId = options.activeSessionId ?? "thread_active";
+  const staleSessionId =
+    Object.prototype.hasOwnProperty.call(options, "staleSessionId")
+      ? (options.staleSessionId ?? null)
+      : "thread_stale";
+  const now = "2026-04-04T12:00:00.000Z";
+
+  database.db
+    .insert(workspaces)
+    .values({
+      workspaceId,
+      workspaceName: "alpha",
+      directoryName: "alpha",
+      createdAt: now,
+      updatedAt: now,
+      activeSessionId: staleSessionId,
+      pendingApprovalCount: options.pendingApprovalCount ?? 0,
+    })
+    .run();
+
+  if (staleSessionId) {
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: staleSessionId,
+        workspaceId,
+        title: "Stale session",
+        status: "waiting_input",
+        createdAt: now,
+        updatedAt: now,
+        startedAt: now,
+        lastMessageAt: now,
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+  }
+
+  database.db
+    .insert(sessions)
+    .values({
+      sessionId: activeSessionId,
+      workspaceId,
+      title: "Active session",
+      status: options.activeSessionStatus ?? "running",
+      createdAt: now,
+      updatedAt: "2026-04-04T12:01:00.000Z",
+      startedAt: now,
+      lastMessageAt: now,
+      activeApprovalId:
+        options.pendingApprovalForActiveSession ?? false ? "apr_pending_001" : null,
+      currentTurnId: options.activeSessionStatus === "running" ? "turn_001" : "turn_approval",
+      pendingAssistantMessageId: null,
+      appSessionOverlayState: "open",
+    })
+    .run();
+
+  if (options.pendingApprovalForActiveSession ?? false) {
+    database.db
+      .insert(approvals)
+      .values({
+        approvalId: "apr_pending_001",
+        sessionId: activeSessionId,
+        workspaceId,
+        status: "pending",
+        resolution: null,
+        approvalCategory: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        operationSummary: null,
+        context: null,
+        createdAt: "2026-04-04T12:01:00.000Z",
+        resolvedAt: null,
+        nativeRequestKind: "approval_request",
+      })
+      .run();
+  }
+
+  return { workspaceId, activeSessionId, staleSessionId };
+}
 
 afterEach(async () => {
   await Promise.all(
@@ -197,6 +293,112 @@ describe("workspace routes", () => {
           pending_approval_count: 0,
         },
       ],
+    });
+
+    await app.close();
+  });
+
+  it("reconciles a stale active session pointer to the persisted active session", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+    });
+
+    const { workspaceId, activeSessionId, staleSessionId } = seedWorkspaceRecoveryState(
+      database,
+    );
+
+    const beforeResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/workspaces/${workspaceId}`,
+    });
+
+    expect(beforeResponse.statusCode).toBe(200);
+    expect(beforeResponse.json()).toMatchObject({
+      active_session_id: staleSessionId,
+      active_session_summary: {
+        session_id: staleSessionId,
+        status: "waiting_input",
+      },
+      pending_approval_count: 0,
+    });
+
+    const reconcileResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/workspaces/${workspaceId}/reconcile`,
+      payload: {},
+    });
+
+    expect(reconcileResponse.statusCode).toBe(200);
+    expect(reconcileResponse.json()).toMatchObject({
+      active_session_id: activeSessionId,
+      active_session_summary: {
+        session_id: activeSessionId,
+        status: "running",
+      },
+      pending_approval_count: 0,
+    });
+
+    await app.close();
+  });
+
+  it("relinks a missing active session and recomputes pending approval count", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+    });
+
+    const { workspaceId, activeSessionId } = seedWorkspaceRecoveryState(database, {
+      staleSessionId: null,
+      activeSessionStatus: "waiting_approval",
+      pendingApprovalCount: 0,
+      pendingApprovalForActiveSession: true,
+    });
+
+    const beforeResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/workspaces/${workspaceId}`,
+    });
+
+    expect(beforeResponse.statusCode).toBe(200);
+    expect(beforeResponse.json()).toMatchObject({
+      active_session_id: null,
+      active_session_summary: null,
+      pending_approval_count: 0,
+    });
+
+    const reconcileResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/workspaces/${workspaceId}/reconcile`,
+      payload: {},
+    });
+
+    expect(reconcileResponse.statusCode).toBe(200);
+    expect(reconcileResponse.json()).toMatchObject({
+      active_session_id: activeSessionId,
+      active_session_summary: {
+        session_id: activeSessionId,
+        status: "waiting_approval",
+      },
+      pending_approval_count: 1,
     });
 
     await app.close();

--- a/tasks/archive/issue-69-phase-3f-recovery/README.md
+++ b/tasks/archive/issue-69-phase-3f-recovery/README.md
@@ -1,0 +1,61 @@
+# Issue 69 Phase 3F Recovery
+
+## Purpose
+
+- Execute the Phase 3F runtime slice for recovery, reconciliation, and partial-failure handling under Issue #69.
+
+## Primary issue
+
+- Issue: `#69 https://github.com/tsukushibito/codex-webui/issues/69`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_internal_api_v0_8.md`
+- `docs/specs/codex_webui_common_spec_v0_8.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Add the minimum runtime recovery state and reconciliation paths needed to converge app-owned session, approval, and event projection after partial failure.
+- Add the detection and replay logic needed to rebuild recoverable projection from persisted runtime/native facts available in this slice.
+- Add tests that prove the main MVP recovery cases converge to the maintained runtime contract.
+
+## Exit criteria
+
+- Runtime can mark recoverable inconsistencies as pending recovery and reconcile them back to maintained session and approval state.
+- Recovery behavior matches the maintained reconstruction rules for the main partial-failure cases covered by MVP.
+- Tests cover the targeted recovery and reconciliation flows for this slice.
+
+## Work plan
+
+- Review the maintained recovery and reconstruction rules plus current runtime persistence/event boundaries.
+- Implement the smallest recovery state and reconciliation paths that materially advance Issue #69.
+- Add or extend runtime tests for the targeted recovery cases and rerun the runtime validation suite.
+
+## Artifacts / evidence
+
+- Validation: `npm test -- --run tests/session-routes.test.ts`
+- Validation: `npm test -- --run tests/workspace-routes.test.ts`
+- Validation: `npm test`
+- Validation: `npm run build`
+- Evidence: `apps/codex-runtime/tests/session-routes.test.ts`
+- Evidence: `apps/codex-runtime/tests/workspace-routes.test.ts`
+
+## Status / handoff notes
+
+- Status: `completed locally`
+- Notes: `Sprint 1 added recovery_pending detection and POST /api/v1/sessions/{session_id}/reconcile for waiting_approval approval-link mismatches, including repair of stale active_approval_id and pending approval relink. Sprint 2 added POST /api/v1/workspaces/{workspace_id}/reconcile plus workspace-level active_session_id and pending_approval_count recomputation, and surfaced workspace active-session drift as recovery_pending on affected session reads. Local validation passed with npm test -- --run tests/session-routes.test.ts, npm test -- --run tests/workspace-routes.test.ts, npm test, and npm run build.`
+
+### Completion retrospective
+
+- Completion boundary: `Issue #69 package reached local completion and is ready for PR / merge / cleanup tracking.`
+- What worked: `Cutting recovery into approval-link repair first and workspace drift repair second kept the scope testable with the current synthetic gateway and existing route surface.`
+- Workflow problems: `The first worker pass returned a no-op status despite a concrete writable slice, and subagent result collection again needed interrupt-driven follow-up.`
+- Improvements to adopt: `For recovery work, pin the mismatch family, reconcile route, and expected read-path signal in the worker prompt so the first write pass is concrete enough to avoid analysis-only drift.`
+- Skill candidates or skill updates: `None. The current sprint-cycle hardening already covers the no-op worker failure mode that recurred here.`
+- Follow-up updates: `Create PR, merge to main, sync parent checkout, remove the worktree, then close Issue #69 and parent Issue #60 and update Project status.`
+
+## Archive conditions
+
+- Archive this package when the recovery slice exit criteria are met and the handoff notes are updated.


### PR DESCRIPTION
## Summary
- add recovery_pending detection and reconcile flows for approval-link and workspace active-session drift
- extend session and workspace routes with narrow recovery reconciliation endpoints
- archive the Issue #69 task package with retrospective notes

## Validation
- npm test -- --run tests/session-routes.test.ts
- npm test -- --run tests/workspace-routes.test.ts
- npm test
- npm run build

Closes #69
