### PR TITLE
Infra: Clarify read-only subagent fallback rules

### DIFF
--- a/.agents/skills/codex-webui-execution-orchestrator/SKILL.md
+++ b/.agents/skills/codex-webui-execution-orchestrator/SKILL.md
@@ -105,6 +105,21 @@ Append an `anomaly` event immediately when any of the following happens:
 - the logger script itself fails
 - execution hits a real hard block and the loop must stop
 
+## Delegated Failure Fallback Classes
+
+Classify delegated-role failures from verified state, not from the delegated agent's self-report.
+Check observed side effects, dirty state, and repo/task/GitHub drift before deciding how to continue.
+
+Use exactly one fallback class:
+
+- `continue`: no verified mutation and no blocking drift; rerun or proceed with a tighter prompt or corrected command framing
+- `quarantine`: unexpected side effects are isolated and non-blocking; log them, exclude the contaminated output from routing judgment, and continue from verified clean inputs
+- `hard_stop_recoverable`: verified repo/task/GitHub mutation or ambiguous dirty state requires explicit cleanup or user-visible recovery before the loop can continue
+- `hard_stop_terminal`: verified mutation or state damage is severe enough that the current loop must stop and hand back a terminal blocker instead of attempting more routing
+
+Do not classify a failure as `continue` only because the delegated agent said it was read-only or harmless.
+The orchestrator owns the classification after checking verified state.
+
 When a resumable stop requires `codex-webui-execution-handoff`, log the failed or blocked condition first, then log the selected handoff and its result. Include the created `.tmp/` handoff path in `details` when available.
 
 Use concise structured entries. Do not dump long transcripts into the run log.
@@ -149,6 +164,25 @@ Every delegated intake message must include all of the following, in plain terms
 Minimum acceptable pattern:
 
 > Use `$codex-webui-work-intake` for this intake pass. This is read-only routing work. Do not edit files, mutate GitHub/Project/task state, or start servers. Inspect Project, issues, tasks, worktree, and relevant docs, then return a concise routing summary with one recommended current target.
+
+Reusable fallback clause for delegated read-only roles:
+
+> If you cannot complete the read-only task cleanly, stop and report only verified observations: what you checked, whether `observed_side_effects` are `none_beyond_reads` or concrete mutations, and what output is unusable. Do not classify the fallback yourself, do not repair drift, and do not create handoff files or other side effects unless explicitly asked.
+
+## Delegated Failure Mapping
+
+Apply these observed-state rules before selecting the next step:
+
+- `delegated_intake_timeout`, failed intake, or unusable intake with no verified side effects: `continue`
+- planner wrong-shape output with `observed_side_effects: none_beyond_reads`: `continue` with tighter prompt and retry
+- validator wrong-command or wrong-run-id framing error with no mutation: `continue` with corrected expected-output framing
+- isolated unexpected side effects such as a stray `.tmp` handoff output, with verified repo/task/GitHub state otherwise clean: `quarantine`
+- verified repo/task/GitHub mutations, or ambiguous dirty state that might hide mutations: `hard_stop_recoverable` unless the damage makes the current run unsafe to resume
+- severe verified state damage or a mutation path that makes safe recovery impossible in the current run: `hard_stop_terminal`
+
+For `continue`, rerun only after tightening the prompt or correcting command framing.
+For `quarantine`, log the side effect explicitly, ignore the contaminated delegated output for routing judgment, and continue from verified clean state.
+For `hard_stop_recoverable` and `hard_stop_terminal`, log the blocker, stop the loop, and route only the recovery or handoff outcome that matches the verified state.
 
 ## Routing Rules
 

--- a/.agents/skills/codex-webui-orchestration-log/SKILL.md
+++ b/.agents/skills/codex-webui-orchestration-log/SKILL.md
@@ -73,6 +73,17 @@ Use `anomaly` for problems such as:
 - the logger script failing
 - a hard block that stops the continue-until loop
 
+Every `anomaly` event must record structured fallback details in `details`:
+
+- `failed_agent_role`
+- `failure_kind`
+- `observed_side_effects`
+- `fallback_class`
+- `remediation`
+- exactly one outcome field: `continued`, `quarantined`, or `stopped`
+
+Prefer short enumerated values over prose. Base `fallback_class` on verified side effects and state drift, not on the delegated agent's own claim.
+
 ## Helper Script
 
 Append events with:
