### PR TITLE
Infra: Harden execution-orchestrator event sequencing and run terminal semantics

### DIFF
--- a/.agents/skills/codex-webui-orchestration-log/SKILL.md
+++ b/.agents/skills/codex-webui-orchestration-log/SKILL.md
@@ -42,6 +42,16 @@ The helper script also appends a token-usage snapshot under `details.token_usage
 - Prefer `YYYY-MM-DDTHH-mm-ssZ-<goal-slug>`
 - Keep the slug short and path-safe
 
+## Run Segment Contract
+
+- The first segment in a run must start with `run_started`
+- Later segments must start with `run_resumed`
+- `run_resumed` is valid only after an earlier segment ended with `run_completed` or `run_blocked`
+- After `run_completed` or `run_blocked`, no further event may be appended until `run_resumed` opens the next segment
+- Each closed segment ends with exactly one terminal event: `run_completed` or `run_blocked`
+
+The append helper enforces this contract on write, and `scripts/summarize_run_log.py --check` reports boundary violations in existing logs without repairing them.
+
 ## Event Coverage
 
 At minimum, log these events when they happen:
@@ -123,7 +133,7 @@ python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py
   --check
 ```
 
-The check view reports invalid JSON lines, duplicated sequence values, missing or multiple terminal events, and mismatched `handoff_started` / `handoff_completed` counts. It is intentionally read-only and does not repair log files.
+The check view reports invalid JSON lines, duplicated sequence values, missing terminal events, segment terminal violations, `run_resumed` boundary violations, and mismatched `handoff_started` / `handoff_completed` counts. It is intentionally read-only and does not repair log files.
 
 ## Guardrails
 

--- a/.agents/skills/codex-webui-orchestration-log/scripts/append_run_event.py
+++ b/.agents/skills/codex-webui-orchestration-log/scripts/append_run_event.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 import re
@@ -12,6 +13,8 @@ from typing import Any
 
 
 RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+TERMINAL_EVENTS = {"run_completed", "run_blocked"}
+SEGMENT_START_EVENTS = {"run_started", "run_resumed"}
 
 
 def parse_args() -> argparse.Namespace:
@@ -83,13 +86,6 @@ def parse_details(raw: str | None) -> dict | None:
     return value
 
 
