### PR TITLE
feat(frontend-bff): add smartphone home ui shell

### DIFF
--- a/apps/frontend-bff/app/approvals/page.tsx
+++ b/apps/frontend-bff/app/approvals/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function ApprovalPlaceholderPage() {
+  return (
+    <main className="placeholder-shell">
+      <div className="placeholder-card">
+        <p className="eyebrow">Phase 4B-3</p>
+        <h1>Approval screen placeholder</h1>
+        <p>
+          The Approval experience will land in a later UI slice. This route
+          keeps the Home approval navigation live in the meantime.
+        </p>
+        <Link className="text-link" href="/">
+          Back to Home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend-bff/app/chat/page.tsx
+++ b/apps/frontend-bff/app/chat/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function ChatPlaceholderPage() {
+  return (
+    <main className="placeholder-shell">
+      <div className="placeholder-card">
+        <p className="eyebrow">Phase 4B-2</p>
+        <h1>Chat screen placeholder</h1>
+        <p>
+          The Chat experience will land in the next UI slice. This route exists
+          now so Home navigation stays valid.
+        </p>
+        <Link className="text-link" href="/">
+          Back to Home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -1,0 +1,302 @@
+:root {
+  color-scheme: light;
+  --page-bg: #f4efe4;
+  --panel-bg: rgba(255, 252, 245, 0.94);
+  --panel-border: rgba(40, 31, 19, 0.12);
+  --text-main: #23180f;
+  --text-muted: #66584a;
+  --accent: #b84d24;
+  --accent-strong: #8e3110;
+  --accent-soft: #f3dfd1;
+  --success: #2f6b4f;
+  --warning: #8f5b14;
+  --shadow: 0 20px 50px rgba(42, 25, 9, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  background:
+    radial-gradient(circle at top, rgba(255, 255, 255, 0.72), transparent 30%),
+    linear-gradient(180deg, #f7f1e7 0%, var(--page-bg) 100%);
+  color: var(--text-main);
+  font-family:
+    "IBM Plex Sans",
+    "Segoe UI",
+    sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.home-shell,
+.placeholder-shell {
+  display: flex;
+  justify-content: center;
+  padding: 20px 12px 40px;
+}
+
+.home-layout,
+.placeholder-card {
+  width: min(100%, 720px);
+}
+
+.home-layout {
+  display: grid;
+  gap: 16px;
+}
+
+.hero-card,
+.workspace-card,
+.create-card,
+.placeholder-card {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.hero-card {
+  overflow: hidden;
+}
+
+.hero-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-card h1,
+.placeholder-card h1 {
+  margin: 0;
+  font-family:
+    "IBM Plex Serif",
+    Georgia,
+    serif;
+  font-size: clamp(2rem, 6vw, 3.2rem);
+  line-height: 0.95;
+}
+
+.hero-copy,
+.placeholder-card p,
+.workspace-meta,
+.workspace-status,
+.empty-state,
+.error-banner,
+.field-hint,
+.status-message {
+  color: var(--text-muted);
+}
+
+.hero-copy {
+  margin: 0;
+  max-width: 36rem;
+  line-height: 1.5;
+}
+
+.hero-metrics,
+.hero-actions,
+.workspace-actions,
+.workspace-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.metric-chip,
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.metric-chip {
+  background: rgba(35, 24, 15, 0.06);
+}
+
+.status-badge {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.status-badge.success {
+  background: rgba(47, 107, 79, 0.12);
+  color: var(--success);
+}
+
+.status-badge.warning {
+  background: rgba(143, 91, 20, 0.12);
+  color: var(--warning);
+}
+
+.primary-link,
+.secondary-link,
+.submit-button {
+  border-radius: 16px;
+  padding: 12px 16px;
+  font-weight: 700;
+  transition:
+    transform 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.primary-link,
+.submit-button {
+  background: var(--accent);
+  color: #fffaf6;
+}
+
+.secondary-link {
+  background: rgba(35, 24, 15, 0.06);
+  color: var(--text-main);
+}
+
+.primary-link:hover,
+.secondary-link:hover,
+.submit-button:hover {
+  transform: translateY(-1px);
+}
+
+.workspace-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.workspace-card,
+.create-card,
+.placeholder-card {
+  padding: 18px;
+}
+
+.workspace-card h2,
+.create-card h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.workspace-card header,
+.create-card header {
+  display: grid;
+  gap: 8px;
+}
+
+.workspace-meta {
+  margin: 0;
+  font-size: 0.92rem;
+}
+
+.workspace-meta-row {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.workspace-status {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.workspace-actions {
+  margin-top: 14px;
+}
+
+.create-form {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.form-label {
+  display: grid;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.text-input {
+  width: 100%;
+  border: 1px solid rgba(35, 24, 15, 0.14);
+  border-radius: 14px;
+  background: #fffdf8;
+  padding: 12px 14px;
+}
+
+.text-input:focus {
+  outline: 2px solid rgba(184, 77, 36, 0.22);
+  outline-offset: 1px;
+}
+
+.submit-button[disabled] {
+  cursor: wait;
+  opacity: 0.72;
+  transform: none;
+}
+
+.field-hint,
+.status-message,
+.error-banner,
+.empty-state {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.status-message {
+  color: var(--success);
+}
+
+.error-banner {
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(184, 77, 36, 0.08);
+  color: var(--accent-strong);
+}
+
+.placeholder-card {
+  display: grid;
+  gap: 14px;
+}
+
+.text-link {
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+@media (min-width: 720px) {
+  .home-shell,
+  .placeholder-shell {
+    padding: 28px 20px 48px;
+  }
+
+  .hero-body {
+    padding: 28px;
+  }
+}

--- a/apps/frontend-bff/app/layout.tsx
+++ b/apps/frontend-bff/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "codex-webui",
+  description: "Smartphone-first Codex WebUI shell",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/frontend-bff/app/page.tsx
+++ b/apps/frontend-bff/app/page.tsx
@@ -1,0 +1,7 @@
+import { HomePageClient } from "@/src/home-page-client";
+
+export const dynamic = "force-dynamic";
+
+export default function HomePage() {
+  return <HomePageClient />;
+}

--- a/apps/frontend-bff/src/home-data.ts
+++ b/apps/frontend-bff/src/home-data.ts
@@ -1,0 +1,56 @@
+import { isErrorEnvelope } from "./errors";
+import type { HomeResponse, RuntimeWorkspaceSummary } from "./runtime-types";
+
+type FetchLike = typeof fetch;
+
+export interface HomeApiError {
+  code: string;
+  message: string;
+}
+
+export async function fetchHomeData(fetchImpl: FetchLike = fetch) {
+  const response = await fetchImpl("/api/v1/home", {
+    cache: "no-store",
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  const payload = (await response.json()) as unknown;
+  if (!response.ok) {
+    if (isErrorEnvelope(payload)) {
+      throw new Error(payload.error.message);
+    }
+
+    throw new Error("Failed to load Home data.");
+  }
+
+  return payload as HomeResponse;
+}
+
+export async function createWorkspaceFromHome(
+  workspaceName: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl("/api/v1/workspaces", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      workspace_name: workspaceName,
+    }),
+  });
+
+  const payload = (await response.json()) as unknown;
+  if (!response.ok) {
+    if (isErrorEnvelope(payload)) {
+      throw new Error(payload.error.message);
+    }
+
+    throw new Error("Failed to create workspace.");
+  }
+
+  return payload as RuntimeWorkspaceSummary;
+}

--- a/apps/frontend-bff/src/home-page-client.tsx
+++ b/apps/frontend-bff/src/home-page-client.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { createWorkspaceFromHome, fetchHomeData } from "./home-data";
+import { HomeView } from "./home-view";
+import type { HomeResponse } from "./runtime-types";
+
+export function HomePageClient() {
+  const [home, setHome] = useState<HomeResponse | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [workspaceName, setWorkspaceName] = useState("");
+
+  async function loadHome() {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      setHome(await fetchHomeData());
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to load Home data.",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadHome();
+  }, []);
+
+  async function handleCreateWorkspace() {
+    const trimmedName = workspaceName.trim();
+    if (trimmedName.length === 0) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      await createWorkspaceFromHome(trimmedName);
+      setWorkspaceName("");
+      setStatusMessage(`Workspace "${trimmedName}" created.`);
+      await loadHome();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to create workspace.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <HomeView
+      errorMessage={errorMessage}
+      home={home}
+      isLoading={isLoading}
+      isSubmitting={isSubmitting}
+      onCreateWorkspace={handleCreateWorkspace}
+      onWorkspaceNameChange={setWorkspaceName}
+      statusMessage={statusMessage}
+      workspaceName={workspaceName}
+    />
+  );
+}

--- a/apps/frontend-bff/src/home-view.tsx
+++ b/apps/frontend-bff/src/home-view.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import Link from "next/link";
+
+import type { HomeResponse } from "./runtime-types";
+
+export interface HomeViewProps {
+  home: HomeResponse | null;
+  errorMessage: string | null;
+  isLoading: boolean;
+  isSubmitting: boolean;
+  statusMessage: string | null;
+  workspaceName: string;
+  onWorkspaceNameChange: (value: string) => void;
+  onCreateWorkspace: () => void;
+}
+
+function formatSessionStatus(status: string) {
+  return status.replaceAll("_", " ");
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return "No messages yet";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function workspaceChatHref(workspaceId: string, sessionId?: string) {
+  const params = new URLSearchParams({
+    workspaceId,
+  });
+
+  if (sessionId) {
+    params.set("sessionId", sessionId);
+  }
+
+  return `/chat?${params.toString()}`;
+}
+
+export function HomeView({
+  home,
+  errorMessage,
+  isLoading,
+  isSubmitting,
+  statusMessage,
+  workspaceName,
+  onWorkspaceNameChange,
+  onCreateWorkspace,
+}: HomeViewProps) {
+  return (
+    <main className="home-shell">
+      <div className="home-layout">
+        <section className="hero-card">
+          <div className="hero-body">
+            <p className="eyebrow">codex-webui</p>
+            <h1>Home</h1>
+            <p className="hero-copy">
+              Manage workspaces, see active sessions, and jump toward Chat or
+              Approval from a smartphone-first shell.
+            </p>
+            <div className="hero-metrics">
+              <span className="metric-chip">
+                Pending approvals: {home?.pending_approval_count ?? 0}
+              </span>
+              <span className="metric-chip">
+                Workspaces: {home?.workspaces.length ?? 0}
+              </span>
+              <span className="metric-chip">
+                Updated: {home ? formatTimestamp(home.updated_at) : "Waiting"}
+              </span>
+            </div>
+            <div className="hero-actions">
+              <Link className="primary-link" href="/approvals">
+                Open Approval queue
+              </Link>
+              <Link className="secondary-link" href="/chat">
+                Open Chat shell
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="create-card">
+          <header>
+            <p className="eyebrow">Create workspace</p>
+            <h2>Start from Home</h2>
+            <p className="field-hint">
+              Create a workspace, then move into Chat when a session is ready.
+            </p>
+          </header>
+          <div className="create-form">
+            <label className="form-label" htmlFor="workspace-name">
+              Workspace name
+              <input
+                className="text-input"
+                id="workspace-name"
+                name="workspace-name"
+                onChange={(event) => onWorkspaceNameChange(event.target.value)}
+                placeholder="alpha-workspace"
+                value={workspaceName}
+              />
+            </label>
+            <button
+              className="submit-button"
+              disabled={isSubmitting || workspaceName.trim().length === 0}
+              onClick={onCreateWorkspace}
+              type="button"
+            >
+              {isSubmitting ? "Creating workspace..." : "Create workspace"}
+            </button>
+            {statusMessage ? (
+              <p className="status-message">{statusMessage}</p>
+            ) : null}
+          </div>
+        </section>
+
+        {errorMessage ? <p className="error-banner">{errorMessage}</p> : null}
+
+        <section className="workspace-grid">
+          {isLoading && !home ? (
+            <article className="workspace-card">
+              <p className="workspace-status">Loading Home data...</p>
+            </article>
+          ) : null}
+
+          {!isLoading && home && home.workspaces.length === 0 ? (
+            <article className="workspace-card">
+              <p className="empty-state">
+                No workspaces yet. Create one above to start the UI flow.
+              </p>
+            </article>
+          ) : null}
+
+          {home?.workspaces.map((workspace) => {
+            const activeSession = workspace.active_session_summary;
+            const statusClassName = activeSession
+              ? "status-badge success"
+              : "status-badge warning";
+
+            return (
+              <article className="workspace-card" key={workspace.workspace_id}>
+                <header>
+                  <div className="workspace-meta-row">
+                    <p className="eyebrow">Workspace</p>
+                    <span className={statusClassName}>
+                      {activeSession
+                        ? formatSessionStatus(activeSession.status)
+                        : "No active session"}
+                    </span>
+                  </div>
+                  <h2>{workspace.workspace_name}</h2>
+                  <p className="workspace-meta">
+                    Updated {formatTimestamp(workspace.updated_at)}
+                  </p>
+                </header>
+
+                <p className="workspace-status">
+                  {activeSession
+                    ? `Active session ${activeSession.session_id} last moved at ${formatTimestamp(
+                        activeSession.last_message_at,
+                      )}.`
+                    : "This workspace is ready for its first session."}
+                </p>
+
+                <div className="hero-metrics">
+                  <span className="metric-chip">
+                    Local approvals: {workspace.pending_approval_count}
+                  </span>
+                  <span className="metric-chip">
+                    ID: {workspace.workspace_id}
+                  </span>
+                </div>
+
+                <div className="workspace-actions">
+                  <Link
+                    className="primary-link"
+                    href={workspaceChatHref(
+                      workspace.workspace_id,
+                      activeSession?.session_id,
+                    )}
+                  >
+                    Go to Chat
+                  </Link>
+                  <Link className="secondary-link" href="/approvals">
+                    Review approvals
+                  </Link>
+                </div>
+              </article>
+            );
+          })}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend-bff/tests/home-data.test.ts
+++ b/apps/frontend-bff/tests/home-data.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createWorkspaceFromHome, fetchHomeData } from "../src/home-data";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+describe("home data access", () => {
+  it("loads the Home aggregate from the public API", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse({
+        workspaces: [
+          {
+            workspace_id: "ws_alpha",
+            workspace_name: "alpha",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            active_session_summary: null,
+            pending_approval_count: 0,
+          },
+        ],
+        pending_approval_count: 1,
+        updated_at: "2026-03-27T05:22:00Z",
+      }),
+    );
+
+    const result = await fetchHomeData(fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/home", {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+      },
+    });
+    expect(result.pending_approval_count).toBe(1);
+    expect(result.workspaces[0]?.workspace_name).toBe("alpha");
+  });
+
+  it("posts workspace creation through the public workspace endpoint", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse({
+        workspace_id: "ws_alpha",
+        workspace_name: "alpha",
+        directory_name: "alpha",
+        created_at: "2026-03-27T05:12:34Z",
+        updated_at: "2026-03-27T05:12:34Z",
+        active_session_id: null,
+        active_session_summary: null,
+        pending_approval_count: 0,
+      }, 201),
+    );
+
+    const result = await createWorkspaceFromHome("alpha", fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/workspaces", {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        workspace_name: "alpha",
+      }),
+    });
+    expect(result.workspace_name).toBe("alpha");
+  });
+});

--- a/apps/frontend-bff/tests/home-view.test.tsx
+++ b/apps/frontend-bff/tests/home-view.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { HomeView } from "../src/home-view";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("HomeView", () => {
+  it("renders workspace summaries and navigation entry points", () => {
+    const markup = renderToStaticMarkup(
+      <HomeView
+        errorMessage={null}
+        home={{
+          workspaces: [
+            {
+              workspace_id: "ws_alpha",
+              workspace_name: "alpha",
+              created_at: "2026-03-27T05:12:34Z",
+              updated_at: "2026-03-27T05:22:00Z",
+              active_session_summary: {
+                session_id: "thread_001",
+                status: "running",
+                last_message_at: "2026-03-27T05:21:40Z",
+              },
+              pending_approval_count: 2,
+            },
+          ],
+          pending_approval_count: 3,
+          updated_at: "2026-03-27T05:22:00Z",
+        }}
+        isLoading={false}
+        isSubmitting={false}
+        onCreateWorkspace={() => {}}
+        onWorkspaceNameChange={() => {}}
+        statusMessage={null}
+        workspaceName=""
+      />,
+    );
+
+    expect(markup).toContain("Pending approvals: 3");
+    expect(markup).toContain("alpha");
+    expect(markup).toContain("Go to Chat");
+    expect(markup).toContain("Review approvals");
+    expect(markup).toContain("Create workspace");
+  });
+});

--- a/apps/frontend-bff/tsconfig.json
+++ b/apps/frontend-bff/tsconfig.json
@@ -36,8 +36,11 @@
   },
   "include": [
     "app/**/*.ts",
+    "app/**/*.tsx",
     "src/**/*.ts",
+    "src/**/*.tsx",
     "tests/**/*.ts",
+    "tests/**/*.tsx",
     "vitest.config.ts",
     ".next/types/**/*.ts"
   ],

--- a/tasks/archive/issue-84-home-ui-shell/README.md
+++ b/tasks/archive/issue-84-home-ui-shell/README.md
@@ -1,0 +1,60 @@
+# Phase 4B-1 Home UI Shell
+
+## Purpose
+
+- Execute Issue #84 by establishing the smartphone-first Home screen and minimal navigation shell for the Phase 4B UI.
+
+## Primary issue
+
+- Issue: `#84` https://github.com/tsukushibito/codex-webui/issues/84
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md` section 9.3
+- `docs/requirements/codex_webui_mvp_requirements_v0_8.md` section 8
+- `docs/specs/codex_webui_public_api_v0_8.md` sections 5.1, 9.1, and 12.1
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Add the initial UI-rendering foundation in `apps/frontend-bff` for the smartphone-focused WebUI.
+- Implement the Home screen route and layout using the documented public API.
+- Render workspace list, workspace creation entry, active session summaries, and pending approval counts.
+- Provide navigation entry points from Home toward the future Chat and Approval screens.
+- Validate that the Home screen remains usable at 360px width without horizontal scrolling.
+
+## Exit criteria
+
+- The `frontend-bff` app serves the Home UI from the documented public API.
+- Workspace creation and workspace selection are available from the Home screen.
+- Active session summaries and pending approval counts are visible on Home.
+- The Home UI remains usable at smartphone width without horizontal scrolling.
+- Validation evidence is recorded here before archive.
+
+## Work plan
+
+- Audit the existing Next.js app surface in `apps/frontend-bff` and identify the minimum page/layout additions for UI rendering.
+- Implement the Home shell, API consumption, and navigation entry points.
+- Add focused validation for the Home UI behavior and responsive layout.
+- Update handoff notes with validation results and any follow-up constraints for Chat / Approval slices.
+
+## Artifacts / evidence
+
+- Validation passed: `npm test` in `apps/frontend-bff`
+- Validation passed: `npm run build` in `apps/frontend-bff`
+- Responsive/manual verification note: Home uses a single-column shell with `width: min(100%, 720px)`, 12px side padding, and wrapping action rows; no fixed-width UI elements were introduced in the Home slice
+- Remaining check for later slices: end-to-end smartphone interaction should still be rechecked once Chat and Approval screens replace the placeholder routes
+
+## Status / handoff notes
+
+- Status: `locally complete and ready to archive`
+- Notes: `Added the initial App Router UI shell in apps/frontend-bff with Home, placeholder Chat/Approval routes, Home data helpers, and focused Home tests.`
+- Validation: `npm test` passed with 12 tests across route and Home UI/data coverage.
+- Validation: `npm run build` passed and generated the Home, Chat, and Approval app routes.
+- Follow-up constraint: Placeholder routes keep navigation valid for #85 and #86 but do not implement those screens' behavior.
+- Retrospective: Split-first for #62 improved execution clarity; the intake agent mutating GitHub and local state despite read-only instructions was a workflow failure and should not be repeated.
+- Retrospective: The Home slice stayed bounded and reused existing public API routes without backend drift.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, validation evidence is recorded, and the handoff notes are updated for merge/completion tracking.


### PR DESCRIPTION
## Summary
- add the first smartphone-first Home UI shell in `frontend-bff`
- render Home data from the existing public API and support workspace creation from Home
- keep Chat and Approval navigation live with placeholder routes until their slices land

## Validation
- npm test
- npm run build

Closes #84