@@ -105,6 +116,19 @@ Token usage notes:
 - when direct subagent sessions are discoverable from the local Codex session logs, they are included under `details.token_usage_snapshot.direct_subagents`
 - `aggregate_total_token_usage` is the sum of the current thread and known direct subagents at snapshot time
 - when the current thread or session log cannot be resolved, the snapshot still records `available: false` with an `unavailable_reason`
+
+For anomaly events, expand `--details-json` to include the required fallback fields. Minimum shape:
+
+```bash
+--details-json '{
+  "failed_agent_role": "validator",
+  "failure_kind": "wrong_command_framing",
+  "observed_side_effects": "none_beyond_reads",
+  "fallback_class": "continue",
+  "remediation": "rerun with corrected expected-output framing",
+  "continued": true
+}'
+```
 
 ## Run Inspection Helper
 

--- a/.agents/skills/codex-webui-pre-push-validation/SKILL.md
+++ b/.agents/skills/codex-webui-pre-push-validation/SKILL.md
@@ -12,6 +12,7 @@ Use this skill to run the dedicated pre-push validation gate after local complet
 This skill exists outside the default sprint loop. A sprint may be evaluator-approved and still not be ready for push, merge, package archive, or completion tracking until this gate passes.
 
 The gate uses the read-only `validator` agent for procedural command execution and evidence capture only. It does not replace `evaluator`, and it does not approve scope changes.
+Validator output is evidence only. It must not judge approval, decide whether the slice should merge, or convert expected diagnostic findings into automatic gate failures.
 
 ## When To Use
 
