### PR TITLE
feat(frontend-bff): implement smartphone approval ui flow

### DIFF
--- a/apps/frontend-bff/app/approvals/page.tsx
+++ b/apps/frontend-bff/app/approvals/page.tsx
@@ -1,19 +1,7 @@
-import Link from "next/link";
+import { ApprovalPageClient } from "@/src/approval-page-client";
 
-export default function ApprovalPlaceholderPage() {
-  return (
-    <main className="placeholder-shell">
-      <div className="placeholder-card">
-        <p className="eyebrow">Phase 4B-3</p>
-        <h1>Approval screen placeholder</h1>
-        <p>
-          The Approval experience will land in a later UI slice. This route
-          keeps the Home approval navigation live in the meantime.
-        </p>
-        <Link className="text-link" href="/">
-          Back to Home
-        </Link>
-      </div>
-    </main>
-  );
+export const dynamic = "force-dynamic";
+
+export default function ApprovalPage() {
+  return <ApprovalPageClient />;
 }

--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -393,6 +393,42 @@ input {
   gap: 14px;
 }
 
+.approval-layout .hero-card,
+.approval-layout > .error-banner,
+.approval-layout > .status-message {
+  grid-column: 1 / -1;
+}
+
+.approval-list {
+  max-height: 32rem;
+  overflow-y: auto;
+}
+
+.approval-empty-card,
+.approval-detail-card {
+  min-height: 18rem;
+}
+
+.approval-detail-grid,
+.approval-context-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.approval-context {
+  display: grid;
+  gap: 10px;
+}
+
+.approval-context-row {
+  display: grid;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.66);
+  word-break: break-word;
+}
+
 .text-link {
   color: var(--accent-strong);
   font-weight: 700;
@@ -406,5 +442,9 @@ input {
 
   .hero-body {
     padding: 28px;
+  }
+
+  .approval-detail-grid {
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/apps/frontend-bff/src/approval-data.ts
+++ b/apps/frontend-bff/src/approval-data.ts
@@ -1,0 +1,79 @@
+import { isErrorEnvelope } from "./errors";
+import type {
+  PublicApprovalDetail,
+  PublicApprovalResolveResult,
+  PublicApprovalSummary,
+  PublicListResponse,
+} from "./approval-types";
+
+type FetchLike = typeof fetch;
+
+async function readJson<T>(response: Response, fallbackMessage: string) {
+  const payload = (await response.json()) as unknown;
+
+  if (!response.ok) {
+    if (isErrorEnvelope(payload)) {
+      throw new Error(payload.error.message);
+    }
+
+    throw new Error(fallbackMessage);
+  }
+
+  return payload as T;
+}
+
+export async function fetchPendingApprovals(fetchImpl: FetchLike = fetch) {
+  const response = await fetchImpl("/api/v1/approvals?status=pending&sort=-requested_at", {
+    cache: "no-store",
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  return readJson<PublicListResponse<PublicApprovalSummary>>(
+    response,
+    "Failed to load the approval queue.",
+  );
+}
+
+export async function fetchApprovalDetail(
+  approvalId: string,
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(`/api/v1/approvals/${approvalId}`, {
+    cache: "no-store",
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  return readJson<PublicApprovalDetail>(response, "Failed to load the approval detail.");
+}
+
+async function resolveApproval(
+  approvalId: string,
+  resolution: "approve" | "deny",
+  fetchImpl: FetchLike = fetch,
+) {
+  const response = await fetchImpl(`/api/v1/approvals/${approvalId}/${resolution}`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+
+  return readJson<PublicApprovalResolveResult>(
+    response,
+    `Failed to ${resolution} the approval.`,
+  );
+}
+
+export function approveApproval(approvalId: string, fetchImpl: FetchLike = fetch) {
+  return resolveApproval(approvalId, "approve", fetchImpl);
+}
+
+export function denyApproval(approvalId: string, fetchImpl: FetchLike = fetch) {
+  return resolveApproval(approvalId, "deny", fetchImpl);
+}

--- a/apps/frontend-bff/src/approval-page-client.tsx
+++ b/apps/frontend-bff/src/approval-page-client.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  approveApproval,
+  denyApproval,
+  fetchApprovalDetail,
+  fetchPendingApprovals,
+} from "./approval-data";
+import type {
+  PublicApprovalDetail,
+  PublicApprovalStreamEvent,
+  PublicApprovalSummary,
+} from "./approval-types";
+import { ApprovalView } from "./approval-view";
+
+function pickSelection(
+  approvals: PublicApprovalSummary[],
+  preferredApprovalId: string | null,
+  currentApprovalId: string | null,
+) {
+  if (
+    preferredApprovalId &&
+    approvals.some((approval) => approval.approval_id === preferredApprovalId)
+  ) {
+    return preferredApprovalId;
+  }
+
+  if (
+    currentApprovalId &&
+    approvals.some((approval) => approval.approval_id === currentApprovalId)
+  ) {
+    return currentApprovalId;
+  }
+
+  return approvals[0]?.approval_id ?? null;
+}
+
+export function ApprovalPageClient() {
+  const [approvals, setApprovals] = useState<PublicApprovalSummary[]>([]);
+  const [selectedApprovalId, setSelectedApprovalId] = useState<string | null>(null);
+  const [selectedApproval, setSelectedApproval] = useState<PublicApprovalDetail | null>(
+    null,
+  );
+  const [isLoadingApprovals, setIsLoadingApprovals] = useState(true);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [connectionState, setConnectionState] = useState<
+    "idle" | "live" | "reconnecting"
+  >("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [streamVersion, setStreamVersion] = useState(0);
+  const selectedApprovalIdRef = useRef<string | null>(null);
+  const reconnectTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    selectedApprovalIdRef.current = selectedApprovalId;
+  }, [selectedApprovalId]);
+
+  async function loadApprovalDetail(approvalId: string) {
+    setIsLoadingDetail(true);
+
+    try {
+      setSelectedApproval(await fetchApprovalDetail(approvalId));
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to load the approval detail.",
+      );
+    } finally {
+      setIsLoadingDetail(false);
+    }
+  }
+
+  async function loadApprovals(preferredApprovalId: string | null = null) {
+    setIsLoadingApprovals(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetchPendingApprovals();
+      setApprovals(response.items);
+
+      const nextSelectedId = pickSelection(
+        response.items,
+        preferredApprovalId,
+        selectedApprovalIdRef.current,
+      );
+
+      setSelectedApprovalId(nextSelectedId);
+      if (nextSelectedId) {
+        await loadApprovalDetail(nextSelectedId);
+      } else {
+        setSelectedApproval(null);
+      }
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to load the approval queue.",
+      );
+    } finally {
+      setIsLoadingApprovals(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadApprovals();
+  }, []);
+
+  useEffect(() => {
+    const stream = new EventSource("/api/v1/approvals/stream");
+    setConnectionState("live");
+
+    stream.onmessage = (messageEvent) => {
+      const event = JSON.parse(messageEvent.data) as PublicApprovalStreamEvent;
+      const approvalId =
+        typeof event.payload.approval_id === "string" ? event.payload.approval_id : null;
+
+      if (event.event_type === "approval.requested") {
+        setStatusMessage("New approval requested. Queue refreshed.");
+        void loadApprovals(approvalId);
+        return;
+      }
+
+      if (event.event_type === "approval.resolved") {
+        setStatusMessage("Approval resolved. Queue refreshed.");
+        void loadApprovals(selectedApprovalIdRef.current);
+      }
+    };
+
+    stream.onerror = () => {
+      stream.close();
+      setConnectionState("reconnecting");
+      void loadApprovals(selectedApprovalIdRef.current).finally(() => {
+        if (reconnectTimerRef.current !== null) {
+          window.clearTimeout(reconnectTimerRef.current);
+        }
+
+        reconnectTimerRef.current = window.setTimeout(() => {
+          setStreamVersion((currentValue) => currentValue + 1);
+        }, 1000);
+      });
+    };
+
+    return () => {
+      stream.close();
+      if (reconnectTimerRef.current !== null) {
+        window.clearTimeout(reconnectTimerRef.current);
+      }
+    };
+  }, [streamVersion]);
+
+  async function handleSelectApproval(approvalId: string) {
+    setSelectedApprovalId(approvalId);
+    setErrorMessage(null);
+    await loadApprovalDetail(approvalId);
+  }
+
+  async function handleResolveApproval(resolution: "approved" | "denied") {
+    if (!selectedApprovalId) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const result =
+        resolution === "approved"
+          ? await approveApproval(selectedApprovalId)
+          : await denyApproval(selectedApprovalId);
+
+      setStatusMessage(
+        resolution === "approved"
+          ? `Approved ${result.approval.approval_id}. Session ${result.session.status}.`
+          : `Denied ${result.approval.approval_id}. Session ${result.session.status}.`,
+      );
+      await loadApprovals();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to resolve the approval.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <ApprovalView
+      approvals={approvals}
+      connectionState={connectionState}
+      errorMessage={errorMessage}
+      isLoadingApprovals={isLoadingApprovals}
+      isLoadingDetail={isLoadingDetail}
+      isSubmitting={isSubmitting}
+      onApprove={() => void handleResolveApproval("approved")}
+      onDeny={() => void handleResolveApproval("denied")}
+      onSelectApproval={(approvalId) => {
+        void handleSelectApproval(approvalId);
+      }}
+      selectedApproval={selectedApproval}
+      selectedApprovalId={selectedApprovalId}
+      statusMessage={statusMessage}
+    />
+  );
+}

--- a/apps/frontend-bff/src/approval-types.ts
+++ b/apps/frontend-bff/src/approval-types.ts
@@ -1,0 +1,38 @@
+import type { PublicListResponse, PublicSessionSummary } from "./chat-types";
+
+export type { PublicListResponse } from "./chat-types";
+
+export interface PublicApprovalSummary {
+  approval_id: string;
+  session_id: string;
+  workspace_id: string;
+  status: "pending" | "approved" | "denied" | "canceled";
+  resolution: "approved" | "denied" | "canceled" | null;
+  approval_category:
+    | "destructive_change"
+    | "external_side_effect"
+    | "network_access"
+    | "privileged_execution";
+  title: string;
+  description: string;
+  requested_at: string;
+  resolved_at: string | null;
+}
+
+export interface PublicApprovalDetail extends PublicApprovalSummary {
+  operation_summary: string | null;
+  context: Record<string, unknown> | null;
+}
+
+export interface PublicApprovalResolveResult {
+  approval: PublicApprovalSummary;
+  session: PublicSessionSummary;
+}
+
+export interface PublicApprovalStreamEvent {
+  event_id: string;
+  session_id: string;
+  event_type: "approval.requested" | "approval.resolved";
+  occurred_at: string;
+  payload: Record<string, unknown>;
+}

--- a/apps/frontend-bff/src/approval-view.tsx
+++ b/apps/frontend-bff/src/approval-view.tsx
@@ -1,0 +1,262 @@
+import React from "react";
+import Link from "next/link";
+
+import type {
+  PublicApprovalDetail,
+  PublicApprovalSummary,
+} from "./approval-types";
+
+export interface ApprovalViewProps {
+  approvals: PublicApprovalSummary[];
+  selectedApprovalId: string | null;
+  selectedApproval: PublicApprovalDetail | null;
+  isLoadingApprovals: boolean;
+  isLoadingDetail: boolean;
+  isSubmitting: boolean;
+  connectionState: "idle" | "live" | "reconnecting";
+  errorMessage: string | null;
+  statusMessage: string | null;
+  onSelectApproval: (approvalId: string) => void;
+  onApprove: () => void;
+  onDeny: () => void;
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return "Not resolved";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatCategory(category: string) {
+  return category.replaceAll("_", " ");
+}
+
+function workspaceChatHref(approval: PublicApprovalSummary | PublicApprovalDetail | null) {
+  if (!approval) {
+    return "/chat";
+  }
+
+  const params = new URLSearchParams({
+    workspaceId: approval.workspace_id,
+    sessionId: approval.session_id,
+  });
+
+  return `/chat?${params.toString()}`;
+}
+
+function contextEntries(context: Record<string, unknown> | null) {
+  if (!context) {
+    return [];
+  }
+
+  return Object.entries(context).map(([key, value]) => ({
+    key,
+    value:
+      typeof value === "string"
+        ? value
+        : JSON.stringify(value),
+  }));
+}
+
+export function ApprovalView({
+  approvals,
+  selectedApprovalId,
+  selectedApproval,
+  isLoadingApprovals,
+  isLoadingDetail,
+  isSubmitting,
+  connectionState,
+  errorMessage,
+  statusMessage,
+  onSelectApproval,
+  onApprove,
+  onDeny,
+}: ApprovalViewProps) {
+  const selectedSummary =
+    approvals.find((approval) => approval.approval_id === selectedApprovalId) ?? null;
+  const selectedItem = selectedApproval ?? selectedSummary;
+  const canResolve = Boolean(selectedApproval && selectedApproval.status === "pending");
+
+  return (
+    <main className="chat-shell">
+      <div className="chat-layout approval-layout">
+        <section className="hero-card">
+          <div className="hero-body">
+            <p className="eyebrow">codex-webui</p>
+            <h1>Approval</h1>
+            <p className="hero-copy">
+              Review the minimum confirmation information, then approve or deny
+              the pending request from a smartphone-first queue.
+            </p>
+            <div className="hero-metrics">
+              <span className="metric-chip">Pending: {approvals.length}</span>
+              <span className="metric-chip">
+                Stream: {connectionState === "live"
+                  ? "live"
+                  : connectionState === "reconnecting"
+                    ? "reacquiring"
+                    : "idle"}
+              </span>
+              <span className="metric-chip">
+                Selected: {selectedItem?.approval_id ?? "none"}
+              </span>
+            </div>
+            <div className="hero-actions">
+              <Link className="secondary-link" href="/">
+                Back to Home
+              </Link>
+              <Link className="primary-link" href={workspaceChatHref(selectedItem)}>
+                Open related Chat
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {errorMessage ? <p className="error-banner">{errorMessage}</p> : null}
+        {statusMessage ? <p className="status-message">{statusMessage}</p> : null}
+
+        <section className="chat-panel create-card">
+          <header>
+            <p className="eyebrow">Queue</p>
+            <h2>Pending approvals</h2>
+            <p className="field-hint">
+              The list stays global. Select an item to reach the minimum
+              confirmation information before acting.
+            </p>
+          </header>
+
+          <div className="session-list approval-list">
+            {isLoadingApprovals ? (
+              <p className="workspace-status">Loading approval queue...</p>
+            ) : null}
+
+            {!isLoadingApprovals && approvals.length === 0 ? (
+              <article className="workspace-card approval-empty-card">
+                <p className="empty-state">
+                  No pending approvals. New requests will appear here through the
+                  queue refresh and approval stream.
+                </p>
+              </article>
+            ) : null}
+
+            {approvals.map((approval) => (
+              <button
+                className={
+                  selectedApprovalId === approval.approval_id
+                    ? "session-summary-card active"
+                    : "session-summary-card"
+                }
+                key={approval.approval_id}
+                onClick={() => onSelectApproval(approval.approval_id)}
+                type="button"
+              >
+                <div className="workspace-meta-row">
+                  <p className="eyebrow">Approval</p>
+                  <span className="status-badge warning">
+                    {formatCategory(approval.approval_category)}
+                  </span>
+                </div>
+                <strong>{approval.title}</strong>
+                <span className="workspace-status">{approval.description}</span>
+                <span className="workspace-meta">
+                  Requested {formatTimestamp(approval.requested_at)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="chat-panel workspace-card approval-detail-card">
+          <header>
+            <div className="workspace-meta-row">
+              <p className="eyebrow">Detail</p>
+              {selectedItem ? (
+                <span className="status-badge warning">
+                  {formatCategory(selectedItem.approval_category)}
+                </span>
+              ) : null}
+            </div>
+            <h2>{selectedItem?.title ?? "Select an approval"}</h2>
+            <p className="workspace-meta">
+              {selectedItem
+                ? `Requested ${formatTimestamp(selectedItem.requested_at)}`
+                : "Choose a pending approval from the queue to inspect it."}
+            </p>
+          </header>
+
+          {isLoadingDetail && selectedItem ? (
+            <p className="workspace-status">Refreshing approval detail...</p>
+          ) : null}
+
+          {!selectedItem ? (
+            <p className="empty-state">
+              The detail view shows the minimum confirmation information needed
+              before approve or deny.
+            </p>
+          ) : (
+            <>
+              <div className="approval-detail-grid">
+                <article className="chat-event">
+                  <p className="eyebrow">Reason</p>
+                  <p>{selectedItem.description}</p>
+                </article>
+                <article className="chat-event">
+                  <p className="eyebrow">Operation summary</p>
+                  <p>{selectedApproval?.operation_summary ?? "No operation summary"}</p>
+                </article>
+                <article className="chat-event">
+                  <p className="eyebrow">Session / workspace</p>
+                  <p>Session {selectedItem.session_id}</p>
+                  <p>Workspace {selectedItem.workspace_id}</p>
+                </article>
+                <article className="chat-event">
+                  <p className="eyebrow">Resolution</p>
+                  <p>{selectedItem.resolution ?? "Still pending"}</p>
+                  <p>Resolved {formatTimestamp(selectedItem.resolved_at)}</p>
+                </article>
+              </div>
+
+              {selectedApproval?.context ? (
+                <section className="approval-context">
+                  <p className="eyebrow">Context</p>
+                  <div className="approval-context-grid">
+                    {contextEntries(selectedApproval.context).map((entry) => (
+                      <div className="approval-context-row" key={entry.key}>
+                        <span>{entry.key}</span>
+                        <strong>{entry.value}</strong>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              <div className="workspace-actions">
+                <button
+                  className="primary-link action-button"
+                  disabled={!canResolve || isSubmitting}
+                  onClick={onApprove}
+                  type="button"
+                >
+                  {isSubmitting ? "Submitting..." : "Approve request"}
+                </button>
+                <button
+                  className="secondary-link action-button"
+                  disabled={!canResolve || isSubmitting}
+                  onClick={onDeny}
+                  type="button"
+                >
+                  {isSubmitting ? "Submitting..." : "Deny request"}
+                </button>
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend-bff/tests/approval-data.test.ts
+++ b/apps/frontend-bff/tests/approval-data.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  approveApproval,
+  fetchApprovalDetail,
+  fetchPendingApprovals,
+} from "../src/approval-data";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+describe("approval data access", () => {
+  it("loads the pending approval queue from the public API", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            approval_id: "apr_001",
+            session_id: "thread_001",
+            workspace_id: "ws_alpha",
+            status: "pending",
+            resolution: null,
+            approval_category: "external_side_effect",
+            title: "Run git push",
+            description: "Codex requests permission to push changes to remote.",
+            requested_at: "2026-03-27T05:18:00Z",
+            resolved_at: null,
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      }),
+    );
+
+    const result = await fetchPendingApprovals(fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/approvals?status=pending&sort=-requested_at",
+      {
+        cache: "no-store",
+        headers: {
+          accept: "application/json",
+        },
+      },
+    );
+    expect(result.items[0]?.approval_id).toBe("apr_001");
+  });
+
+  it("loads details and resolves approvals through the public API", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          approval_id: "apr_001",
+          session_id: "thread_001",
+          workspace_id: "ws_alpha",
+          status: "pending",
+          resolution: null,
+          approval_category: "external_side_effect",
+          title: "Run git push",
+          description: "Codex requests permission to push changes to remote.",
+          operation_summary: "git push origin main",
+          requested_at: "2026-03-27T05:18:00Z",
+          resolved_at: null,
+          context: {
+            command: "git push origin main",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          approval: {
+            approval_id: "apr_001",
+            session_id: "thread_001",
+            workspace_id: "ws_alpha",
+            status: "approved",
+            resolution: "approved",
+            approval_category: "external_side_effect",
+            title: "Run git push",
+            description: "Codex requests permission to push changes to remote.",
+            requested_at: "2026-03-27T05:18:00Z",
+            resolved_at: "2026-03-27T05:19:00Z",
+          },
+          session: {
+            session_id: "thread_001",
+            workspace_id: "ws_alpha",
+            title: "Fix build error",
+            status: "running",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:19:00Z",
+            started_at: "2026-03-27T05:13:00Z",
+            last_message_at: "2026-03-27T05:18:00Z",
+            active_approval_id: null,
+            can_send_message: false,
+            can_start: false,
+            can_stop: true,
+          },
+        }),
+      );
+
+    const detail = await fetchApprovalDetail("apr_001", fetchMock);
+    const result = await approveApproval("apr_001", fetchMock);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/v1/approvals/apr_001", {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+      },
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/approvals/apr_001/approve",
+      {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(detail.operation_summary).toBe("git push origin main");
+    expect(result.approval.status).toBe("approved");
+  });
+});

--- a/apps/frontend-bff/tests/approval-view.test.tsx
+++ b/apps/frontend-bff/tests/approval-view.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ApprovalView } from "../src/approval-view";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("ApprovalView", () => {
+  it("renders the pending queue, minimum confirmation information, and actions", () => {
+    const markup = renderToStaticMarkup(
+      <ApprovalView
+        approvals={[
+          {
+            approval_id: "apr_001",
+            session_id: "thread_001",
+            workspace_id: "ws_alpha",
+            status: "pending",
+            resolution: null,
+            approval_category: "external_side_effect",
+            title: "Run git push",
+            description: "Codex requests permission to push changes to remote.",
+            requested_at: "2026-03-27T05:18:00Z",
+            resolved_at: null,
+          },
+        ]}
+        connectionState="live"
+        errorMessage={null}
+        isLoadingApprovals={false}
+        isLoadingDetail={false}
+        isSubmitting={false}
+        onApprove={() => {}}
+        onDeny={() => {}}
+        onSelectApproval={() => {}}
+        selectedApproval={{
+          approval_id: "apr_001",
+          session_id: "thread_001",
+          workspace_id: "ws_alpha",
+          status: "pending",
+          resolution: null,
+          approval_category: "external_side_effect",
+          title: "Run git push",
+          description: "Codex requests permission to push changes to remote.",
+          operation_summary: "git push origin main",
+          requested_at: "2026-03-27T05:18:00Z",
+          resolved_at: null,
+          context: {
+            command: "git push origin main",
+          },
+        }}
+        selectedApprovalId="apr_001"
+        statusMessage="Approval queue ready."
+      />,
+    );
+
+    expect(markup).toContain("Pending approvals");
+    expect(markup).toContain("Run git push");
+    expect(markup).toContain("git push origin main");
+    expect(markup).toContain("Approve request");
+    expect(markup).toContain("Deny request");
+    expect(markup).toContain("Open related Chat");
+  });
+});

--- a/tasks/archive/issue-86-approval-ui-flow/README.md
+++ b/tasks/archive/issue-86-approval-ui-flow/README.md
@@ -1,0 +1,60 @@
+# Phase 4B-3 Approval UI Flow
+
+## Purpose
+
+- Execute Issue #86 by implementing the smartphone-focused Approval screen and approval action flow for Phase 4B.
+
+## Primary issue
+
+- Issue: `#86` https://github.com/tsukushibito/codex-webui/issues/86
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md` section 9.3
+- `docs/requirements/codex_webui_mvp_requirements_v0_8.md` sections 6.3 and 8
+- `docs/specs/codex_webui_public_api_v0_8.md` sections 5.3, 9.3, and 12.3
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Replace the placeholder `/approvals` route in `apps/frontend-bff` with the first real smartphone-focused Approval screen.
+- Render pending approval list and approval detail views from the documented public API.
+- Implement approve / deny flows and refresh behavior around the approval stream.
+- Reflect stop-origin `canceled_approval` updates in Approval and Chat-facing UI state where this slice owns the behavior.
+- Keep the Approval layout usable at 360px width without horizontal scrolling.
+
+## Exit criteria
+
+- Approval list and detail render from the documented public API.
+- Approve / deny actions update local UI state correctly.
+- Stop-triggered approval cancellation is reflected correctly.
+- Approval actions remain reachable within the documented smartphone interaction constraints.
+- Validation evidence is recorded here before archive.
+
+## Work plan
+
+- Audit the merged Home and Chat shells to define the smallest Approval-focused UI slice.
+- Implement approval data access, list/detail state, and action handling in `apps/frontend-bff`.
+- Add focused tests for Approval data/render/action behavior.
+- Record validation results and any final Phase 4B handoff notes in this README.
+
+## Artifacts / evidence
+
+- Validation passed: `npm test` in `apps/frontend-bff`
+- Validation passed: `npm run build` in `apps/frontend-bff`
+- Approval stream note: the Approval screen refreshes queue/detail state from `/api/v1/approvals/stream` on requested/resolved events and after stream error recovery
+- Responsive/manual verification note: Approval reuses the single-column shell up to 720px with wrapping action rows, a scrollable queue column, and no fixed-width controls in the new slice
+
+## Status / handoff notes
+
+- Status: `locally complete and ready to archive`
+- Notes: `Replaced the /approvals placeholder with a real Approval queue/detail/action UI, plus dedicated approval data helpers and focused tests.`
+- Validation: `npm test` passed with 19 tests across route, Home, Chat, and Approval coverage.
+- Validation: `npm run build` passed and generated the dynamic /approvals route.
+- Follow-up constraint: 360px usability is evidenced here by the implemented layout rules and existing single-column shell rather than an in-browser viewport harness.
+- Retrospective: Reusing the merged Home/Chat shell kept the Approval slice bounded and avoided unnecessary styling churn.
+- Retrospective: Worktree-local `node_modules` had drifted and required a local `npm install` repair before validations passed; no repo-tracked process change adopted from this slice yet.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, validation evidence is recorded, and the handoff notes are updated for merge/completion tracking.


### PR DESCRIPTION
Fixes #86

## Summary
- replace the Approval placeholder with a smartphone-focused queue/detail/action screen
- add approval data helpers and client-side stream reconciliation for approve/deny flows
- add focused Approval view/data tests and archive the completed #86 task package

## Validation
- npm test
- npm run build
