### PR TITLE
feat(bff): implement phase 4a2 home aggregation

### DIFF
--- a/apps/frontend-bff/app/api/v1/home/route.ts
+++ b/apps/frontend-bff/app/api/v1/home/route.ts
@@ -1,0 +1,5 @@
+import { getHome } from "../../../../src/handlers";
+
+export async function GET(request: Request) {
+  return getHome(request);
+}

--- a/apps/frontend-bff/src/handlers.ts
+++ b/apps/frontend-bff/src/handlers.ts
@@ -16,8 +16,10 @@ import {
 } from "./mappings";
 import { RuntimeClient } from "./runtime-client";
 import type {
+  HomeResponse,
   ListResponse,
   RuntimeApprovalProjection,
+  RuntimeApprovalSummary,
   RuntimeApprovalResolveResult,
   RuntimeMessageProjection,
   RuntimeSessionEventProjection,
@@ -27,6 +29,10 @@ import type {
 } from "./runtime-types";
 
 const runtimeClient = new RuntimeClient();
+
+function latestTimestamp(values: string[]) {
+  return values.reduce((latest, value) => (value > latest ? value : latest));
+}
 
 function forwardSearch(request: Request) {
   return new URL(request.url).search;
@@ -79,6 +85,42 @@ export async function listWorkspaces(request: Request) {
     }
 
     return jsonResponse(result.status, mapWorkspaceList(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getHome(_request: Request) {
+  try {
+    const [workspaceResult, approvalSummaryResult] = await Promise.all([
+      runtimeClient.requestJson<ListResponse<RuntimeWorkspaceSummary>>("/api/v1/workspaces"),
+      runtimeClient.requestJson<RuntimeApprovalSummary>("/api/v1/approvals/summary"),
+    ]);
+
+    if (isErrorEnvelope(workspaceResult.body)) {
+      return passthroughRuntimeError(workspaceResult.status, workspaceResult.body);
+    }
+
+    if (isErrorEnvelope(approvalSummaryResult.body)) {
+      return passthroughRuntimeError(
+        approvalSummaryResult.status,
+        approvalSummaryResult.body,
+      );
+    }
+
+    const workspaces = workspaceResult.body.items.map(mapWorkspace);
+    const updatedAt = latestTimestamp([
+      approvalSummaryResult.body.updated_at,
+      ...workspaces.map((workspace) => workspace.updated_at),
+    ]);
+
+    const response: HomeResponse = {
+      workspaces,
+      pending_approval_count: approvalSummaryResult.body.pending_approval_count,
+      updated_at: updatedAt,
+    };
+
+    return jsonResponse(200, response);
   } catch (error) {
     return toErrorResponse(error);
   }

--- a/apps/frontend-bff/src/runtime-types.ts
+++ b/apps/frontend-bff/src/runtime-types.ts
@@ -94,6 +94,23 @@ export interface RuntimeApprovalSummary {
   updated_at: string;
 }
 
+export interface HomeResponse {
+  workspaces: Array<{
+    workspace_id: string;
+    workspace_name: string;
+    created_at: string;
+    updated_at: string;
+    active_session_summary: {
+      session_id: string;
+      status: string;
+      last_message_at: string | null;
+    } | null;
+    pending_approval_count: number;
+  }>;
+  pending_approval_count: number;
+  updated_at: string;
+}
+
 export interface ListResponse<T> {
   items: T[];
   next_cursor: string | null;

--- a/apps/frontend-bff/tests/routes.test.ts
+++ b/apps/frontend-bff/tests/routes.test.ts
@@ -4,6 +4,7 @@ import {
   approveApproval,
   createSession,
   getApproval,
+  getHome,
   listEvents,
   listWorkspaces,
   stopSession,
@@ -74,6 +75,63 @@ describe("frontend-bff route handlers", () => {
       ],
       next_cursor: null,
       has_more: false,
+    });
+  });
+
+  it("combines workspace summaries and approval summary for the Home response", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              workspace_id: "ws_alpha",
+              workspace_name: "alpha",
+              directory_name: "alpha",
+              created_at: "2026-03-27T05:12:34Z",
+              updated_at: "2026-03-27T05:21:00Z",
+              active_session_id: "thread_001",
+              active_session_summary: {
+                session_id: "thread_001",
+                status: "running",
+                last_message_at: "2026-03-27T05:21:00Z",
+              },
+              pending_approval_count: 1,
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          pending_approval_count: 2,
+          updated_at: "2026-03-27T05:22:00Z",
+        }),
+      );
+
+    const response = await getHome(
+      new Request("http://localhost/api/v1/home"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      workspaces: [
+        {
+          workspace_id: "ws_alpha",
+          workspace_name: "alpha",
+          created_at: "2026-03-27T05:12:34Z",
+          updated_at: "2026-03-27T05:21:00Z",
+          active_session_summary: {
+            session_id: "thread_001",
+            status: "running",
+            last_message_at: "2026-03-27T05:21:00Z",
+          },
+          pending_approval_count: 1,
+        },
+      ],
+      pending_approval_count: 2,
+      updated_at: "2026-03-27T05:22:00Z",
     });
   });
 

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -15,4 +15,5 @@ Archive entries preserve the work instructions that were used at the time, while
 - [app_server_behavior_validation](./app_server_behavior_validation/README.md)
 - [issue-64-phase-3a-foundation](./issue-64-phase-3a-foundation/README.md)
 - [issue-65-phase-3b-session-lifecycle](./issue-65-phase-3b-session-lifecycle/README.md)