@@ -47,9 +48,10 @@ Read `README.md`, `AGENTS.md`, `tasks/README.md`, and the active task package `R
 2. Identify the exact pre-push validation commands that should run now. Prefer commands already named by the planner, task package, or source-of-truth docs, plus any narrow read-only inspections needed to explain failures. For changes under `apps/frontend-bff` or `apps/codex-runtime` that are covered by the app-local Biome scripts, include each touched app's local `npm run check` as a required Biome lint/style gate before any push-oriented handoff.
 3. Spawn the read-only `validator` agent and explicitly tell it that this is the dedicated pre-push validation gate, not part of the default sprint loop.
 4. In the validator prompt, require read-only command execution, faithful evidence capture, and no approval judgment, file edits, commits, pushes, or tracking mutations.
-5. Review the validator result locally for command coverage, pass/fail status, and any blocked commands.
-6. If the validator finds failures, missing prerequisites, or commands that cannot run, stop the publish-oriented path and report the gate as failed.
-7. If the validator evidence is complete and the required commands pass, report the gate as passed and hand back the evidence summary for the next publish-oriented skill.
+5. Review the validator result locally for command coverage, pass/fail status, expected diagnostic findings, and any blocked commands.
+6. Treat pre-declared expected diagnostic findings as evidence, not as automatic gate failures. Wrong-command or wrong-run-id framing errors with no side effects are recoverable rerun cases with corrected expected-output framing.
+7. If the validator finds real failures, missing prerequisites, or commands that cannot run after any recoverable rerun, stop the publish-oriented path and report the gate as failed.
+8. If the validator evidence is complete and the required commands pass or match the pre-declared expected diagnostic findings, report the gate as passed and hand back the evidence summary for the next publish-oriented skill.
 
 ## Required Validator Prompt Content
 
@@ -60,10 +62,11 @@ Every validator prompt for this skill must include all of the following:
 - an explicit prohibition on editing files, creating commits, pushing branches, or mutating GitHub/task state
 - the exact commands to run and the exact worktree to inspect
 - an explicit instruction to return evidence only and not judge approval
+- any pre-declared expected diagnostic findings that should be treated as read-only evidence rather than as gate failures
 
 Minimum acceptable pattern:
 
-> This is the dedicated `codex-webui` pre-push validation gate. Stay read-only. Do not edit files, create commits, push branches, or mutate GitHub/task state. Run only these commands in `<worktree>`, capture their outcomes faithfully, and return evidence only without judging approval.
+> This is the dedicated `codex-webui` pre-push validation gate. Stay read-only. Do not edit files, create commits, push branches, or mutate GitHub/task state. Run only these commands in `<worktree>`, capture their outcomes faithfully, treat the declared expected diagnostic findings as evidence only, and return evidence only without judging approval.
 
 ## Output Contract
 
@@ -87,6 +90,8 @@ If the gate passes, `Next handoff` should name the publish-oriented skill or wor
 - Do not treat sprint approval as a substitute for this gate when publish-oriented handoff is next
 - Do not let `validator` edit files, create commits, push, merge, or update tracking state
 - Do not let `validator` decide whether the slice is approved or complete
+- Do not treat pre-declared expected diagnostic findings from read-only checker commands as automatic gate failures
+- Do not treat wrong-command or wrong-run-id framing errors with no side effects as anything other than recoverable rerun cases
 - Do not broaden pre-push validation beyond the commands needed for the current handoff without saying so explicitly
 - Do not continue to push-oriented, merge-oriented, or archive-oriented handoff when the gate has failing or missing evidence
 

--- a/artifacts/execution_orchestrator/README.md
+++ b/artifacts/execution_orchestrator/README.md
@@ -78,6 +78,18 @@ Record an `anomaly` event when any of the following happens:
 - a logger invocation fails
 - the orchestration loop stops on a concrete hard block
 
+Each `anomaly` event must include these structured `details` fields:
+
+- `failed_agent_role`
+- `failure_kind`
+- `observed_side_effects`
+- `fallback_class`
+- `remediation`
+- exactly one outcome field: `continued`, `quarantined`, or `stopped`
+
+Use `fallback_class` values `continue`, `quarantine`, `hard_stop_recoverable`, or `hard_stop_terminal`.
+Set the outcome field from verified state and the orchestrator decision, not from delegated self-report.
+
 ## Usage note
 
 Use `.agents/skills/codex-webui-orchestration-log/scripts/append_run_event.py` to append events instead of writing `events.ndjson` manually.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-135-read-only-fallback-rules](./archive/issue-135-read-only-fallback-rules/README.md)
 - [issue-134-orchestrator-run-semantics](./archive/issue-134-orchestrator-run-semantics/README.md)
 - [issue-133-orchestration-log-summaries](./archive/issue-133-orchestration-log-summaries/README.md)
 - [app_server_behavior_validation](./archive/app_server_behavior_validation/README.md)

--- a/tasks/archive/issue-135-read-only-fallback-rules/README.md
+++ b/tasks/archive/issue-135-read-only-fallback-rules/README.md
@@ -1,0 +1,72 @@
+# Issue #135 Read-Only Fallback Rules
+
+## Purpose
+
+- Execute the delegated-agent policy slice for Issue `#135` so orchestrator routing can classify read-only violations and unusable delegated results with explicit recovery rules.
+
+## Primary issue
+
+- Issue: `#135` https://github.com/tsukushibito/codex-webui/issues/135
+
+## Source docs
+
+- `artifacts/execution_orchestrator/README.md`
+- `.agents/skills/codex-webui-orchestration-log/SKILL.md`
+- `.agents/skills/codex-webui-execution-orchestrator/SKILL.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+
+## Scope for this package
+
+- tighten orchestrator guidance so delegated intake and evaluator prompts explicitly invoke the intended read-only role guidance
+- document and enforce the fallback classes for missing, unusable, or policy-violating delegated results
+- keep the slice focused on Issue `#135`; log sequence and terminal semantics already landed in sibling Issue `#134`
+
+## Exit criteria
+
+- delegated read-only prompts have explicit reusable guidance for intended role/skill invocation
+- orchestration docs distinguish `continue`, `quarantine`, `hard_stop_recoverable`, and `hard_stop_terminal`
+- fallback handling is based on observed side effects and verified drift, not delegated self-report
+- orchestration logging guidance records violation class, remediation decision, and whether execution resumed or stopped
+
+## Work plan
+
+- inspect the current orchestrator, orchestration-log, and related workflow docs against the now-observed timeout and read-only drift patterns
+- implement the minimum doc and helper updates needed to make delegated read-only fallback behavior explicit and reusable
+- validate the new guidance against the existing issue-127 and issue-132 orchestration evidence without broadening into unrelated workflow changes
+
+## Artifacts / evidence
+
+- `.agents/skills/codex-webui-execution-orchestrator/SKILL.md`
+- `.agents/skills/codex-webui-orchestration-log/SKILL.md`
+- `.agents/skills/codex-webui-pre-push-validation/SKILL.md`
+- `artifacts/execution_orchestrator/README.md`
+- `artifacts/execution_orchestrator/runs/2026-04-09T14-30-02Z-issue-127-close/events.ndjson`
+- `artifacts/execution_orchestrator/runs/2026-04-10T01-45-00Z-issue-132-close/events.ndjson`
+- Sprint validation:
+  - `git diff --check`
+  - `rg -n "continue|quarantine|hard_stop_recoverable|hard_stop_terminal" .agents/skills/codex-webui-execution-orchestrator/SKILL.md .agents/skills/codex-webui-orchestration-log/SKILL.md artifacts/execution_orchestrator/README.md`
+  - `rg -n "failed_agent_role|failure_kind|observed_side_effects|fallback_class|remediation|continued|quarantined|stopped" .agents/skills/codex-webui-orchestration-log/SKILL.md artifacts/execution_orchestrator/README.md`
+  - `rg -n "expected diagnostic|evidence only|not judge approval|read-only" .agents/skills/codex-webui-pre-push-validation/SKILL.md`
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --events-path /workspace/artifacts/execution_orchestrator/runs/2026-04-09T14-30-02Z-issue-127-close/events.ndjson --anomalies`
+  - `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --events-path /workspace/artifacts/execution_orchestrator/runs/2026-04-10T01-45-00Z-issue-132-close/events.ndjson --anomalies`
+- Dedicated pre-push validation:
+  - Initial validator run reported `failed` because it treated expected pre-commit implementation diffs as a clean-worktree blocker.
+  - Retry validator run reported `passed` after the prompt explicitly framed the expected dirty worktree as evidence, not a gate failure.
+  - Retry evidence: commands above passed and `git status --short` showed only the expected implementation and package changes.
+
+## Status / handoff notes
+
+- Status: `locally complete; archived after pre-push validation`
+- Notes: Created from `codex-webui-execution-orchestrator` routing for parent Issue `#132` after Issue `#134` reached `main`. The completed slice codifies read-only prompting and delegated fallback boundaries observed in the current orchestration run, without changing product code or reopening the log-semantics work from `#134`.
+- Completion retrospective:
+  - Completion boundary: package archive after evaluator approval and dedicated pre-push validation.
+  - Contract check: Issue `#135` conditions are satisfied locally by reusable delegated-role prompt guidance, fallback class taxonomy, side-effect-based violation handling, hard-stop recovery rules, terminal handoff policy, and structured anomaly logging guidance.
+  - What worked: the retry validator framing matched the new policy and cleanly distinguished expected implementation diffs from real blockers.
+  - Workflow problems: the first validator run repeated the exact ambiguity this Issue fixes by treating expected dirty state as a gate failure.
+  - Improvements to adopt: future validation prompts should predeclare expected diagnostics and expected status entries when the branch is intentionally pre-commit.
+  - Skill candidates or skill updates: no new skill needed; this package updates the existing orchestrator, log, and pre-push validation skills.
+  - Follow-up updates: merge this branch, sync `main`, remove the worktree, then let GitHub-side tracking close Issue `#135`.
+
+## Archive conditions
+
+- Archived after the delegated-role guidance and fallback policy updates were completed, focused validation was recorded, and the dedicated pre-push validation gate passed.


