### PR TITLE
feat(frontend-bff): implement smartphone chat ui flow

### DIFF
--- a/apps/frontend-bff/app/chat/page.tsx
+++ b/apps/frontend-bff/app/chat/page.tsx
@@ -1,19 +1,7 @@
-import Link from "next/link";
+import { ChatPageClient } from "@/src/chat-page-client";
 
-export default function ChatPlaceholderPage() {
-  return (
-    <main className="placeholder-shell">
-      <div className="placeholder-card">
-        <p className="eyebrow">Phase 4B-2</p>
-        <h1>Chat screen placeholder</h1>
-        <p>
-          The Chat experience will land in the next UI slice. This route exists
-          now so Home navigation stays valid.
-        </p>
-        <Link className="text-link" href="/">
-          Back to Home
-        </Link>
-      </div>
-    </main>
-  );
+export const dynamic = "force-dynamic";
+
+export default function ChatPage() {
+  return <ChatPageClient />;
 }

--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -260,6 +260,114 @@ input {
   transform: none;
 }
 
+.action-button {
+  border: 0;
+  cursor: pointer;
+}
+
+.chat-shell {
+  display: flex;
+  justify-content: center;
+  padding: 20px 12px 40px;
+}
+
+.chat-layout {
+  width: min(100%, 720px);
+  display: grid;
+  gap: 16px;
+}
+
+.chat-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.session-list,
+.chat-message-list,
+.chat-event-list {
+  display: grid;
+  gap: 12px;
+}
+
+.session-summary-card {
+  display: grid;
+  gap: 8px;
+  width: 100%;
+  border: 1px solid var(--panel-border);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.62);
+  padding: 14px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-summary-card.active {
+  border-color: rgba(184, 77, 36, 0.4);
+  background: rgba(243, 223, 209, 0.45);
+}
+
+.chat-composer {
+  display: grid;
+  gap: 12px;
+}
+
+.chat-textarea {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+  border: 1px solid rgba(35, 24, 15, 0.14);
+  border-radius: 16px;
+  background: #fffdf8;
+  padding: 12px 14px;
+}
+
+.chat-textarea:focus {
+  outline: 2px solid rgba(184, 77, 36, 0.22);
+  outline-offset: 1px;
+}
+
+.chat-message,
+.chat-event {
+  display: grid;
+  gap: 8px;
+  border-radius: 20px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.66);
+}
+
+.chat-message.user {
+  border: 1px solid rgba(184, 77, 36, 0.18);
+}
+
+.chat-message.assistant {
+  border: 1px solid rgba(35, 24, 15, 0.08);
+}
+
+.chat-message p,
+.chat-event p,
+.approval-signal {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.approval-signal {
+  border-radius: 16px;
+  background: rgba(143, 91, 20, 0.12);
+  color: var(--warning);
+  padding: 12px 14px;
+  font-weight: 600;
+}
+
+@media (min-width: 720px) {
+  .chat-layout {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .chat-layout > :first-child {
+    grid-column: 1 / -1;
+  }
+}
+
 .field-hint,
 .status-message,
 .error-banner,

--- a/apps/frontend-bff/src/chat-data.ts
+++ b/apps/frontend-bff/src/chat-data.ts
@@ -1,0 +1,176 @@
+import { isErrorEnvelope } from "./errors";
+import type {
+  PublicListResponse,
+  PublicMessage,
+  PublicSessionEvent,
+  PublicSessionSummary,
+  PublicStopResult,
+} from "./chat-types";
+
+type FetchLike = typeof fetch;
+
+async function readJson<T>(response: Response) {
+  const payload = (await response.json()) as unknown;
+
+  if (!response.ok) {
+    if (isErrorEnvelope(payload)) {
+      throw new Error(payload.error.message);
+    }
+
+    throw new Error("Chat request failed.");
+  }
+
+  return payload as T;
+}
+
+export async function listWorkspaceSessions(
+  workspaceId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(
+    `/api/v1/workspaces/${workspaceId}/sessions?sort=-updated_at`,
+    {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+      },
+    },
+  );
+
+  return readJson<PublicListResponse<PublicSessionSummary>>(response);
+}
+
+export async function createSessionFromChat(
+  workspaceId: string,
+  title: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(`/api/v1/workspaces/${workspaceId}/sessions`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ title }),
+  });
+
+  return readJson<PublicSessionSummary>(response);
+}
+
+export async function startSessionFromChat(
+  sessionId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(`/api/v1/sessions/${sessionId}/start`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+
+  return readJson<PublicSessionSummary>(response);
+}
+
+export async function getSessionDetails(
+  sessionId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(`/api/v1/sessions/${sessionId}`, {
+    cache: "no-store",
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  return readJson<PublicSessionSummary>(response);
+}
+
+export async function listSessionMessages(
+  sessionId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(
+    `/api/v1/sessions/${sessionId}/messages?sort=created_at`,
+    {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+      },
+    },
+  );
+
+  return readJson<PublicListResponse<PublicMessage>>(response);
+}
+
+export async function listSessionEvents(
+  sessionId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(
+    `/api/v1/sessions/${sessionId}/events?sort=occurred_at`,
+    {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+      },
+    },
+  );
+
+  return readJson<PublicListResponse<PublicSessionEvent>>(response);
+}
+
+export async function loadChatSessionBundle(
+  sessionId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const [session, messages, events] = await Promise.all([
+    getSessionDetails(sessionId, fetchImpl),
+    listSessionMessages(sessionId, fetchImpl),
+    listSessionEvents(sessionId, fetchImpl),
+  ]);
+
+  return {
+    session,
+    messages: messages.items,
+    events: events.items,
+  };
+}
+
+export async function sendSessionMessage(
+  sessionId: string,
+  content: string,
+  clientMessageId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(`/api/v1/sessions/${sessionId}/messages`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      client_message_id: clientMessageId,
+      content,
+    }),
+  });
+
+  return readJson<PublicMessage>(response);
+}
+
+export async function stopSessionFromChat(
+  sessionId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(`/api/v1/sessions/${sessionId}/stop`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+
+  return readJson<PublicStopResult>(response);
+}

--- a/apps/frontend-bff/src/chat-page-client.tsx
+++ b/apps/frontend-bff/src/chat-page-client.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+import {
+  createSessionFromChat,
+  listWorkspaceSessions,
+  loadChatSessionBundle,
+  sendSessionMessage,
+  startSessionFromChat,
+  stopSessionFromChat,
+} from "./chat-data";
+import type {
+  PublicMessage,
+  PublicSessionEvent,
+  PublicSessionSummary,
+} from "./chat-types";
+import { ChatView } from "./chat-view";
+
+function createClientMessageId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `msgclient_${Date.now()}`;
+}
+
+function upsertSession(
+  sessions: PublicSessionSummary[],
+  nextSession: PublicSessionSummary,
+) {
+  const remaining = sessions.filter(
+    (session) => session.session_id !== nextSession.session_id,
+  );
+
+  return [nextSession, ...remaining];
+}
+
+function upsertMessage(messages: PublicMessage[], nextMessage: PublicMessage) {
+  const existingIndex = messages.findIndex(
+    (message) => message.message_id === nextMessage.message_id,
+  );
+
+  if (existingIndex < 0) {
+    return [...messages, nextMessage];
+  }
+
+  return messages.map((message, index) =>
+    index === existingIndex ? nextMessage : message,
+  );
+}
+
+function upsertEvent(events: PublicSessionEvent[], nextEvent: PublicSessionEvent) {
+  const existingIndex = events.findIndex(
+    (event) => event.event_id === nextEvent.event_id,
+  );
+
+  if (existingIndex < 0) {
+    return [...events, nextEvent].sort((left, right) => left.sequence - right.sequence);
+  }
+
+  return events.map((event, index) => (index === existingIndex ? nextEvent : event));
+}
+
+export function ChatPageClient() {
+  const searchParams = useSearchParams();
+  const workspaceId = searchParams.get("workspaceId");
+  const initialSessionId = searchParams.get("sessionId");
+  const [sessions, setSessions] = useState<PublicSessionSummary[]>([]);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
+    initialSessionId,
+  );
+  const [selectedSession, setSelectedSession] = useState<PublicSessionSummary | null>(
+    null,
+  );
+  const [messages, setMessages] = useState<PublicMessage[]>([]);
+  const [events, setEvents] = useState<PublicSessionEvent[]>([]);
+  const [draftAssistantMessages, setDraftAssistantMessages] = useState<
+    Record<string, string>
+  >({});
+  const [createSessionTitle, setCreateSessionTitle] = useState("");
+  const [messageDraft, setMessageDraft] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [isLoadingSessions, setIsLoadingSessions] = useState(false);
+  const [isLoadingSession, setIsLoadingSession] = useState(false);
+  const [isCreatingSession, setIsCreatingSession] = useState(false);
+  const [isStartingSession, setIsStartingSession] = useState(false);
+  const [isSendingMessage, setIsSendingMessage] = useState(false);
+  const [isStoppingSession, setIsStoppingSession] = useState(false);
+  const [connectionState, setConnectionState] = useState<
+    "idle" | "live" | "reconnecting"
+  >("idle");
+  const [streamVersion, setStreamVersion] = useState(0);
+  const reconnectTimerRef = useRef<number | null>(null);
+
+  async function refreshSessions(preferredSessionId?: string | null) {
+    if (!workspaceId) {
+      setSessions([]);
+      setSelectedSessionId(null);
+      return;
+    }
+
+    setIsLoadingSessions(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await listWorkspaceSessions(workspaceId);
+      setSessions(response.items);
+
+      const nextSelectedId =
+        preferredSessionId && response.items.some((item) => item.session_id === preferredSessionId)
+          ? preferredSessionId
+          : selectedSessionId &&
+              response.items.some((item) => item.session_id === selectedSessionId)
+            ? selectedSessionId
+            : initialSessionId &&
+                response.items.some((item) => item.session_id === initialSessionId)
+              ? initialSessionId
+              : response.items[0]?.session_id ?? null;
+
+      setSelectedSessionId(nextSelectedId);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to load sessions.",
+      );
+    } finally {
+      setIsLoadingSessions(false);
+    }
+  }
+
+  async function refreshSelectedSession(sessionId: string) {
+    setIsLoadingSession(true);
+    setErrorMessage(null);
+
+    try {
+      const bundle = await loadChatSessionBundle(sessionId);
+      setSelectedSession(bundle.session);
+      setMessages(bundle.messages);
+      setEvents(bundle.events);
+      setDraftAssistantMessages({});
+      setSessions((currentSessions) => upsertSession(currentSessions, bundle.session));
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to load the selected session.",
+      );
+    } finally {
+      setIsLoadingSession(false);
+    }
+  }
+
+  useEffect(() => {
+    void refreshSessions(initialSessionId);
+  }, [workspaceId, initialSessionId]);
+
+  useEffect(() => {
+    if (!selectedSessionId) {
+      setSelectedSession(null);
+      setMessages([]);
+      setEvents([]);
+      setDraftAssistantMessages({});
+      setConnectionState("idle");
+      return;
+    }
+
+    void refreshSelectedSession(selectedSessionId);
+  }, [selectedSessionId]);
+
+  useEffect(() => {
+    if (!selectedSessionId) {
+      return;
+    }
+
+    const stream = new EventSource(`/api/v1/sessions/${selectedSessionId}/stream`);
+    setConnectionState("live");
+
+    stream.onmessage = (messageEvent) => {
+      const event = JSON.parse(messageEvent.data) as PublicSessionEvent;
+      setEvents((currentEvents) => upsertEvent(currentEvents, event));
+
+      if (event.event_type === "session.status_changed") {
+        const toStatus = event.payload.to_status;
+        if (typeof toStatus === "string") {
+          setSelectedSession((currentSession) =>
+            currentSession
+              ? {
+                  ...currentSession,
+                  status: toStatus as PublicSessionSummary["status"],
+                  updated_at: event.occurred_at,
+                }
+              : currentSession,
+          );
+          setSessions((currentSessions) =>
+            currentSessions.map((session) =>
+              session.session_id === selectedSessionId
+                ? {
+                    ...session,
+                    status: toStatus as PublicSessionSummary["status"],
+                    updated_at: event.occurred_at,
+                  }
+                : session,
+            ),
+          );
+        }
+      }
+
+      if (event.event_type === "message.user") {
+        const messageId = event.payload.message_id;
+        const content = event.payload.content;
+        if (typeof messageId === "string" && typeof content === "string") {
+          setMessages((currentMessages) =>
+            upsertMessage(currentMessages, {
+              message_id: messageId,
+              session_id: event.session_id,
+              role: "user",
+              content,
+              created_at: event.occurred_at,
+            }),
+          );
+        }
+      }
+
+      if (event.event_type === "message.assistant.delta") {
+        const messageId = event.payload.message_id;
+        const delta = event.payload.delta;
+        if (typeof messageId === "string" && typeof delta === "string") {
+          setDraftAssistantMessages((currentDrafts) => ({
+            ...currentDrafts,
+            [messageId]: `${currentDrafts[messageId] ?? ""}${delta}`,
+          }));
+        }
+      }
+
+      if (event.event_type === "message.assistant.completed") {
+        const messageId = event.payload.message_id;
+        const content = event.payload.content;
+        const createdAt = event.payload.created_at;
+        if (
+          typeof messageId === "string" &&
+          typeof content === "string" &&
+          typeof createdAt === "string"
+        ) {
+          setDraftAssistantMessages((currentDrafts) => {
+            const nextDrafts = { ...currentDrafts };
+            delete nextDrafts[messageId];
+            return nextDrafts;
+          });
+          setMessages((currentMessages) =>
+            upsertMessage(currentMessages, {
+              message_id: messageId,
+              session_id: event.session_id,
+              role: "assistant",
+              content,
+              created_at: createdAt,
+            }),
+          );
+        }
+      }
+
+      if (event.event_type === "approval.requested") {
+        const approvalId = event.payload.approval_id;
+        setStatusMessage("Approval requested. Review the pending action when needed.");
+        if (typeof approvalId === "string") {
+          setSelectedSession((currentSession) =>
+            currentSession
+              ? {
+                  ...currentSession,
+                  active_approval_id: approvalId,
+                  status: "waiting_approval",
+                }
+              : currentSession,
+          );
+        }
+      }
+
+      if (event.event_type === "approval.resolved") {
+        setStatusMessage("Approval resolved.");
+        setSelectedSession((currentSession) =>
+          currentSession
+            ? {
+                ...currentSession,
+                active_approval_id: null,
+              }
+            : currentSession,
+        );
+      }
+    };
+
+    stream.onerror = () => {
+      stream.close();
+      setConnectionState("reconnecting");
+      void refreshSelectedSession(selectedSessionId).finally(() => {
+        if (reconnectTimerRef.current !== null) {
+          window.clearTimeout(reconnectTimerRef.current);
+        }
+        reconnectTimerRef.current = window.setTimeout(() => {
+          setStreamVersion((currentValue) => currentValue + 1);
+        }, 1000);
+      });
+    };
+
+    return () => {
+      stream.close();
+      if (reconnectTimerRef.current !== null) {
+        window.clearTimeout(reconnectTimerRef.current);
+      }
+    };
+  }, [selectedSessionId, streamVersion]);
+
+  async function handleCreateSession() {
+    if (!workspaceId) {
+      return;
+    }
+
+    const trimmedTitle = createSessionTitle.trim();
+    if (trimmedTitle.length === 0) {
+      return;
+    }
+
+    setIsCreatingSession(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const nextSession = await createSessionFromChat(workspaceId, trimmedTitle);
+      setCreateSessionTitle("");
+      setSessions((currentSessions) => upsertSession(currentSessions, nextSession));
+      setSelectedSessionId(nextSession.session_id);
+      setStatusMessage(`Session "${trimmedTitle}" created.`);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to create a session.",
+      );
+    } finally {
+      setIsCreatingSession(false);
+    }
+  }
+
+  async function handleStartSession() {
+    if (!selectedSessionId) {
+      return;
+    }
+
+    setIsStartingSession(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const nextSession = await startSessionFromChat(selectedSessionId);
+      setSelectedSession(nextSession);
+      setSessions((currentSessions) => upsertSession(currentSessions, nextSession));
+      await refreshSelectedSession(selectedSessionId);
+      setStatusMessage("Session started.");
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to start the session.",
+      );
+    } finally {
+      setIsStartingSession(false);
+    }
+  }
+
+  async function handleSendMessage() {
+    if (!selectedSessionId) {
+      return;
+    }
+
+    const trimmedMessage = messageDraft.trim();
+    if (trimmedMessage.length === 0) {
+      return;
+    }
+
+    setIsSendingMessage(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const message = await sendSessionMessage(
+        selectedSessionId,
+        trimmedMessage,
+        createClientMessageId(),
+      );
+      setMessages((currentMessages) => upsertMessage(currentMessages, message));
+      setMessageDraft("");
+      setStatusMessage("Message accepted. Waiting for stream updates.");
+      setSelectedSession((currentSession) =>
+        currentSession
+          ? {
+              ...currentSession,
+              status: "running",
+              updated_at: message.created_at,
+              last_message_at: message.created_at,
+            }
+          : currentSession,
+      );
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to send the message.",
+      );
+    } finally {
+      setIsSendingMessage(false);
+    }
+  }
+
+  async function handleStopSession() {
+    if (!selectedSessionId) {
+      return;
+    }
+
+    setIsStoppingSession(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const result = await stopSessionFromChat(selectedSessionId);
+      setSelectedSession(result.session);
+      setSessions((currentSessions) => upsertSession(currentSessions, result.session));
+      setStatusMessage(
+        result.canceled_approval
+          ? `Session stopped and approval ${result.canceled_approval.approval_id} was canceled.`
+          : "Session stopped.",
+      );
+      await refreshSelectedSession(selectedSessionId);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to stop the session.",
+      );
+    } finally {
+      setIsStoppingSession(false);
+    }
+  }
+
+  return (
+    <ChatView
+      connectionState={connectionState}
+      createSessionTitle={createSessionTitle}
+      draftAssistantMessages={Object.entries(draftAssistantMessages).map(
+        ([messageId, content]) => ({
+          message_id: messageId,
+          content,
+        }),
+      )}
+      errorMessage={errorMessage}
+      events={events}
+      isCreatingSession={isCreatingSession}
+      isLoadingSession={isLoadingSession}
+      isLoadingSessions={isLoadingSessions}
+      isSendingMessage={isSendingMessage}
+      isStartingSession={isStartingSession}
+      isStoppingSession={isStoppingSession}
+      messageDraft={messageDraft}
+      messages={messages}
+      onCreateSession={handleCreateSession}
+      onCreateSessionTitleChange={setCreateSessionTitle}
+      onMessageDraftChange={setMessageDraft}
+      onSelectSession={setSelectedSessionId}
+      onSendMessage={handleSendMessage}
+      onStartSession={handleStartSession}
+      onStopSession={handleStopSession}
+      selectedSession={selectedSession}
+      selectedSessionId={selectedSessionId}
+      sessions={sessions}
+      statusMessage={statusMessage}
+      workspaceId={workspaceId}
+    />
+  );
+}

