### PR TITLE
fix(runtime): align phase3 session contract gaps

### DIFF
--- a/apps/codex-runtime/src/domain/sessions/native-session-gateway.ts
+++ b/apps/codex-runtime/src/domain/sessions/native-session-gateway.ts
@@ -16,6 +16,10 @@ export interface NativeSessionGateway {
   sendUserMessage(input: SendNativeSessionMessageInput): Promise<{
     turnId: string;
   }>;
+  cancelPendingApproval(input: {
+    sessionId: string;
+    approvalId: string;
+  }): Promise<void>;
   resolveApproval(input: {
     sessionId: string;
     approvalId: string;
@@ -42,6 +46,10 @@ export class SyntheticNativeSessionGateway implements NativeSessionGateway {
     approvalId: string;
     resolution: "approved" | "denied";
   }) {
+    return;
+  }
+
+  async cancelPendingApproval(_input: { sessionId: string; approvalId: string }) {
     return;
   }
 

--- a/apps/codex-runtime/src/domain/sessions/session-service.ts
+++ b/apps/codex-runtime/src/domain/sessions/session-service.ts
@@ -273,6 +273,37 @@ export class SessionService {
     });
   }
 
+  private markSessionRecoveryPending(input: {
+    sessionId: string;
+    workspaceId: string;
+    updatedAt: string;
+    currentTurnId: string;
+  }) {
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .update(sessions)
+        .set({
+          status: "running",
+          updatedAt: input.updatedAt,
+          lastMessageAt: input.updatedAt,
+          currentTurnId: input.currentTurnId,
+          pendingAssistantMessageId: null,
+          appSessionOverlayState: "recovery_pending",
+        })
+        .where(eq(sessions.sessionId, input.sessionId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          activeSessionId: input.sessionId,
+          updatedAt: input.updatedAt,
+        })
+        .where(eq(workspaces.workspaceId, input.workspaceId))
+        .run();
+    })();
+  }
+
   private getSessionRecord(sessionId: string) {
     return firstRequiredRow(
       this.database.db
@@ -499,25 +530,34 @@ export class SessionService {
 
     const now = toIsoString(this.now());
 
-    this.database.db
-      .update(sessions)
-      .set({
-        status: "running",
-        updatedAt: now,
-        startedAt: session.started_at ?? now,
-        appSessionOverlayState: "open",
-      })
-      .where(eq(sessions.sessionId, sessionId))
-      .run();
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .update(sessions)
+        .set({
+          status: "running",
+          updatedAt: now,
+          startedAt: session.started_at ?? now,
+          appSessionOverlayState: "open",
+        })
+        .where(eq(sessions.sessionId, sessionId))
+        .run();
 
-    this.database.db
-      .update(workspaces)
-      .set({
-        activeSessionId: sessionId,
-        updatedAt: now,
-      })
-      .where(eq(workspaces.workspaceId, session.workspace_id))
-      .run();
+      this.database.db
+        .update(workspaces)
+        .set({
+          activeSessionId: sessionId,
+          updatedAt: now,
+        })
+        .where(eq(workspaces.workspaceId, session.workspace_id))
+        .run();
+
+      this.appendSessionStatusChangedEvent({
+        sessionId,
+        occurredAt: now,
+        fromStatus: session.status,
+        toStatus: "running",
+      });
+    })();
 
     return this.getSession(sessionId);
   }
@@ -551,16 +591,55 @@ export class SessionService {
       });
     }
 