-def next_sequence(events_path: Path) -> int:
-    if not events_path.exists():
-        return 1
-    with events_path.open("r", encoding="utf-8") as handle:
-        return sum(1 for _ in handle) + 1
-
-
 def validate_args(args: argparse.Namespace) -> None:
     if not RUN_ID_PATTERN.match(args.run_id):
         raise SystemExit(
@@ -110,6 +106,99 @@ def parse_jsonl_line(raw_line: str) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
     return value
+
+
+def read_existing_events(events_path: Path) -> list[dict[str, Any]]:
+    if not events_path.exists():
+        return []
+
+    events: list[dict[str, Any]] = []
+    with events_path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            record = parse_jsonl_line(raw_line)
+            if record is not None:
+                events.append(record)
+    return events
+
+
+def next_sequence(events: list[dict[str, Any]]) -> int:
+    sequences = [
+        event.get("sequence")
+        for event in events
+        if isinstance(event.get("sequence"), int)
+    ]
+    if not sequences:
+        return 1
+    return max(sequences) + 1
+
+
+def event_ref(event: dict[str, Any]) -> str:
+    sequence = event.get("sequence")
+    if isinstance(sequence, int):
+        return f"seq {sequence}"
+    return "existing event"
+
+
+def validate_transition(event_type: str, events: list[dict[str, Any]]) -> None:
+    if not events:
+        if event_type != "run_started":
+            raise SystemExit(
+                "cannot append event: first event in a run must be run_started."
+            )
+        return
+
+    last_event = events[-1]
+    last_event_type = last_event.get("event_type")
+
+    if last_event_type in TERMINAL_EVENTS and event_type != "run_resumed":
+        raise SystemExit(
+            "cannot append event after terminal event "
+            f"{event_ref(last_event)} {last_event_type}: "
+            "append run_resumed to open a new segment."
+        )
+
+    if event_type == "run_started":
+        raise SystemExit(
+            "cannot append run_started after the first segment: "
+            "use run_resumed only after a terminal event."
+        )
+
+    if event_type == "run_resumed":
+        if last_event_type not in TERMINAL_EVENTS:
+            raise SystemExit(
+                "cannot append run_resumed before a terminal event closes "
+                f"the current segment; last event is {event_ref(last_event)} "
+                f"{last_event_type}."
+            )
+        return
+
+    seen_terminal = any(event.get("event_type") in TERMINAL_EVENTS for event in events)
+    if not seen_terminal:
+        return
+
+    last_segment_start_index = None
+    for index in range(len(events) - 1, -1, -1):
+        event = events[index]
+        if event.get("event_type") in SEGMENT_START_EVENTS:
+            last_segment_start_index = index
+            break
+
+    if last_segment_start_index is None:
+        raise SystemExit(
+            "cannot append event: run history is missing a segment start "
+            "event (run_started or run_resumed)."
+        )
+
+    terminal_count = sum(
+        1
+        for event in events[last_segment_start_index:]
+        if event.get("event_type") in TERMINAL_EVENTS
+    )
+    if terminal_count > 1:
+        raise SystemExit(
+            "cannot append event: current segment already contains multiple "
+            "terminal events; append-only history must be repaired manually."
+        )
 
 
 def find_session_file(root: Path, thread_id: str) -> Path | None:
@@ -312,10 +401,17 @@ def main() -> int:
     run_dir = root / "runs" / args.run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     events_path = run_dir / "events.ndjson"
+    lock_path = run_dir / ".events.lock"
 
-    event = build_event(args, next_sequence(events_path), details)
-    with events_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    with lock_path.open("a+", encoding="utf-8") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        events = read_existing_events(events_path)
+        validate_transition(args.event_type, events)
+        event = build_event(args, next_sequence(events), details)
+        with events_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
 
     print(events_path)
     return 0

--- a/.agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py
+++ b/.agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py
@@ -10,8 +10,6 @@ from typing import Any
 
 
 TERMINAL_EVENTS = {"run_completed", "run_blocked"}
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Read an orchestration run log and print concise operational views."
@@ -200,6 +198,88 @@ def handoff_mismatches(events: list[dict[str, Any]]) -> list[str]:
     return mismatches
 
 
+def event_ref(event: dict[str, Any], fallback_index: int) -> str:
+    sequence = event.get("sequence")
+    if isinstance(sequence, int):
+        return f"seq {sequence}"
+    return f"event {fallback_index}"
+
+
+def segment_boundary_findings(events: list[dict[str, Any]]) -> list[str]:
+    findings: list[str] = []
+    if not events:
+        return findings
+
+    segment_start_index: int | None = None
+    terminal_event: tuple[int, dict[str, Any]] | None = None
+
+    for index, event in enumerate(events, start=1):
+        event_type = event.get("event_type")
+        current_ref = event_ref(event, index)
+
+        if segment_start_index is None:
+            if event_type != "run_started":
+                findings.append(
+                    f"run_resumed boundary violation: first segment must start with "
+                    f"run_started, saw {current_ref} {event_type}"
+                )
+                segment_start_index = index
+            else:
+                segment_start_index = index
+            if event_type in TERMINAL_EVENTS:
+                terminal_event = (index, event)
+            continue
+
+        if terminal_event is not None:
+            terminal_index, terminal = terminal_event
+            terminal_ref = event_ref(terminal, terminal_index)
+            terminal_type = terminal.get("event_type")
+            if event_type != "run_resumed":
+                findings.append(
+                    f"run_resumed boundary violation: expected run_resumed after "
+                    f"{terminal_ref} {terminal_type}, saw {current_ref} {event_type}"
+                )
+                if event_type in TERMINAL_EVENTS:
+                    findings.append(
+                        f"terminal event violation: segment starting at "
+                        f"{event_ref(events[segment_start_index - 1], segment_start_index)} "
+                        f"contains multiple terminal events including "
+                        f"{terminal_ref} {terminal_type} and {current_ref} {event_type}"
+                    )
+                    terminal_event = (index, event)
+                continue
+
+            terminal_event = None
+            segment_start_index = index
+            continue
+
+        if event_type == "run_started":
+            findings.append(
+                f"run_resumed boundary violation: later segments must start with "
+                f"run_resumed, saw {current_ref} run_started"
+            )
+            segment_start_index = index
+            terminal_event = None
+            continue
+
+        if event_type == "run_resumed":
+            findings.append(
+                f"run_resumed boundary violation: {current_ref} run_resumed appears "
+                "before a terminal event closes the current segment"
+            )
+            segment_start_index = index
+            terminal_event = None
+            continue
+
+        if event_type in TERMINAL_EVENTS:
+            terminal_event = (index, event)
+
+    if terminal_event is None:
+        findings.append("missing terminal event: expected run_completed or run_blocked")
+
+    return findings
+
+
 def print_check(events: list[dict[str, Any]], invalid_lines: list[str]) -> None:
     findings: list[str] = []
 
@@ -212,15 +292,7 @@ def print_check(events: list[dict[str, Any]], invalid_lines: list[str]) -> None:
             "duplicate sequence values: " + ", ".join(str(sequence) for sequence in duplicates)
         )
 