### PR DESCRIPTION
## Summary

- document delegated read-only fallback classes for continue/quarantine/hard-stop cases
- require structured anomaly details for fallback classification and outcomes
- clarify pre-push validator evidence-only framing for expected diagnostics
- archive the #135 task package after dedicated pre-push validation

## Validation

- `git diff --check`
- `rg -n "continue|quarantine|hard_stop_recoverable|hard_stop_terminal" .agents/skills/codex-webui-execution-orchestrator/SKILL.md .agents/skills/codex-webui-orchestration-log/SKILL.md artifacts/execution_orchestrator/README.md`
- `rg -n "failed_agent_role|failure_kind|observed_side_effects|fallback_class|remediation|continued|quarantined|stopped" .agents/skills/codex-webui-orchestration-log/SKILL.md artifacts/execution_orchestrator/README.md`
- `rg -n "expected diagnostic|evidence only|not judge approval|read-only" .agents/skills/codex-webui-pre-push-validation/SKILL.md`
- `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --events-path /workspace/artifacts/execution_orchestrator/runs/2026-04-09T14-30-02Z-issue-127-close/events.ndjson --anomalies`
- `python .agents/skills/codex-webui-orchestration-log/scripts/summarize_run_log.py --events-path /workspace/artifacts/execution_orchestrator/runs/2026-04-10T01-45-00Z-issue-132-close/events.ndjson --anomalies`

Closes #135