+- [issue-78-phase-4a2-home-aggregation](./issue-78-phase-4a2-home-aggregation/README.md)
 - [issue-79-phase-4a1-rest-facade](./issue-79-phase-4a1-rest-facade/README.md)

--- a/tasks/archive/issue-78-phase-4a2-home-aggregation/README.md
+++ b/tasks/archive/issue-78-phase-4a2-home-aggregation/README.md
@@ -1,0 +1,62 @@
+# issue-78-phase-4a2-home-aggregation
+
+## Purpose
+
+Implement the Home aggregation slice under #78 by exposing `GET /api/v1/home` from `frontend-bff`.
+
+## Primary issue
+
+- #78 `Phase 4A-2: Implement Home aggregation and approval summary mapping`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md` section 9.2
+- `docs/specs/codex_webui_public_api_v0_8.md`
+- `docs/specs/codex_webui_internal_api_v0_8.md`
+- `docs/specs/codex_webui_technical_stack_decision_v0_1.md`
+- `apps/README.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Add `GET /api/v1/home` to `apps/frontend-bff/`
+- Combine internal `GET /api/v1/workspaces` and `GET /api/v1/approvals/summary`
+- Return the documented Home aggregation shape
+- Add focused tests for Home initialization and aggregation timestamp behavior
+
+## Exit criteria
+
+- `GET /api/v1/home` returns the maintained public response shape
+- Home data combines workspace summaries and approval summary correctly
+- Targeted tests pass for the Home aggregation slice
+
+## Work plan
+
+1. Inspect the Home aggregation contract in the maintained public/internal specs.
+2. Reuse the existing `frontend-bff` runtime client and workspace mapping.
+3. Add the Home route handler and aggregation logic.
+4. Add focused route tests for the aggregated response.
+5. Validate locally and update handoff notes.
+
+## Artifacts / evidence
+
+- Route and aggregation tests under `apps/frontend-bff/tests/`
+- Command output for targeted validation runs
+
+## Status / handoff notes
+
+- Status: `locally_complete`
+- Notes:
+  - Active worktree created at `.worktrees/issue-78-phase-4a2-home-aggregation`
+  - Package created after `origin/main` sync with the branch/worktree recorded on issue `#78`
+  - Implemented `GET /api/v1/home` in `apps/frontend-bff/` by aggregating runtime workspace and approval summary data
+  - Validation: `npm test`
+  - Validation: `npm run build`
+  - Retrospective:
+    - What worked: the BFF runtime client and workspace mapping added in #79 were reusable as-is.
+    - Workflow problem: none.
+    - Improvement: keep Phase 4A split so Home aggregation stays independent from SSE relay and can land quickly.
+
+## Archive conditions
+
+- Archive this package after the current #78 slice is locally complete, handoff notes are updated, and the execution state is ready to hand off for PR/merge cleanup


### PR DESCRIPTION
## Summary
- add `GET /api/v1/home` to `frontend-bff`
- aggregate runtime workspace data with approval summary for the Home screen initializer
- archive the completed #78 task package

## Validation
- npm test
- npm run build

Closes #78
