### PR TITLE
chore: add orchestration log summary helper

### DIFF
--- a/.agents/skills/codex-webui-orchestration-log/SKILL.md
+++ b/.agents/skills/codex-webui-orchestration-log/SKILL.md
@@ -96,6 +96,35 @@ Token usage notes:
 - `aggregate_total_token_usage` is the sum of the current thread and known direct subagents at snapshot time
 - when the current thread or session log cannot be resolved, the snapshot still records `available: false` with an `unavailable_reason`
 
+## Run Inspection Helper
+
+Use `scripts/summarize_run_log.py` when you need a read-only operational view of an existing run log instead of manually inspecting raw NDJSON.
+
+Default concise summary:
+
+```bash
+python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py \
+  --run-id 2026-04-09T14-30-02Z-issue-127-close
+```
+
+Anomaly-only view:
+
+```bash
+python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py \
+  --run-id 2026-04-09T14-30-02Z-issue-127-close \
+  --anomalies
+```
+
+Basic consistency checks:
+
+```bash
+python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py \
+  --run-id 2026-04-09T14-30-02Z-issue-127-close \
+  --check
+```
+
+The check view reports invalid JSON lines, duplicated sequence values, missing or multiple terminal events, and mismatched `handoff_started` / `handoff_completed` counts. It is intentionally read-only and does not repair log files.
+
 ## Guardrails
 
 - Do not write ad hoc orchestration logs outside `artifacts/execution_orchestrator/`