-    terminals = [event for event in events if event.get("event_type") in TERMINAL_EVENTS]
-    if not terminals:
-        findings.append("missing terminal event: expected run_completed or run_blocked")
-    elif len(terminals) > 1:
-        terminal_refs = ", ".join(
-            f"seq {event_value(event, 'sequence')} {event_value(event, 'event_type')}"
-            for event in terminals
-        )
-        findings.append(f"multiple terminal events: {terminal_refs}")
+    findings.extend(segment_boundary_findings(events))
 
     for mismatch in handoff_mismatches(events):
         findings.append(f"handoff started/completed mismatch: {mismatch}")

--- a/artifacts/execution_orchestrator/README.md
+++ b/artifacts/execution_orchestrator/README.md
@@ -29,6 +29,16 @@ artifacts/execution_orchestrator/
 - Prefer structured fields such as `issue`, `skill`, `target`, and `details` over long prose
 - Do not copy full command transcripts, secrets, or large outputs into the log
 
+## Run segment contract
+
+- The first segment in a run starts with `run_started`
+- Each later segment starts with `run_resumed`
+- `run_resumed` is allowed only after a prior `run_completed` or `run_blocked`
+- After `run_completed` or `run_blocked`, the next appended event must be `run_resumed`
+- Each closed segment ends with exactly one terminal event: `run_completed` or `run_blocked`
+
+Use `.agents/skills/codex-webui-orchestration-log/scripts/append_run_event.py` to enforce this contract during append, and use `.agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --check` to detect boundary violations in existing logs.
+
 ## Minimum event schema
 
 Each event should include at least:

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-134-orchestrator-run-semantics](./archive/issue-134-orchestrator-run-semantics/README.md)
 - [issue-133-orchestration-log-summaries](./archive/issue-133-orchestration-log-summaries/README.md)
 - [app_server_behavior_validation](./archive/app_server_behavior_validation/README.md)
 - [issue-117-wiki-agent-guidance](./archive/issue-117-wiki-agent-guidance/README.md)