--- a/apps/frontend-bff/src/chat-types.ts
+++ b/apps/frontend-bff/src/chat-types.ts
@@ -1,0 +1,73 @@
+export interface PublicSessionSummary {
+  session_id: string;
+  workspace_id: string;
+  title: string;
+  status:
+    | "created"
+    | "running"
+    | "waiting_input"
+    | "waiting_approval"
+    | "completed"
+    | "failed"
+    | "stopped";
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  last_message_at: string | null;
+  active_approval_id: string | null;
+  can_send_message: boolean;
+  can_start: boolean;
+  can_stop: boolean;
+}
+
+export interface PublicMessage {
+  message_id: string;
+  session_id: string;
+  role: "user" | "assistant";
+  content: string;
+  created_at: string;
+}
+
+export interface PublicSessionEvent {
+  event_id: string;
+  session_id: string;
+  event_type:
+    | "session.status_changed"
+    | "message.user"
+    | "message.assistant.delta"
+    | "message.assistant.completed"
+    | "approval.requested"
+    | "approval.resolved"
+    | "error.raised";
+  sequence: number;
+  occurred_at: string;
+  payload: Record<string, unknown>;
+}
+
+export interface PublicApprovalSummary {
+  approval_id: string;
+  session_id: string;
+  workspace_id: string;
+  status: "pending" | "approved" | "denied" | "canceled";
+  resolution: "approved" | "denied" | "canceled" | null;
+  approval_category:
+    | "destructive_change"
+    | "external_side_effect"
+    | "network_access"
+    | "privileged_execution";
+  title: string;
+  description: string;
+  requested_at: string;
+  resolved_at: string | null;
+}
+
+export interface PublicStopResult {
+  session: PublicSessionSummary;
+  canceled_approval: PublicApprovalSummary | null;
+}
+
+export interface PublicListResponse<T> {
+  items: T[];
+  next_cursor: string | null;
+  has_more: boolean;
+}

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -1,0 +1,406 @@
+import React from "react";
+import Link from "next/link";
+
+import type {
+  PublicMessage,
+  PublicSessionEvent,
+  PublicSessionSummary,
+} from "./chat-types";
+
+export interface DraftAssistantMessage {
+  message_id: string;
+  content: string;
+}
+
+export interface ChatViewProps {
+  workspaceId: string | null;
+  sessions: PublicSessionSummary[];
+  selectedSessionId: string | null;
+  selectedSession: PublicSessionSummary | null;
+  messages: PublicMessage[];
+  events: PublicSessionEvent[];
+  draftAssistantMessages: DraftAssistantMessage[];
+  isLoadingSessions: boolean;
+  isLoadingSession: boolean;
+  isCreatingSession: boolean;
+  isStartingSession: boolean;
+  isSendingMessage: boolean;
+  isStoppingSession: boolean;
+  connectionState: "idle" | "live" | "reconnecting";
+  errorMessage: string | null;
+  statusMessage: string | null;
+  createSessionTitle: string;
+  messageDraft: string;
+  onCreateSessionTitleChange: (value: string) => void;
+  onMessageDraftChange: (value: string) => void;
+  onCreateSession: () => void;
+  onSelectSession: (sessionId: string) => void;
+  onStartSession: () => void;
+  onSendMessage: () => void;
+  onStopSession: () => void;
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return "Not available";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatSessionStatus(status: string) {
+  return status.replaceAll("_", " ");
+}
+
+function eventSummary(event: PublicSessionEvent) {
+  switch (event.event_type) {
+    case "session.status_changed":
+      return `${String(event.payload.from_status ?? "unknown")} -> ${String(
+        event.payload.to_status ?? "unknown",
+      )}`;
+    case "message.assistant.delta":
+      return String(event.payload.delta ?? "assistant typing");
+    case "message.assistant.completed":
+      return String(event.payload.content ?? "assistant response completed");
+    case "approval.requested":
+      return String(event.payload.title ?? "approval requested");
+    case "approval.resolved":
+      return "approval resolved";
+    case "error.raised":
+      return String(event.payload.message ?? "session error");
+    default:
+      return event.event_type;
+  }
+}
+
+function sessionBadgeClass(session: PublicSessionSummary) {
+  if (session.status === "waiting_approval") {
+    return "status-badge warning";
+  }
+
+  if (
+    session.status === "running" ||
+    session.status === "waiting_input" ||
+    session.status === "completed"
+  ) {
+    return "status-badge success";
+  }
+
+  return "status-badge";
+}
+
+export function ChatView({
+  workspaceId,
+  sessions,
+  selectedSessionId,
+  selectedSession,
+  messages,
+  events,
+  draftAssistantMessages,
+  isLoadingSessions,
+  isLoadingSession,
+  isCreatingSession,
+  isStartingSession,
+  isSendingMessage,
+  isStoppingSession,
+  connectionState,
+  errorMessage,
+  statusMessage,
+  createSessionTitle,
+  messageDraft,
+  onCreateSessionTitleChange,
+  onMessageDraftChange,
+  onCreateSession,
+  onSelectSession,
+  onStartSession,
+  onSendMessage,
+  onStopSession,
+}: ChatViewProps) {
+  const allMessages = [
+    ...messages,
+    ...draftAssistantMessages.map((message) => ({
+      message_id: message.message_id,
+      session_id: selectedSessionId ?? "",
+      role: "assistant" as const,
+      content: `${message.content}…`,
+      created_at: selectedSession?.updated_at ?? new Date().toISOString(),
+    })),
+  ];
+
+  return (
+    <main className="chat-shell">
+      <div className="chat-layout">
+        <section className="hero-card">
+          <div className="hero-body">
+            <p className="eyebrow">codex-webui</p>
+            <h1>Chat</h1>
+            <p className="hero-copy">
+              Run a workspace session, watch stream updates, and re-acquire state
+              after disconnects from one smartphone-first screen.
+            </p>
+            <div className="hero-metrics">
+              <span className="metric-chip">
+                Workspace: {workspaceId ?? "Choose from Home"}
+              </span>
+              <span className="metric-chip">
+                Stream: {connectionState === "live"
+                  ? "live"
+                  : connectionState === "reconnecting"
+                    ? "reacquiring"
+                    : "idle"}
+              </span>
+              <span className="metric-chip">
+                Sessions: {sessions.length}
+              </span>
+            </div>
+            <div className="hero-actions">
+              <Link className="secondary-link" href="/">
+                Back to Home
+              </Link>
+              <Link className="primary-link" href="/approvals">
+                Approval queue
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {!workspaceId ? (
+          <section className="placeholder-card">
+            <p className="eyebrow">Missing workspace</p>
+            <h1>Start from Home</h1>
+            <p>
+              Open Chat from the Home workspace cards so the workspace context is
+              already selected.
+            </p>
+          </section>
+        ) : null}
+
+        {errorMessage ? <p className="error-banner">{errorMessage}</p> : null}
+        {statusMessage ? <p className="status-message">{statusMessage}</p> : null}
+
+        {workspaceId ? (
+          <>
+            <section className="chat-panel create-card">
+              <header>
+                <p className="eyebrow">Sessions</p>
+                <h2>Create or select a session</h2>
+                <p className="field-hint">
+                  Pick an existing session or create a new one before starting the
+                  chat flow.
+                </p>
+              </header>
+
+              <div className="create-form">
+                <label className="form-label" htmlFor="session-title">
+                  New session title
+                  <input
+                    className="text-input"
+                    id="session-title"
+                    name="session-title"
+                    onChange={(event) => onCreateSessionTitleChange(event.target.value)}
+                    placeholder="Fix build error"
+                    value={createSessionTitle}
+                  />
+                </label>
+                <button
+                  className="submit-button"
+                  disabled={isCreatingSession || createSessionTitle.trim().length === 0}
+                  onClick={onCreateSession}
+                  type="button"
+                >
+                  {isCreatingSession ? "Creating session..." : "Create session"}
+                </button>
+              </div>
+
+              <div className="session-list">
+                {isLoadingSessions ? (
+                  <p className="workspace-status">Loading sessions...</p>
+                ) : null}
+
+                {!isLoadingSessions && sessions.length === 0 ? (
+                  <p className="empty-state">
+                    No sessions yet. Create one above to start the Chat flow.
+                  </p>
+                ) : null}
+
+                {sessions.map((session) => (
+                  <button
+                    className={
+                      selectedSessionId === session.session_id
+                        ? "session-summary-card active"
+                        : "session-summary-card"
+                    }
+                    key={session.session_id}
+                    onClick={() => onSelectSession(session.session_id)}
+                    type="button"
+                  >
+                    <div className="workspace-meta-row">
+                      <p className="eyebrow">Session</p>
+                      <span className={sessionBadgeClass(session)}>
+                        {formatSessionStatus(session.status)}
+                      </span>
+                    </div>
+                    <strong>{session.title}</strong>
+                    <span className="workspace-meta">
+                      Updated {formatTimestamp(session.updated_at)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            <section className="chat-panel workspace-card">
+              <header>
+                <div className="workspace-meta-row">
+                  <p className="eyebrow">Current session</p>
+                  {selectedSession ? (
+                    <span className={sessionBadgeClass(selectedSession)}>
+                      {formatSessionStatus(selectedSession.status)}
+                    </span>
+                  ) : null}
+                </div>
+                <h2>{selectedSession?.title ?? "Select a session"}</h2>
+                <p className="workspace-meta">
+                  {selectedSession
+                    ? `Last message ${formatTimestamp(selectedSession.last_message_at)}`
+                    : "Pick a session from the list to load messages and activity."}
+                </p>
+              </header>
+
+              {selectedSession?.active_approval_id ? (
+                <p className="approval-signal">
+                  Approval waiting: {selectedSession.active_approval_id}
+                </p>
+              ) : null}
+
+              <div className="workspace-actions">
+                <button
+                  className="primary-link action-button"
+                  disabled={
+                    !selectedSession || !selectedSession.can_start || isStartingSession
+                  }
+                  onClick={onStartSession}
+                  type="button"
+                >
+                  {isStartingSession ? "Starting..." : "Start session"}
+                </button>
+                <button
+                  className="secondary-link action-button"
+                  disabled={!selectedSession || !selectedSession.can_stop || isStoppingSession}
+                  onClick={onStopSession}
+                  type="button"
+                >
+                  {isStoppingSession ? "Stopping..." : "Stop session"}
+                </button>
+              </div>
+
+              <div className="chat-composer">
+                <label className="form-label" htmlFor="message-input">
+                  Send message
+                  <textarea
+                    className="chat-textarea"
+                    id="message-input"
+                    name="message-input"
+                    onChange={(event) => onMessageDraftChange(event.target.value)}
+                    placeholder="Ask Codex to review a diff or explain a build issue."
+                    rows={4}
+                    value={messageDraft}
+                  />
+                </label>
+                <button
+                  className="submit-button"
+                  disabled={
+                    !selectedSession ||
+                    !selectedSession.can_send_message ||
+                    isSendingMessage ||
+                    messageDraft.trim().length === 0
+                  }
+                  onClick={onSendMessage}
+                  type="button"
+                >
+                  {isSendingMessage ? "Sending..." : "Send message"}
+                </button>
+              </div>
+            </section>
+
+            <section className="chat-panel workspace-card">
+              <header>
+                <p className="eyebrow">Transcript</p>
+                <h2>Messages</h2>
+                <p className="field-hint">
+                  User and assistant messages are restored from the public message
+                  history, with assistant delta streamed into the latest bubble.
+                </p>
+              </header>
+
+              {isLoadingSession ? (
+                <p className="workspace-status">Refreshing session detail...</p>
+              ) : null}
+
+              <div className="chat-message-list">
+                {!isLoadingSession && allMessages.length === 0 ? (
+                  <p className="empty-state">
+                    No chat messages yet. Start the session and send a message to
+                    begin.
+                  </p>
+                ) : null}
+
+                {allMessages.map((message) => (
+                  <article
+                    className={
+                      message.role === "assistant"
+                        ? "chat-message assistant"
+                        : "chat-message user"
+                    }
+                    key={message.message_id}
+                  >
+                    <div className="workspace-meta-row">
+                      <strong>{message.role === "assistant" ? "Assistant" : "You"}</strong>
+                      <span className="workspace-meta">
+                        {formatTimestamp(message.created_at)}
+                      </span>
+                    </div>
+                    <p>{message.content}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="chat-panel workspace-card">
+              <header>
+                <p className="eyebrow">Activity</p>
+                <h2>Event log</h2>
+                <p className="field-hint">
+                  Session events stay ordered by sequence and are re-acquired after
+                  stream disconnects.
+                </p>
+              </header>
+
+              <div className="chat-event-list">
+                {!isLoadingSession && events.length === 0 ? (
+                  <p className="empty-state">No activity yet for this session.</p>
+                ) : null}
+
+                {events.map((event) => (
+                  <article className="chat-event" key={event.event_id}>
+                    <div className="workspace-meta-row">
+                      <strong>{event.event_type}</strong>
+                      <span className="workspace-meta">#{event.sequence}</span>
+                    </div>
+                    <p>{eventSummary(event)}</p>
+                    <span className="workspace-meta">
+                      {formatTimestamp(event.occurred_at)}
+                    </span>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend-bff/tests/chat-data.test.ts
+++ b/apps/frontend-bff/tests/chat-data.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createSessionFromChat,
+  listWorkspaceSessions,
+  loadChatSessionBundle,
+  sendSessionMessage,
+} from "../src/chat-data";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+describe("chat data access", () => {
+  it("loads workspace sessions from the public API", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            session_id: "thread_001",
+            workspace_id: "ws_alpha",
+            title: "Fix build error",
+            status: "waiting_input",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            started_at: "2026-03-27T05:13:00Z",
+            last_message_at: "2026-03-27T05:21:40Z",
+            active_approval_id: null,
+            can_send_message: true,
+            can_start: false,
+            can_stop: true,
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      }),
+    );
+
+    const result = await listWorkspaceSessions("ws_alpha", fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/workspaces/ws_alpha/sessions?sort=-updated_at",
+      {
+        cache: "no-store",
+        headers: {
+          accept: "application/json",
+        },
+      },
+    );
+    expect(result.items[0]?.session_id).toBe("thread_001");
+  });
+
+  it("creates sessions and sends messages through the public API", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            session_id: "thread_002",
+            workspace_id: "ws_alpha",
+            title: "Review docs",
+            status: "created",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:12:34Z",
+            started_at: null,
+            last_message_at: null,
+            active_approval_id: null,
+            can_send_message: false,
+            can_start: true,
+            can_stop: false,
+          },
+          201,
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            message_id: "msg_user_001",
+            session_id: "thread_002",
+            role: "user",
+            content: "Please explain the changes.",
+            created_at: "2026-03-27T05:15:00Z",
+          },
+          202,
+        ),
+      );
+
+    const session = await createSessionFromChat("ws_alpha", "Review docs", fetchMock);
+    const message = await sendSessionMessage(
+      "thread_002",
+      "Please explain the changes.",
+      "msgclient_001",
+      fetchMock,
+    );
+
+    expect(session.title).toBe("Review docs");
+    expect(message.message_id).toBe("msg_user_001");
+  });
+
+  it("loads session, messages, and events in parallel for a chat refresh", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          session_id: "thread_001",
+          workspace_id: "ws_alpha",
+          title: "Fix build error",
+          status: "waiting_input",
+          created_at: "2026-03-27T05:12:34Z",
+          updated_at: "2026-03-27T05:22:00Z",
+          started_at: "2026-03-27T05:13:00Z",
+          last_message_at: "2026-03-27T05:21:40Z",
+          active_approval_id: null,
+          can_send_message: true,
+          can_start: false,
+          can_stop: true,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [],
+          next_cursor: null,
+          has_more: false,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              event_id: "evt_001",
+              session_id: "thread_001",
+              event_type: "session.status_changed",
+              sequence: 1,
+              occurred_at: "2026-03-27T05:13:00Z",
+              payload: {
+                from_status: "created",
+                to_status: "running",
+              },
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
+        }),
+      );
+
+    const bundle = await loadChatSessionBundle("thread_001", fetchMock);
+
+    expect(bundle.session.session_id).toBe("thread_001");
+    expect(bundle.events[0]?.event_type).toBe("session.status_changed");
+  });
+});

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatView } from "../src/chat-view";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("ChatView", () => {
+  it("renders the chat transcript, activity log, and approval waiting signal", () => {
+    const markup = renderToStaticMarkup(
+      <ChatView
+        connectionState="live"
+        createSessionTitle=""
+        draftAssistantMessages={[
+          {
+            message_id: "draft_001",
+            content: "Streaming update",
+          },
+        ]}
+        errorMessage={null}
+        events={[
+          {
+            event_id: "evt_001",
+            session_id: "thread_001",
+            event_type: "approval.requested",
+            sequence: 3,
+            occurred_at: "2026-03-27T05:18:00Z",
+            payload: {
+              approval_id: "apr_001",
+              title: "Run git push",
+            },
+          },
+        ]}
+        isCreatingSession={false}
+        isLoadingSession={false}
+        isLoadingSessions={false}
+        isSendingMessage={false}
+        isStartingSession={false}
+        isStoppingSession={false}
+        messageDraft=""
+        messages={[
+          {
+            message_id: "msg_user_001",
+            session_id: "thread_001",
+            role: "user",
+            content: "Please explain the diff.",
+            created_at: "2026-03-27T05:14:00Z",
+          },
+        ]}
+        onCreateSession={() => {}}
+        onCreateSessionTitleChange={() => {}}
+        onMessageDraftChange={() => {}}
+        onSelectSession={() => {}}
+        onSendMessage={() => {}}
+        onStartSession={() => {}}
+        onStopSession={() => {}}
+        selectedSession={{
+          session_id: "thread_001",
+          workspace_id: "ws_alpha",
+          title: "Fix build error",
+          status: "waiting_approval",
+          created_at: "2026-03-27T05:12:34Z",
+          updated_at: "2026-03-27T05:22:00Z",
+          started_at: "2026-03-27T05:13:00Z",
+          last_message_at: "2026-03-27T05:21:40Z",
+          active_approval_id: "apr_001",
+          can_send_message: false,
+          can_start: false,
+          can_stop: true,
+        }}
+        selectedSessionId="thread_001"
+        sessions={[
+          {
+            session_id: "thread_001",
+            workspace_id: "ws_alpha",
+            title: "Fix build error",
+            status: "waiting_approval",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            started_at: "2026-03-27T05:13:00Z",
+            last_message_at: "2026-03-27T05:21:40Z",
+            active_approval_id: "apr_001",
+            can_send_message: false,
+            can_start: false,
+            can_stop: true,
+          },
+        ]}
+        statusMessage="Approval requested."
+        workspaceId="ws_alpha"
+      />,
+    );
+
+    expect(markup).toContain("Fix build error");
+    expect(markup).toContain("Approval waiting: apr_001");
+    expect(markup).toContain("Please explain the diff.");
+    expect(markup).toContain("Streaming update");
+    expect(markup).toContain("approval.requested");
+  });
+});

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -18,3 +18,5 @@ Archive entries preserve the work instructions that were used at the time, while
 - [issue-78-phase-4a2-home-aggregation](./issue-78-phase-4a2-home-aggregation/README.md)
 - [issue-79-phase-4a1-rest-facade](./issue-79-phase-4a1-rest-facade/README.md)
 - [issue-80-phase-4a3-sse-relay](./issue-80-phase-4a3-sse-relay/README.md)