+    let activeApprovalRecord: typeof approvals.$inferSelect | null = null;
+    if (session.status === "waiting_approval" && session.active_approval_id !== null) {
+      activeApprovalRecord = firstRequiredRow(
+        this.database.db
+          .select()
+          .from(approvals)
+          .where(eq(approvals.approvalId, session.active_approval_id))
+          .limit(1)
+          .all(),
+        () => {
+          throw new RuntimeError(
+            404,
+            "approval_not_found",
+            "approval was not found",
+            {
+              approval_id: session.active_approval_id,
+            },
+          );
+        },
+      );
+
+      if (activeApprovalRecord.status === "pending") {
+        await this.nativeSessionGateway.cancelPendingApproval({
+          sessionId,
+          approvalId: activeApprovalRecord.approvalId,
+        });
+      }
+    }
+
     const now = toIsoString(this.now());
     let canceledApproval: ApprovalProjection | null = null;
 
     this.database.sqlite.transaction(() => {
-      if (session.status === "waiting_approval" && session.active_approval_id !== null) {
-        const approval = firstRequiredRow(
+      if (activeApprovalRecord?.status === "pending") {
+        this.database.db
+          .update(approvals)
+          .set({
+            status: "canceled",
+            resolution: "canceled",
+            resolvedAt: now,
+          })
+          .where(eq(approvals.approvalId, activeApprovalRecord.approvalId))
+          .run();
+
+        const updatedApproval = firstRequiredRow(
           this.database.db
             .select()
             .from(approvals)
-            .where(eq(approvals.approvalId, session.active_approval_id))
+            .where(eq(approvals.approvalId, activeApprovalRecord.approvalId))
             .limit(1)
             .all(),
           () => {
@@ -569,56 +648,25 @@ export class SessionService {
               "approval_not_found",
               "approval was not found",
               {
-                approval_id: session.active_approval_id,
+                approval_id: activeApprovalRecord.approvalId,
               },
             );
           },
         );
+        canceledApproval = mapApprovalProjection(updatedApproval);
 
-        if (approval.status === "pending") {
-          this.database.db
-            .update(approvals)
-            .set({
-              status: "canceled",
-              resolution: "canceled",
-              resolvedAt: now,
-            })
-            .where(eq(approvals.approvalId, approval.approvalId))
-            .run();
-
-          const updatedApproval = firstRequiredRow(
-            this.database.db
-              .select()
-              .from(approvals)
-              .where(eq(approvals.approvalId, approval.approvalId))
-              .limit(1)
-              .all(),
-            () => {
-              throw new RuntimeError(
-                404,
-                "approval_not_found",
-                "approval was not found",
-                {
-                  approval_id: approval.approvalId,
-                },
-              );
-            },
-          );
-          canceledApproval = mapApprovalProjection(updatedApproval);
-
-          this.appendSessionEvent({
-            sessionId,
-            eventType: "approval.resolved",
-            occurredAt: now,
-            payload: {
-              approval_id: approval.approvalId,
-              workspace_id: approval.workspaceId,
-              approval_category: approval.approvalCategory,
-              summary: approval.summary,
-              resolution: "canceled",
-            },
-          });
-        }
+        this.appendSessionEvent({
+          sessionId,
+          eventType: "approval.resolved",
+          occurredAt: now,
+          payload: {
+            approval_id: activeApprovalRecord.approvalId,
+            workspace_id: activeApprovalRecord.workspaceId,
+            approval_category: activeApprovalRecord.approvalCategory,
+            summary: activeApprovalRecord.summary,
+            resolution: "canceled",
+          },
+        });
       }
 
       this.database.db
@@ -1111,59 +1159,74 @@ export class SessionService {
     const userMessageId = generateMessageId("user");
     const userCreatedAt = toIsoString(this.now());
 
-    this.database.sqlite.transaction(() => {
-      this.database.db
-        .insert(messages)
-        .values({
-          messageId: userMessageId,
+    try {
+      this.database.sqlite.transaction(() => {
+        this.database.db
+          .insert(messages)
+          .values({
+            messageId: userMessageId,
+            sessionId,
+            role: "user",
+            content: input.content,
+            createdAt: userCreatedAt,
+            sourceItemType: "user_message",
+            clientMessageId: input.client_message_id,
+          })
+          .run();
+
+        this.appendSessionEvent({
           sessionId,
-          role: "user",
-          content: input.content,
-          createdAt: userCreatedAt,
-          sourceItemType: "user_message",
-          clientMessageId: input.client_message_id,
-        })
-        .run();
+          eventType: "message.user",
+          occurredAt: userCreatedAt,
+          payload: {
+            message_id: userMessageId,
+            content: input.content,
+          },
+        });
 
-      this.appendSessionEvent({
-        sessionId,
-        eventType: "message.user",
-        occurredAt: userCreatedAt,
-        payload: {
-          message_id: userMessageId,
-          content: input.content,
-        },
-      });
+        this.database.db
+          .update(sessions)
+          .set({
+            status: "running",
+            updatedAt: userCreatedAt,
+            lastMessageAt: userCreatedAt,
+            currentTurnId: nativeTurn.turnId,
+            pendingAssistantMessageId: null,
+            appSessionOverlayState: "open",
+          })
+          .where(eq(sessions.sessionId, sessionId))
+          .run();
 
-      this.database.db
-        .update(sessions)
-        .set({
-          status: "running",
+        this.database.db
+          .update(workspaces)
+          .set({
+            activeSessionId: sessionId,
+            updatedAt: userCreatedAt,
+          })
+          .where(eq(workspaces.workspaceId, session.workspace_id))
+          .run();
+
+        this.appendSessionStatusChangedEvent({
+          sessionId,
+          occurredAt: userCreatedAt,
+          fromStatus: session.status,
+          toStatus: "running",
+        });
+      })();
+    } catch (error) {
+      try {
+        this.markSessionRecoveryPending({
+          sessionId,
+          workspaceId: session.workspace_id,
           updatedAt: userCreatedAt,
-          lastMessageAt: userCreatedAt,
           currentTurnId: nativeTurn.turnId,
-          pendingAssistantMessageId: null,
-          appSessionOverlayState: "open",
-        })
-        .where(eq(sessions.sessionId, sessionId))
-        .run();
+        });
+      } catch {
+        // Keep the original post-native persistence failure as the primary error.
+      }
 
-      this.database.db
-        .update(workspaces)
-        .set({
-          activeSessionId: sessionId,
-          updatedAt: userCreatedAt,
-        })
-        .where(eq(workspaces.workspaceId, session.workspace_id))
-        .run();
-
-      this.appendSessionStatusChangedEvent({
-        sessionId,
-        occurredAt: userCreatedAt,
-        fromStatus: session.status,
-        toStatus: "running",
-      });
-    })();
+      throw error;
+    }
 
     return {
       message_id: userMessageId,

--- a/apps/codex-runtime/tests/session-routes.test.ts
+++ b/apps/codex-runtime/tests/session-routes.test.ts
@@ -6,7 +6,10 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { buildApp } from "../src/app.js";
 import type { NativeSessionGateway } from "../src/domain/sessions/native-session-gateway.js";
-import { approvals, sessions, workspaces } from "../src/db/schema.js";
+import { SessionService } from "../src/domain/sessions/session-service.js";
+import { WorkspaceFilesystem } from "../src/domain/workspaces/workspace-filesystem.js";
+import { WorkspaceRegistry } from "../src/domain/workspaces/workspace-registry.js";
+import { approvals, messages, sessions, workspaces } from "../src/db/schema.js";
 import { createTempDatabase, createTempWorkspaceRoot } from "./helpers.js";
 
 const cleanupPaths: string[] = [];
@@ -17,6 +20,7 @@ class StubNativeSessionGateway implements NativeSessionGateway {
     private readonly turnIds: string[] = [],
     readonly interrupts: Array<{ sessionId: string; turnId: string }> = [],
     readonly sentMessages: Array<{ sessionId: string; content: string }> = [],
+    readonly canceledApprovals: Array<{ sessionId: string; approvalId: string }> = [],
     readonly resolvedApprovals: Array<{
       sessionId: string;
       approvalId: string;
@@ -48,6 +52,10 @@ class StubNativeSessionGateway implements NativeSessionGateway {
     resolution: "approved" | "denied";
   }) {
     this.resolvedApprovals.push(input);
+  }
+
+  async cancelPendingApproval(input: { sessionId: string; approvalId: string }) {
+    this.canceledApprovals.push(input);
   }
 
   async interruptSessionTurn(input: { sessionId: string; turnId: string }) {
@@ -471,6 +479,25 @@ describe("session routes", () => {
       session_id: "thread_001",
       status: "running",
       started_at: expect.any(String),
+    });
+
+    expect(await listSessionEvents(app, "thread_001")).toEqual({
+      items: [
+        {
+          event_id: expect.any(String),
+          session_id: "thread_001",
+          event_type: "session.status_changed",
+          sequence: 1,
+          occurred_at: startFirst.json().updated_at,
+          payload: {
+            from_status: "created",
+            to_status: "running",
+          },
+          native_event_name: null,
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
     });
 
     const workspaceAfterStart = await app.inject({
@@ -1377,6 +1404,12 @@ describe("session routes", () => {
       resolution: "canceled",
       resolved_at: expect.any(String),
     });
+    expect(nativeSessionGateway.canceledApprovals).toEqual([
+      {
+        sessionId,
+        approvalId: approval.approval_id,
+      },
+    ]);
 
     expect(await listSessionEvents(app, sessionId, "?sort=-occurred_at&limit=2")).toEqual({
       items: [
@@ -1411,6 +1444,111 @@ describe("session routes", () => {
       next_cursor: null,
       has_more: false,
     });
+
+    await app.close();
+  });
+
+  it("surfaces recovery_pending when canonical message persistence fails after native send", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("workspace-root");
+    const database = await createTempDatabase("workspace-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const workspaceFilesystem = new WorkspaceFilesystem(workspaceRoot);
+    const workspaceRegistry = new WorkspaceRegistry(database, workspaceFilesystem);
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+    const sessionService = new SessionService(
+      database,
+      workspaceRegistry,
+      workspaceFilesystem,
+      nativeSessionGateway,
+    );
+    const sessionServiceProbe = sessionService as unknown as Record<string, unknown>;
+    const originalAppendSessionEvent = (
+      sessionServiceProbe.appendSessionEvent as (input: {
+        sessionId: string;
+        eventType: string;
+        occurredAt: string;
+        payload: Record<string, unknown>;
+        nativeEventName?: string | null;
+      }) => void
+    ).bind(sessionService);
+    let failMessageEventAppend = true;
+    sessionServiceProbe.appendSessionEvent = (input: {
+      sessionId: string;
+      eventType: string;
+      occurredAt: string;
+      payload: Record<string, unknown>;
+      nativeEventName?: string | null;
+    }) => {
+      if (failMessageEventAppend && input.eventType === "message.user") {
+        failMessageEventAppend = false;
+        throw new Error("simulated message event persistence failure");
+      }
+
+      return originalAppendSessionEvent(input);
+    };
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        workspaceRegistry,
+        sessionService,
+        nativeSessionGateway,
+      },
+    });
+
+    const { sessionId } = seedWaitingInputSession(database);
+
+    const sendResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/sessions/${sessionId}/messages`,
+      payload: {
+        client_message_id: "msgclient_failure_001",
+        content: "Please explain the diff.",
+      },
+    });
+
+    expect(sendResponse.statusCode).toBe(500);
+    expect(sendResponse.json()).toEqual({
+      error: {
+        code: "internal_server_error",
+        message: "unexpected runtime failure",
+        details: {},
+      },
+    });
+    expect(nativeSessionGateway.sentMessages).toEqual([
+      {
+        sessionId,
+        content: "Please explain the diff.",
+      },
+    ]);
+
+    const sessionResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/sessions/${sessionId}`,
+    });
+
+    expect(sessionResponse.statusCode).toBe(200);
+    expect(sessionResponse.json()).toMatchObject({
+      session_id: sessionId,
+      status: "running",
+      current_turn_id: "turn_001",
+      app_session_overlay_state: "recovery_pending",
+    });
+
+    const persistedMessages = database.db
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, sessionId))
+      .all();
+
+    expect(persistedMessages).toEqual([]);
 
     await app.close();
   });


### PR DESCRIPTION
## Summary
- add native cancel for waiting_approval stop
- append the canonical created -> running session.status_changed event
- surface recovery_pending when message persistence fails after native send

## Validation
- npm test -- --run tests/session-routes.test.ts
- npm test
- npm run build