--- a/tasks/archive/issue-134-orchestrator-run-semantics/README.md
+++ b/tasks/archive/issue-134-orchestrator-run-semantics/README.md
@@ -1,0 +1,62 @@
+# Issue #134 Orchestrator Run Semantics
+
+## Purpose
+
+- Execute the log-semantics hardening slice for Issue `#134` so orchestration runs remain append-only, replayable, and machine-checkable across terminal and resumed boundaries.
+
+## Primary issue
+
+- Issue: `#134` https://github.com/tsukushibito/codex-webui/issues/134
+
+## Source docs
+
+- `artifacts/execution_orchestrator/README.md`
+- `.agents/skills/codex-webui-orchestration-log/SKILL.md`
+- `.agents/skills/codex-webui-execution-orchestrator/SKILL.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+
+## Scope for this package
+
+- harden `.agents/skills/codex-webui-orchestration-log/scripts/append_run_event.py` so event sequencing stays unambiguous during append and resume flows
+- tighten terminal and resume semantics in the orchestration log guidance and any read-only helpers that check or summarize runs
+- keep the slice focused on Issue `#134`; delegated-role prompting and fallback classification remain with sibling Issue `#135`
+
+## Exit criteria
+
+- event append no longer permits duplicated sequence ambiguity within one run log
+- terminal events and resumed-pass boundaries are documented in a machine-checkable way
+- consistency checks fail fast when a run violates the documented terminal or resume contract
+- the reference issue-127 run either becomes representable under the clarified rules or is flagged immediately by the checker
+
+## Work plan
+
+- inspect the current append helper, log checker, and run artifacts to isolate the sequence and terminal-state failure modes
+- implement the minimum helper changes needed to make append/resume semantics explicit and detectable
+- update the orchestration-log and execution-orchestrator guidance so the emitted events match the helper behavior
+- run focused validation against the existing issue-127 run artifact and the active issue-132 closeability run
+
+## Artifacts / evidence
+
+- `.agents/skills/codex-webui-orchestration-log/scripts/append_run_event.py`
+- `.agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py`
+- `artifacts/execution_orchestrator/README.md`
+- `artifacts/execution_orchestrator/runs/2026-04-09T14-30-02Z-issue-127-close/events.ndjson`
+- `artifacts/execution_orchestrator/runs/2026-04-10T01-45-00Z-issue-132-close/events.ndjson`
+- Local validation on 2026-04-10:
+  - `python -m py_compile .agents/skills/codex-webui-orchestration-log/scripts/append_run_event.py .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py` passed
+  - concurrency and transition-guard temp-root harness passed with strictly increasing `sequence` values and expected terminal/resume rejections
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --events-path /workspace/artifacts/execution_orchestrator/runs/2026-04-09T14-30-02Z-issue-127-close/events.ndjson --check` passed with expected `run_resumed boundary violation` findings
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --events-path /workspace/artifacts/execution_orchestrator/runs/2026-04-10T01-45-00Z-issue-132-close/events.ndjson --check` passed with the expected in-progress findings and no false `run_resumed` boundary hit
+- Pre-push validation gate on 2026-04-10:
+  - dedicated validator gate passed after rerunning the checker commands with explicit expected-output assertions
+  - `git diff --check` passed
+
+## Status / handoff notes
+
+- Status: `locally complete; archived after pre-push validation`
+- Notes: Created from `codex-webui-execution-orchestrator` routing for parent Issue `#132` after Issue `#133` merged to `main`. This slice hardened append-time sequence allocation with file locking, enforced terminal/resume segment boundaries, and extended the read-only checker to diagnose `run_resumed` boundary violations in historical run logs.
+- Completion retrospective: Package archive boundary only. Contract check for Issue `#134` is satisfied at the local slice level by the helper changes, the documented run-segment contract, the focused checker behavior, evaluator approval, and the dedicated pre-push validation pass. What worked: the bounded slice stayed within the logger helper and docs write scope. Workflow problems: delegated intake timed out repeatedly, and the first validator pass treated expected diagnostic findings as failures because the commands did not assert expected output. Improvements to adopt: validator prompts for diagnostic checkers should encode expected findings explicitly, and the repeated delegated-agent timeout pattern remains a follow-up input for sibling Issue `#135`. Follow-up updates: publish the branch, merge to `main`, clean up the worktree, and then close Issue `#134`.
+
+## Archive conditions
+
+- Archive this package when the helper and doc changes are complete, focused validation is recorded, and the package handoff notes are updated after the dedicated pre-push validation gate passes.


### PR DESCRIPTION
## Summary
- harden orchestration log appends with serialized sequence allocation and strict segment transition guards
- extend the run checker to report terminal and run_resumed boundary violations in historical logs
- document the enforced run segment contract and archive the local Issue #134 package

Closes #134