+- [issue-84-home-ui-shell](./issue-84-home-ui-shell/README.md)
+- [issue-85-chat-ui-flow](./issue-85-chat-ui-flow/README.md)

--- a/tasks/archive/issue-85-chat-ui-flow/README.md
+++ b/tasks/archive/issue-85-chat-ui-flow/README.md
@@ -1,0 +1,61 @@
+# Phase 4B-2 Chat UI Flow
+
+## Purpose
+
+- Execute Issue #85 by implementing the smartphone-focused Chat screen, session interaction flow, and reconnect handling for Phase 4B.
+
+## Primary issue
+
+- Issue: `#85` https://github.com/tsukushibito/codex-webui/issues/85
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md` section 9.3
+- `docs/requirements/codex_webui_mvp_requirements_v0_8.md` sections 6 and 8
+- `docs/specs/codex_webui_public_api_v0_8.md` sections 5.2, 9.2, and 12.2
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Replace the placeholder `/chat` route in `apps/frontend-bff` with the first real smartphone-focused Chat screen.
+- Implement session list, session creation, and session start entry points that use the documented public API.
+- Render session detail, message history, activity log, and session status.
+- Support message send, stop, and session stream updates with REST reacquisition after disconnect.
+- Keep the Chat layout usable at 360px width without horizontal scrolling.
+
+## Exit criteria
+
+- Main chat operations work through the documented public API.
+- Session stream updates render correctly in the UI, including delta and completed states.
+- Chat can recover consistency through REST reacquisition after stream disconnect.
+- The Chat screen remains usable at smartphone width without horizontal scrolling.
+- Validation evidence is recorded here before archive.
+
+## Work plan
+
+- Audit the merged Home shell and BFF routes to define the smallest Chat-focused UI slice.
+- Implement Chat data access, session flow actions, and session stream handling in `apps/frontend-bff`.
+- Add focused tests for Chat data/rendering behavior and reconnect handling where practical.
+- Record validation results and any Approval-slice dependencies in the handoff notes.
+
+## Artifacts / evidence
+
+- Validation passed: `npm test` in `apps/frontend-bff`
+- Validation passed: `npm run build` in `apps/frontend-bff`
+- Reconnect note: Chat reacquires session, messages, and events from REST when the session stream errors before attempting to reconnect
+- Responsive/manual verification note: Chat uses a single-column shell up to 720px with full-width cards, wrapping action rows, and no fixed-width controls
+- Remaining check for later slices: Chat-side approval waiting is visible, but full approval action reflection remains in `#86`
+
+## Status / handoff notes
+
+- Status: `implementation complete pending evaluator review`
+- Notes: `Replaced the /chat placeholder with a real Chat shell covering session list/create/start, transcript, event log, message send, stop, and stream reconnect reacquisition.`
+- Validation: `npm test` passed with 16 tests across route, Home, and Chat coverage.
+- Validation: `npm run build` passed and generated the dynamic /chat route.
+- Follow-up constraint: Approval actions are intentionally deferred to `#86`; Chat only surfaces approval-waiting state in this slice.
+- Retrospective: Reusing the merged Home shell kept the UI slice bounded and reduced new styling churn.
+- Retrospective: The worker stalled during `npm install` and needed manual recovery before validation; no repo-tracked process change adopted from this slice yet.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, validation evidence is recorded, and the handoff notes are updated for merge/completion tracking.


### PR DESCRIPTION
Fixes #85

## Summary
- replace the Chat placeholder with a smartphone-focused Chat screen
- add public API data helpers and UI state for session create/start/send/stop flows
- add transcript, event log, and stream reconnect reacquisition coverage

## Validation
- npm test
- npm run build
