### PR TITLE
feat: implement phase 4a3 sse relay

### DIFF
--- a/apps/frontend-bff/app/api/v1/approvals/stream/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/stream/route.ts
@@ -1,0 +1,5 @@
+import { getApprovalStream } from "../../../../../src/handlers";
+
+export async function GET(request: Request) {
+  return getApprovalStream(request);
+}

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stream/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stream/route.ts
@@ -1,0 +1,9 @@
+import { getSessionStream } from "../../../../../../src/handlers";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await context.params;
+  return getSessionStream(request, sessionId);
+}

--- a/apps/frontend-bff/src/handlers.ts
+++ b/apps/frontend-bff/src/handlers.ts
@@ -5,6 +5,8 @@ import {
   mapApprovalDetail,
   mapApprovalList,
   mapApprovalResolveResult,
+  mapApprovalStreamEvent,
+  mapEvent,
   mapEventList,
   mapMessage,
   mapMessageList,
@@ -20,6 +22,7 @@ import type {
   ListResponse,
   RuntimeApprovalProjection,
   RuntimeApprovalSummary,
+  RuntimeApprovalStreamEventProjection,
   RuntimeApprovalResolveResult,
   RuntimeMessageProjection,
   RuntimeSessionEventProjection,
@@ -61,6 +64,115 @@ async function fetchWorkspaceActiveSessionId(workspaceId: string) {
 
 function jsonResponse(status: number, body: unknown) {
   return NextResponse.json(body, { status });
+}
+
+async function parseRuntimeErrorResponse(response: Response) {
+  try {
+    const payload = await response.json();
+    if (isErrorEnvelope(payload)) {
+      return jsonResponse(response.status, payload);
+    }
+  } catch {
+    // fall through
+  }
+
+  return toErrorResponse(
+    new Error("codex-runtime returned an invalid stream error response"),
+  );
+}
+
+function encodeSseData(data: unknown) {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+function mapSseChunk<TInput, TOutput>(
+  chunk: string,
+  mapper: (value: TInput) => TOutput,
+) {
+  const trimmed = chunk.trimEnd();
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  if (trimmed.startsWith(":")) {
+    return `${trimmed}\n\n`;
+  }
+
+  const dataLines = trimmed
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trimStart());
+
+  if (dataLines.length === 0) {
+    return `${trimmed}\n\n`;
+  }
+
+  return encodeSseData(mapper(JSON.parse(dataLines.join("\n")) as TInput));
+}
+
+function createSseRelayStream<TInput, TOutput>(
+  source: ReadableStream<Uint8Array>,
+  mapper: (value: TInput) => TOutput,
+) {
+  const reader = source.getReader();
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        if (buffer.length > 0) {
+          const mappedChunk = mapSseChunk(buffer, mapper);
+          if (mappedChunk.length > 0) {
+            controller.enqueue(encoder.encode(mappedChunk));
+          }
+        }
+        controller.close();
+        return;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      let boundaryIndex = buffer.indexOf("\n\n");
+      while (boundaryIndex >= 0) {
+        const chunk = buffer.slice(0, boundaryIndex);
+        buffer = buffer.slice(boundaryIndex + 2);
+        const mappedChunk = mapSseChunk(chunk, mapper);
+        if (mappedChunk.length > 0) {
+          controller.enqueue(encoder.encode(mappedChunk));
+        }
+        boundaryIndex = buffer.indexOf("\n\n");
+      }
+    },
+    async cancel() {
+      await reader.cancel();
+    },
+  });
+}
+
+async function relaySse<TInput, TOutput>(
+  path: string,
+  mapper: (value: TInput) => TOutput,
+) {
+  const response = await runtimeClient.requestStream(path);
+  if (!response.ok) {
+    return parseRuntimeErrorResponse(response);
+  }
+
+  if (!response.body) {
+    return toErrorResponse(new Error("codex-runtime stream response had no body"));
+  }
+
+  return new Response(createSseRelayStream(response.body, mapper), {
+    status: 200,
+    headers: {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+    },
+  });
 }
 
 function passthroughRuntimeError(
@@ -404,6 +516,28 @@ export async function approveApproval(_request: Request, approvalId: string) {
 export async function denyApproval(_request: Request, approvalId: string) {
   try {
     return await resolveApproval(approvalId, "denied");
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getSessionStream(_request: Request, sessionId: string) {
+  try {
+    return await relaySse<RuntimeSessionEventProjection, ReturnType<typeof mapEvent>>(
+      `/api/v1/sessions/${sessionId}/stream`,
+      mapEvent,
+    );
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getApprovalStream(_request: Request) {
+  try {
+    return await relaySse<
+      RuntimeApprovalStreamEventProjection,
+      ReturnType<typeof mapApprovalStreamEvent>
+    >("/api/v1/approvals/stream", mapApprovalStreamEvent);
   } catch (error) {
     return toErrorResponse(error);
   }

--- a/apps/frontend-bff/src/mappings.ts
+++ b/apps/frontend-bff/src/mappings.ts
@@ -2,6 +2,7 @@ import type {
   ListResponse,
   RuntimeApprovalProjection,
   RuntimeApprovalResolveResult,
+  RuntimeApprovalStreamEventProjection,
   RuntimeMessageProjection,
   RuntimeSessionEventProjection,
   RuntimeSessionSummary,
@@ -132,6 +133,27 @@ export function mapApprovalDetail(approval: RuntimeApprovalProjection) {
     ...mapApprovalSummary(approval),
     operation_summary: approval.operation_summary,
     context: approval.context,
+  };
+}
+
+export function mapApprovalStreamEvent(event: RuntimeApprovalStreamEventProjection) {
+  const payload: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(event.payload)) {
+    if (key === "summary" && typeof value === "string") {
+      payload.title = value;
+      continue;
+    }
+
+    payload[key] = value;
+  }
+
+  return {
+    event_id: event.event_id,
+    session_id: event.session_id,
+    event_type: event.event_type,
+    occurred_at: event.occurred_at,
+    payload,
   };
 }
 

--- a/apps/frontend-bff/src/runtime-client.ts
+++ b/apps/frontend-bff/src/runtime-client.ts
@@ -78,4 +78,30 @@ export class RuntimeClient {
       body: payload as T,
     };
   }
+
+  async requestStream(path: string) {
+    let response: Response;
+    try {
+      response = await fetch(`${this.runtimeBaseUrl}${path}`, {
+        headers: {
+          accept: "text/event-stream",
+        },
+        cache: "no-store",
+      });
+    } catch (error) {
+      throw new BffError(
+        503,
+        "session_runtime_error",
+        "backend dependency temporarily unavailable",
+        {
+          cause:
+            error instanceof Error
+              ? error.message
+              : "failed to connect to codex-runtime",
+        },
+      );
+    }
+
+    return response;
+  }
 }

--- a/apps/frontend-bff/src/runtime-types.ts
+++ b/apps/frontend-bff/src/runtime-types.ts
@@ -94,6 +94,15 @@ export interface RuntimeApprovalSummary {
   updated_at: string;
 }
 
+export interface RuntimeApprovalStreamEventProjection {
+  event_id: string;
+  session_id: string;
+  event_type: "approval.requested" | "approval.resolved";
+  occurred_at: string;
+  payload: Record<string, unknown>;
+  native_event_name: string | null;
+}
+
 export interface HomeResponse {
   workspaces: Array<{
     workspace_id: string;

--- a/apps/frontend-bff/tests/routes.test.ts
+++ b/apps/frontend-bff/tests/routes.test.ts
@@ -4,7 +4,9 @@ import {
   approveApproval,
   createSession,
   getApproval,
+  getApprovalStream,
   getHome,
+  getSessionStream,
   listEvents,
   listWorkspaces,
   stopSession,
@@ -17,6 +19,26 @@ function jsonResponse(body: unknown, status = 200) {
       "content-type": "application/json",
     },
   });
+}
+
+function sseResponse(frames: string[]) {
+  const encoder = new TextEncoder();
+
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const frame of frames) {
+          controller.enqueue(encoder.encode(frame));
+        }
+        controller.close();
+      },
+    }),
+    {
+      headers: {
+        "content-type": "text/event-stream; charset=utf-8",
+      },
+    },
+  );
 }
 
 describe("frontend-bff route handlers", () => {
@@ -472,6 +494,88 @@ describe("frontend-bff route handlers", () => {
       next_cursor: null,
       has_more: false,
     });
+  });
+
+  it("relays session stream events using the public envelope", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      sseResponse([
+        ": connected\n\n",
+        `data: ${JSON.stringify({
+          event_id: "evt_001",
+          session_id: "thread_001",
+          event_type: "message.assistant.delta",
+          sequence: 12,
+          occurred_at: "2026-03-27T05:20:10Z",
+          payload: {
+            message_id: "msg_assistant_003",
+            delta: "Updated the config",
+          },
+          native_event_name: "item/delta",
+        })}\n\n`,
+      ]),
+    );
+
+    const response = await getSessionStream(
+      new Request("http://localhost/api/v1/sessions/thread_001/stream"),
+      "thread_001",
+    );
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    await expect(response.text()).resolves.toContain(
+      `data: ${JSON.stringify({
+        event_id: "evt_001",
+        session_id: "thread_001",
+        event_type: "message.assistant.delta",
+        sequence: 12,
+        occurred_at: "2026-03-27T05:20:10Z",
+        payload: {
+          message_id: "msg_assistant_003",
+          delta: "Updated the config",
+        },
+      })}`,
+    );
+  });
+
+  it("maps approval stream payloads from summary to title", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      sseResponse([
+        `data: ${JSON.stringify({
+          event_id: "evt_apr_001",
+          session_id: "thread_001",
+          event_type: "approval.requested",
+          occurred_at: "2026-03-27T05:18:00Z",
+          payload: {
+            approval_id: "apr_001",
+            workspace_id: "ws_alpha",
+            summary: "Run git push",
+            approval_category: "external_side_effect",
+          },
+          native_event_name: "request/started",
+        })}\n\n`,
+      ]),
+    );
+
+    const response = await getApprovalStream(
+      new Request("http://localhost/api/v1/approvals/stream"),
+    );
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    await expect(response.text()).resolves.toContain(
+      `data: ${JSON.stringify({
+        event_id: "evt_apr_001",
+        session_id: "thread_001",
+        event_type: "approval.requested",
+        occurred_at: "2026-03-27T05:18:00Z",
+        payload: {
+          approval_id: "apr_001",
+          workspace_id: "ws_alpha",
+          title: "Run git push",
+          approval_category: "external_side_effect",
+        },
+      })}`,
+    );
   });
 
   it("returns a public runtime-unavailable error when codex-runtime cannot be reached", async () => {

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -74,3 +74,4 @@ Each active task package `README.md` must include at least the following section
 - [app_server_behavior_validation](./archive/app_server_behavior_validation/README.md)
 - [issue-64-phase-3a-foundation](./archive/issue-64-phase-3a-foundation/README.md)
 - [issue-65-phase-3b-session-lifecycle](./archive/issue-65-phase-3b-session-lifecycle/README.md)
+- [issue-80-phase-4a3-sse-relay](./archive/issue-80-phase-4a3-sse-relay/README.md)

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -17,3 +17,4 @@ Archive entries preserve the work instructions that were used at the time, while
 - [issue-65-phase-3b-session-lifecycle](./issue-65-phase-3b-session-lifecycle/README.md)
 - [issue-78-phase-4a2-home-aggregation](./issue-78-phase-4a2-home-aggregation/README.md)
 - [issue-79-phase-4a1-rest-facade](./issue-79-phase-4a1-rest-facade/README.md)
+- [issue-80-phase-4a3-sse-relay](./issue-80-phase-4a3-sse-relay/README.md)

--- a/tasks/archive/issue-80-phase-4a3-sse-relay/README.md
+++ b/tasks/archive/issue-80-phase-4a3-sse-relay/README.md
@@ -1,0 +1,63 @@
+# issue-80-phase-4a3-sse-relay
+
+## Purpose
+
+Implement the Phase 4A streaming slice under #80 by relaying runtime SSE through `frontend-bff`.
+
+## Primary issue
+
+- #80 `Phase 4A-3: Implement session and approval SSE relay with reacquisition support`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md` section 9.2
+- `docs/specs/codex_webui_public_api_v0_8.md`
+- `docs/specs/codex_webui_internal_api_v0_8.md`
+- `docs/specs/codex_webui_technical_stack_decision_v0_1.md`
+- `apps/README.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Add public session stream relay to `apps/frontend-bff/`
+- Add public approvals stream relay to `apps/frontend-bff/`
+- Map internal SSE envelopes to the public contract shape
+- Add focused tests for session and approvals stream relay behavior
+
+## Exit criteria
+
+- Public session and approvals stream routes emit the maintained public SSE envelopes
+- Public stream payloads omit internal-only fields and apply the documented field mappings
+- Targeted tests pass for the relay behavior
+
+## Work plan
+
+1. Inspect the maintained public/internal SSE contracts.
+2. Reuse the existing `frontend-bff` runtime client and event mapping logic.
+3. Add SSE relay helpers and the two stream route handlers.
+4. Add focused tests for session and approvals stream mapping.
+5. Validate locally and update handoff notes.
+
+## Artifacts / evidence
+
+- Stream relay tests under `apps/frontend-bff/tests/`
+- `npm test` in `apps/frontend-bff/`
+- `npm run build` in `apps/frontend-bff/`
+
+## Status / handoff notes
+
+- Status: `locally_complete`
+- Notes:
+  - Added public session and approval SSE relay handlers in `apps/frontend-bff/`
+  - Verified stream responses keep `text/event-stream` headers and map approval `summary` to public `title`
+  - Validation passed with `npm test` and `npm run build` in `apps/frontend-bff/`
+  - Retrospective:
+    - What worked: existing REST mapping/runtime client structure made the SSE slice small and testable
+    - Workflow problems: none beyond one missing import and one payload-order regression caught by tests before PR creation
+    - Improvements to adopt: keep focused stream tests when adding transport-layer slices so SSE envelope regressions are caught before merge
+    - Skill candidates or skill updates: none
+    - Follow-up updates: archive this package, open PR, merge to `main`, then remove the worktree before closing `#80`
+
+## Archive conditions
+
+- Archive this package after the current #80 slice is locally complete, handoff notes are updated, and the execution state is ready to hand off for PR/merge cleanup


### PR DESCRIPTION
## Summary
- add public session and approvals SSE relay endpoints to frontend-bff
- map runtime stream payloads to the public contract and preserve SSE transport headers
- archive the #80 task package after local validation

## Validation
- npm test
- npm run build

Closes #80