--- a/.agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py
+++ b/.agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+TERMINAL_EVENTS = {"run_completed", "run_blocked"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read an orchestration run log and print concise operational views."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--run-id",
+        help="Run id under artifacts/execution_orchestrator/runs/<run_id>/events.ndjson.",
+    )
+    source.add_argument(
+        "--events-path",
+        help="Direct path to an events.ndjson file.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--anomalies",
+        action="store_true",
+        help="Print only anomaly events in a concise table.",
+    )
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Print basic consistency checks for the run log.",
+    )
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def events_path(args: argparse.Namespace) -> Path:
+    if args.events_path:
+        return Path(args.events_path).resolve()
+    root = repo_root()
+    candidate = run_events_path(root, args.run_id)
+    if candidate.exists():
+        return candidate
+    if root.parent.name == ".worktrees":
+        parent_checkout = root.parent.parent
+        parent_candidate = run_events_path(parent_checkout, args.run_id)
+        if parent_candidate.exists():
+            return parent_candidate
+    return candidate
+
+
+def run_events_path(root: Path, run_id: str) -> Path:
+    return (
+        root
+        / "artifacts"
+        / "execution_orchestrator"
+        / "runs"
+        / run_id
+        / "events.ndjson"
+    )
+
+
+def event_value(event: dict[str, Any], key: str) -> str:
+    value = event.get(key)
+    if value is None:
+        return "-"
+    return str(value)
+
+
+def read_events(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    events: list[dict[str, Any]] = []
+    invalid_lines: list[str] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                invalid_lines.append(f"line {line_number}: invalid JSON: {exc.msg}")
+                continue
+            if not isinstance(value, dict):
+                invalid_lines.append(f"line {line_number}: JSON value is not an object")
+                continue
+            events.append(value)
+    return events, invalid_lines
+
+
+def infer_run_id(path: Path, events: list[dict[str, Any]]) -> str:
+    for event in events:
+        run_id = event.get("run_id")
+        if isinstance(run_id, str) and run_id:
+            return run_id
+    if path.name == "events.ndjson" and path.parent.name:
+        return path.parent.name
+    return "-"
+
+
+def count_values(events: list[dict[str, Any]], key: str) -> Counter[str]:
+    return Counter(event_value(event, key) for event in events)
+
+
+def format_counter(counter: Counter[str]) -> str:
+    if not counter:
+        return "-"
+    return ", ".join(f"{key}={value}" for key, value in sorted(counter.items()))
+
+
+def handoff_events(events: list[dict[str, Any]], event_type: str) -> list[dict[str, Any]]:
+    return [event for event in events if event.get("event_type") == event_type]
+
+
+def print_summary(path: Path, events: list[dict[str, Any]], invalid_lines: list[str]) -> None:
+    run_id = infer_run_id(path, events)
+    sequences = [event.get("sequence") for event in events if isinstance(event.get("sequence"), int)]
+    terminals = [event for event in events if event.get("event_type") in TERMINAL_EVENTS]
+    anomalies = [event for event in events if event.get("event_type") == "anomaly"]
+    last_event = events[-1] if events else {}
+
+    print(f"Run: {run_id}")
+    print(f"Path: {path}")
+    print(f"Events: {len(events)} valid, {len(invalid_lines)} invalid")
+    if sequences:
+        print(f"Sequence range: {min(sequences)}..{max(sequences)}")
+    else:
+        print("Sequence range: -")
+    print(f"Stages: {format_counter(count_values(events, 'stage'))}")
+    print(f"Event types: {format_counter(count_values(events, 'event_type'))}")
+    print(f"Statuses: {format_counter(count_values(events, 'status'))}")
+    print(f"Current target: {event_value(last_event, 'target')}")
+    print(f"Last event: {event_value(last_event, 'event_type')} ({event_value(last_event, 'status')})")
+    print(f"Terminal events: {len(terminals)}")
+    print(f"Anomalies: {len(anomalies)}")
+
+    selected = handoff_events(events, "handoff_selected")
+    if selected:
+        print("Selected handoffs:")
+        for event in selected:
+            print(
+                f"- seq {event_value(event, 'sequence')}: "
+                f"{event_value(event, 'skill')} target={event_value(event, 'target')} "
+                f"status={event_value(event, 'status')}"
+            )
+    else:
+        print("Selected handoffs: none")
+
+
+def print_anomalies(events: list[dict[str, Any]]) -> None:
+    anomalies = [event for event in events if event.get("event_type") == "anomaly"]
+    if not anomalies:
+        print("Anomalies: none")
+        return
+
+    print(f"Anomalies: {len(anomalies)}")
+    for event in anomalies:
+        print(
+            f"- seq {event_value(event, 'sequence')}: "
+            f"stage={event_value(event, 'stage')} "
+            f"status={event_value(event, 'status')} "
+            f"target={event_value(event, 'target')} "
+            f"skill={event_value(event, 'skill')} "
+            f"issue={event_value(event, 'issue')} - "
+            f"{event_value(event, 'summary')}"
+        )
+
+
+def duplicate_sequences(events: list[dict[str, Any]]) -> list[int]:
+    counts = Counter(
+        event.get("sequence") for event in events if isinstance(event.get("sequence"), int)
+    )
+    return sorted(sequence for sequence, count in counts.items() if count > 1)
+
+
+def handoff_key(event: dict[str, Any]) -> tuple[str, str]:
+    return (event_value(event, "skill"), event_value(event, "target"))
+
+
+def handoff_mismatches(events: list[dict[str, Any]]) -> list[str]:
+    started = Counter(handoff_key(event) for event in handoff_events(events, "handoff_started"))
+    completed = Counter(handoff_key(event) for event in handoff_events(events, "handoff_completed"))
+    keys = sorted(set(started) | set(completed))
+    mismatches: list[str] = []
+    for key in keys:
+        if started[key] == completed[key]:
+            continue
+        skill, target = key
+        mismatches.append(
+            f"{skill} target={target}: started={started[key]} completed={completed[key]}"
+        )
+    return mismatches
+
+
+def print_check(events: list[dict[str, Any]], invalid_lines: list[str]) -> None:
+    findings: list[str] = []
+
+    for invalid_line in invalid_lines:
+        findings.append(invalid_line)
+
+    duplicates = duplicate_sequences(events)
+    if duplicates:
+        findings.append(
+            "duplicate sequence values: " + ", ".join(str(sequence) for sequence in duplicates)
+        )
+
+    terminals = [event for event in events if event.get("event_type") in TERMINAL_EVENTS]
+    if not terminals:
+        findings.append("missing terminal event: expected run_completed or run_blocked")
+    elif len(terminals) > 1:
+        terminal_refs = ", ".join(
+            f"seq {event_value(event, 'sequence')} {event_value(event, 'event_type')}"
+            for event in terminals
+        )
+        findings.append(f"multiple terminal events: {terminal_refs}")
+
+    for mismatch in handoff_mismatches(events):
+        findings.append(f"handoff started/completed mismatch: {mismatch}")
+
+    if findings:
+        print(f"Check result: issues found ({len(findings)})")
+        for finding in findings:
+            print(f"- {finding}")
+        return
+
+    print("Check result: ok")
+
+
+def main() -> int:
+    args = parse_args()
+    path = events_path(args)
+    if not path.exists():
+        print(f"events file not found: {path}", file=sys.stderr)
+        return 2
+
+    events, invalid_lines = read_events(path)
+    if args.anomalies:
+        print_anomalies(events)
+    elif args.check:
+        print_check(events, invalid_lines)
+    else:
+        print_summary(path, events, invalid_lines)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-133-orchestration-log-summaries](./archive/issue-133-orchestration-log-summaries/README.md)
 - [app_server_behavior_validation](./archive/app_server_behavior_validation/README.md)
 - [issue-117-wiki-agent-guidance](./archive/issue-117-wiki-agent-guidance/README.md)
 - [issue-116-wiki-index-log](./archive/issue-116-wiki-index-log/README.md)

--- a/tasks/archive/issue-133-orchestration-log-summaries/README.md
+++ b/tasks/archive/issue-133-orchestration-log-summaries/README.md
@@ -1,0 +1,61 @@
+# Issue #133 Orchestration Log Summaries
+
+## Purpose
+
+- Start the read-only helper-script slice for Issue `#133` so orchestration runs can be summarized and checked without ad hoc NDJSON inspection.
+
+## Primary issue
+
+- Issue: `#133` https://github.com/tsukushibito/codex-webui/issues/133
+
+## Source docs
+
+- `artifacts/execution_orchestrator/README.md`
+- `.agents/skills/codex-webui-orchestration-log/SKILL.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+
+## Scope for this package
+
+- add read-only helper scripts under `.agents/skills/codex-webui-orchestration-log/` for concise run summaries, anomaly-focused summaries, and basic log consistency checks
+- keep the helpers operational and short so they are suitable for orchestration routing and handoff use
+- keep the slice limited to Issue `#133`; sequence semantics and delegated-role guidance stay with sibling slices `#134` and `#135`
+
+## Exit criteria
+
+- documented read-only helper scripts exist for run summary and consistency checks
+- the helpers work against `artifacts/execution_orchestrator/runs/<run_id>/events.ndjson`
+- outputs stay concise and highlight anomalies and terminal/run-state problems without dumping raw logs
+
+## Work plan
+
+- inspect the current orchestration-log script layout and the existing issue-127 run artifact
+- implement the minimum read-only scripts needed for run summary, anomaly summary, and consistency checks
+- add or update skill documentation so the helper usage is discoverable from the orchestration-log workflow
+- run focused validation against the reference run artifact and record the commands used
+
+## Artifacts / evidence
+
+- `.agents/skills/codex-webui-orchestration-log/`
+- `artifacts/execution_orchestrator/runs/2026-04-09T14-30-02Z-issue-127-close/events.ndjson`
+- Validation run on 2026-04-10:
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --help` passed
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --run-id 2026-04-09T14-30-02Z-issue-127-close` passed and produced a concise summary
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --run-id 2026-04-09T14-30-02Z-issue-127-close --anomalies` passed and listed 26 anomaly events
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --run-id 2026-04-09T14-30-02Z-issue-127-close --check` passed and detected duplicated sequence values, multiple terminal events, and handoff count mismatches
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --run-id 2026-04-10T01-45-00Z-issue-132-close --check` passed and detected the expected in-progress run state: missing terminal event and open sprint-cycle handoff
+  - `python -m py_compile .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py` passed
+- Pre-push validation gate on 2026-04-10:
+  - all sprint validation commands passed
+  - `git diff --check` passed
+
+## Status / handoff notes
+
+- Status: `locally complete; archived after pre-push validation`
+- Notes: Created from `codex-webui-execution-orchestrator` routing for parent Issue `#132`. Issue `#133` is the first bounded execution slice because the parent issue is already split into actionable child issues and this slice can start without further Project restructuring.
+- Adoption note: On 2026-04-10, the main orchestrator adopted this package state after a prior read-only intake violation had already created the branch, worktree, and task package. The active package path, Issue `Execution` section, and Project `In Progress` status now match.
+- Implementation note: Added `summarize_run_log.py` as a dependency-free read-only helper for default run summaries, anomaly-only summaries, and basic consistency checks. Documented usage in the orchestration-log skill.
+- Completion retrospective: Package archive boundary only. The package exit criteria are satisfied by the new helper script, documented usage, concise summary/anomaly/check output, and validation against the issue-127 and current issue-132 run logs. Issue close remains blocked until this branch is merged to `main`, the parent checkout is synced, the active worktree is cleaned up, and GitHub tracking is updated.
+
+## Archive conditions
+
+- Archive this package when the helper scripts and related documentation are complete, validation is recorded, and the package handoff notes are updated.


### PR DESCRIPTION
## Summary
- add a read-only orchestration run summary/check helper
- document summary, anomaly, and consistency-check usage
- archive the #133 task package after sprint and pre-push validation

## Validation
- python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --help
- python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --run-id 2026-04-09T14-30-02Z-issue-127-close
- python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --run-id 2026-04-09T14-30-02Z-issue-127-close --anomalies
- python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --run-id 2026-04-09T14-30-02Z-issue-127-close --check
- python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --run-id 2026-04-10T01-45-00Z-issue-132-close --check
- python -m py_compile .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py
- git diff --check

Closes #133