### PR TITLE
[codex] Cut over BFF thread request REST routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 .next/
 dist/
 coverage/
+*.tsbuildinfo
 .DS_Store
 apps/frontend-bff/playwright-report/
 apps/frontend-bff/test-results/

--- a/apps/frontend-bff/app/api/v1/requests/[requestId]/response/route.ts
+++ b/apps/frontend-bff/app/api/v1/requests/[requestId]/response/route.ts
@@ -1,0 +1,6 @@
+import { postRequestResponse } from "../../../../../../src/handlers";
+
+export async function POST(request: Request, context: { params: Promise<{ requestId: string }> }) {
+  const { requestId } = await context.params;
+  return postRequestResponse(request, requestId);
+}

--- a/apps/frontend-bff/app/api/v1/requests/[requestId]/route.ts
+++ b/apps/frontend-bff/app/api/v1/requests/[requestId]/route.ts
@@ -1,0 +1,6 @@
+import { getRequestDetail } from "../../../../../src/handlers";
+
+export async function GET(request: Request, context: { params: Promise<{ requestId: string }> }) {
+  const { requestId } = await context.params;
+  return getRequestDetail(request, requestId);
+}

--- a/apps/frontend-bff/app/api/v1/threads/[threadId]/inputs/route.ts
+++ b/apps/frontend-bff/app/api/v1/threads/[threadId]/inputs/route.ts
@@ -1,0 +1,6 @@
+import { postThreadInput } from "../../../../../../src/handlers";
+
+export async function POST(request: Request, context: { params: Promise<{ threadId: string }> }) {
+  const { threadId } = await context.params;
+  return postThreadInput(request, threadId);
+}

--- a/apps/frontend-bff/app/api/v1/threads/[threadId]/interrupt/route.ts
+++ b/apps/frontend-bff/app/api/v1/threads/[threadId]/interrupt/route.ts
@@ -1,0 +1,6 @@
+import { postThreadInterrupt } from "../../../../../../src/handlers";
+
+export async function POST(request: Request, context: { params: Promise<{ threadId: string }> }) {
+  const { threadId } = await context.params;
+  return postThreadInterrupt(request, threadId);
+}

--- a/apps/frontend-bff/app/api/v1/threads/[threadId]/pending_request/route.ts
+++ b/apps/frontend-bff/app/api/v1/threads/[threadId]/pending_request/route.ts
@@ -1,0 +1,6 @@
+import { getPendingRequest } from "../../../../../../src/handlers";
+
+export async function GET(request: Request, context: { params: Promise<{ threadId: string }> }) {
+  const { threadId } = await context.params;
+  return getPendingRequest(request, threadId);
+}

--- a/apps/frontend-bff/app/api/v1/threads/[threadId]/route.ts
+++ b/apps/frontend-bff/app/api/v1/threads/[threadId]/route.ts
@@ -1,0 +1,6 @@
+import { getThread } from "../../../../../src/handlers";
+
+export async function GET(request: Request, context: { params: Promise<{ threadId: string }> }) {
+  const { threadId } = await context.params;
+  return getThread(request, threadId);
+}

--- a/apps/frontend-bff/app/api/v1/threads/[threadId]/timeline/route.ts
+++ b/apps/frontend-bff/app/api/v1/threads/[threadId]/timeline/route.ts
@@ -1,0 +1,6 @@
+import { getTimeline } from "../../../../../../src/handlers";
+
+export async function GET(request: Request, context: { params: Promise<{ threadId: string }> }) {
+  const { threadId } = await context.params;
+  return getTimeline(request, threadId);
+}

--- a/apps/frontend-bff/app/api/v1/threads/[threadId]/view/route.ts
+++ b/apps/frontend-bff/app/api/v1/threads/[threadId]/view/route.ts
@@ -1,0 +1,6 @@
+import { getThreadView } from "../../../../../../src/handlers";
+
+export async function GET(request: Request, context: { params: Promise<{ threadId: string }> }) {
+  const { threadId } = await context.params;
+  return getThreadView(request, threadId);
+}

--- a/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/inputs/route.ts
+++ b/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/inputs/route.ts
@@ -1,0 +1,9 @@
+import { postWorkspaceInput } from "../../../../../../src/handlers";
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ workspaceId: string }> },
+) {
+  const { workspaceId } = await context.params;
+  return postWorkspaceInput(request, workspaceId);
+}

--- a/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/threads/route.ts
+++ b/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/threads/route.ts
@@ -1,0 +1,6 @@
+import { listThreads } from "../../../../../../src/handlers";
+
+export async function GET(request: Request, context: { params: Promise<{ workspaceId: string }> }) {
+  const { workspaceId } = await context.params;
+  return listThreads(request, workspaceId);
+}

--- a/apps/frontend-bff/package-lock.json
+++ b/apps/frontend-bff/package-lock.json
@@ -18,6 +18,7 @@
         "@playwright/test": "^1.59.1",
         "@types/node": "^24.6.0",
         "@types/react": "19.2.14",
+        "@types/react-dom": "^19.2.3",
         "jsdom": "^29.0.1",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -1878,6 +1879,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@vitest/expect": {

--- a/apps/frontend-bff/package.json
+++ b/apps/frontend-bff/package.json
@@ -27,6 +27,7 @@
     "@playwright/test": "^1.59.1",
     "@types/node": "^24.6.0",
     "@types/react": "19.2.14",
+    "@types/react-dom": "^19.2.3",
     "jsdom": "^29.0.1",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"

--- a/apps/frontend-bff/src/handlers.ts
+++ b/apps/frontend-bff/src/handlers.ts
@@ -11,9 +11,17 @@ import {
   mapEventList,
   mapMessage,
   mapMessageList,
+  mapPendingRequestView,
+  mapRequestDetail,
+  mapRequestResponseResult,
   mapSession,
   mapSessionList,
   mapStopResult,
+  mapThread,
+  mapThreadInputAcceptedResponse,
+  mapThreadList,
+  mapThreadView,
+  mapTimeline,
   mapWorkspace,
   mapWorkspaceList,
 } from "./mappings";
@@ -26,9 +34,17 @@ import type {
   RuntimeApprovalStreamEventProjection,
   RuntimeApprovalSummary,
   RuntimeMessageProjection,
+  RuntimeRequestDetailView,
+  RuntimeRequestResponseResult,
   RuntimeSessionEventProjection,
   RuntimeSessionSummary,
   RuntimeStopResult,
+  RuntimeThreadInputAcceptedResponse,
+  RuntimeThreadInterruptResponse,
+  RuntimeThreadPendingRequestView,
+  RuntimeThreadSummary,
+  RuntimeThreadViewHelper,
+  RuntimeTimelineItem,
   RuntimeWorkspaceSummary,
 } from "./runtime-types";
 
@@ -285,6 +301,189 @@ export async function getWorkspace(_request: Request, workspaceId: string) {
     }
 
     return jsonResponse(result.status, mapWorkspace(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function listThreads(request: Request, workspaceId: string) {
+  try {
+    const result = await runtimeClient.requestJson<ListResponse<RuntimeThreadSummary>>(
+      `/api/v1/workspaces/${workspaceId}/threads${forwardSearch(request)}`,
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapThreadList(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getThread(_request: Request, threadId: string) {
+  try {
+    const result = await runtimeClient.requestJson<RuntimeThreadSummary>(
+      `/api/v1/threads/${threadId}`,
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapThread(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getPendingRequest(_request: Request, threadId: string) {
+  try {
+    const result = await runtimeClient.requestJson<RuntimeThreadPendingRequestView>(
+      `/api/v1/threads/${threadId}/pending_request`,
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapPendingRequestView(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getRequestDetail(_request: Request, requestId: string) {
+  try {
+    const result = await runtimeClient.requestJson<RuntimeRequestDetailView>(
+      `/api/v1/requests/${requestId}`,
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapRequestDetail(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getThreadView(_request: Request, threadId: string) {
+  try {
+    const [viewResult, timelineResult] = await Promise.all([
+      runtimeClient.requestJson<RuntimeThreadViewHelper>(`/api/v1/threads/${threadId}/view`),
+      runtimeClient.requestJson<ListResponse<RuntimeTimelineItem>>(
+        `/api/v1/threads/${threadId}/timeline`,
+      ),
+    ]);
+
+    if (isErrorEnvelope(viewResult.body)) {
+      return passthroughRuntimeError(viewResult.status, viewResult.body);
+    }
+
+    if (isErrorEnvelope(timelineResult.body)) {
+      return passthroughRuntimeError(timelineResult.status, timelineResult.body);
+    }
+
+    return jsonResponse(viewResult.status, mapThreadView(viewResult.body, timelineResult.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getTimeline(request: Request, threadId: string) {
+  try {
+    const result = await runtimeClient.requestJson<ListResponse<RuntimeTimelineItem>>(
+      `/api/v1/threads/${threadId}/timeline${forwardSearch(request)}`,
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapTimeline(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function postWorkspaceInput(request: Request, workspaceId: string) {
+  try {
+    const result = await runtimeClient.requestJson<RuntimeThreadInputAcceptedResponse>(
+      `/api/v1/workspaces/${workspaceId}/inputs`,
+      {
+        method: "POST",
+        body: await readJsonBody(request),
+      },
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapThreadInputAcceptedResponse(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function postThreadInput(request: Request, threadId: string) {
+  try {
+    const result = await runtimeClient.requestJson<RuntimeThreadInputAcceptedResponse>(
+      `/api/v1/threads/${threadId}/inputs`,
+      {
+        method: "POST",
+        body: await readJsonBody(request),
+      },
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapThreadInputAcceptedResponse(result.body));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function postThreadInterrupt(_request: Request, threadId: string) {
+  try {
+    const result = await runtimeClient.requestJson<RuntimeThreadInterruptResponse>(
+      `/api/v1/threads/${threadId}/interrupt`,
+      {
+        method: "POST",
+        body: {},
+      },
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapThread(result.body.thread));
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function postRequestResponse(request: Request, requestId: string) {
+  try {
+    const result = await runtimeClient.requestJson<RuntimeRequestResponseResult>(
+      `/api/v1/requests/${requestId}/response`,
+      {
+        method: "POST",
+        body: await readJsonBody(request),
+      },
+    );
+
+    if (isErrorEnvelope(result.body)) {
+      return passthroughRuntimeError(result.status, result.body);
+    }
+
+    return jsonResponse(result.status, mapRequestResponseResult(result.body));
   } catch (error) {
     return toErrorResponse(error);
   }

--- a/apps/frontend-bff/src/mappings.ts
+++ b/apps/frontend-bff/src/mappings.ts
@@ -3,10 +3,19 @@ import type {
   RuntimeApprovalProjection,
   RuntimeApprovalResolveResult,
   RuntimeApprovalStreamEventProjection,
+  RuntimeLatestResolvedRequestSummary,
   RuntimeMessageProjection,
+  RuntimePendingRequestSummary,
+  RuntimeRequestDetailView,
+  RuntimeRequestResponseResult,
   RuntimeSessionEventProjection,
   RuntimeSessionSummary,
   RuntimeStopResult,
+  RuntimeThreadInputAcceptedResponse,
+  RuntimeThreadPendingRequestView,
+  RuntimeThreadSummary,
+  RuntimeThreadViewHelper,
+  RuntimeTimelineItem,
   RuntimeWorkspaceSummary,
 } from "./runtime-types";
 
@@ -34,6 +43,294 @@ export function mapWorkspaceList(response: ListResponse<RuntimeWorkspaceSummary>
     items: response.items.map(mapWorkspace),
     next_cursor: response.next_cursor,
     has_more: response.has_more,
+  };
+}
+
+function hasActiveFlag(thread: RuntimeThreadSummary, flag: string) {
+  return thread.native_status.active_flags.includes(flag);
+}
+
+function deriveThreadCurrentActivity(thread: RuntimeThreadSummary) {
+  if (thread.derived_hints.has_pending_request || hasActiveFlag(thread, "waitingOnApproval")) {
+    return {
+      kind: "waiting_on_approval",
+      label: "Approval required",
+    };
+  }
+
+  if (hasActiveFlag(thread, "systemError")) {
+    return {
+      kind: "system_error",
+      label: "System error",
+    };
+  }
+
+  if (thread.native_status.latest_turn_status === "failed") {
+    return {
+      kind: "latest_turn_failed",
+      label: "Latest turn failed",
+    };
+  }
+
+  if (thread.native_status.thread_status === "active") {
+    return {
+      kind: "running",
+      label: "Running",
+    };
+  }
+
+  if (thread.derived_hints.accepting_user_input) {
+    return {
+      kind: "waiting_on_user_input",
+      label: "Waiting for your input",
+    };
+  }
+
+  return {
+    kind: "idle",
+    label: "Idle",
+  };
+}
+
+function deriveThreadBadge(thread: RuntimeThreadSummary) {
+  if (thread.derived_hints.has_pending_request || hasActiveFlag(thread, "waitingOnApproval")) {
+    return {
+      kind: "approval_required",
+      label: "Approval required",
+    };
+  }
+
+  if (hasActiveFlag(thread, "systemError")) {
+    return {
+      kind: "system_error",
+      label: "System error",
+    };
+  }
+
+  if (thread.native_status.latest_turn_status === "failed") {
+    return {
+      kind: "latest_turn_failed",
+      label: "Failed",
+    };
+  }
+
+  return null;
+}
+
+function deriveThreadBlockedCue(thread: RuntimeThreadSummary) {
+  if (thread.derived_hints.has_pending_request || hasActiveFlag(thread, "waitingOnApproval")) {
+    return {
+      kind: "approval_required",
+      label: "Needs your response",
+    };
+  }
+
+  if (hasActiveFlag(thread, "systemError")) {
+    return {
+      kind: "system_error",
+      label: "Needs attention",
+    };
+  }
+
+  if (thread.native_status.latest_turn_status === "failed") {
+    return {
+      kind: "latest_turn_failed",
+      label: "Needs attention",
+    };
+  }
+
+  return null;
+}
+
+function deriveThreadResumeCue(thread: RuntimeThreadSummary) {
+  if (thread.derived_hints.has_pending_request || hasActiveFlag(thread, "waitingOnApproval")) {
+    return {
+      reason_kind: "waiting_on_approval",
+      priority_band: "highest" as const,
+      label: "Resume here first",
+    };
+  }
+
+  if (hasActiveFlag(thread, "systemError")) {
+    return {
+      reason_kind: "system_error",
+      priority_band: "high" as const,
+      label: "Resume soon",
+    };
+  }
+
+  if (thread.native_status.latest_turn_status === "failed") {
+    return {
+      reason_kind: "latest_turn_failed",
+      priority_band: "high" as const,
+      label: "Resume soon",
+    };
+  }
+
+  if (thread.native_status.thread_status === "active") {
+    return {
+      reason_kind: "active_thread",
+      priority_band: "medium" as const,
+      label: "Active now",
+    };
+  }
+
+  return null;
+}
+
+export function mapThread(thread: RuntimeThreadSummary) {
+  return {
+    thread_id: thread.thread_id,
+    workspace_id: thread.workspace_id,
+    native_status: thread.native_status,
+    updated_at: thread.updated_at,
+  };
+}
+
+export function mapThreadListItem(thread: RuntimeThreadSummary) {
+  return {
+    ...mapThread(thread),
+    current_activity: deriveThreadCurrentActivity(thread),
+    badge: deriveThreadBadge(thread),
+    blocked_cue: deriveThreadBlockedCue(thread),
+    resume_cue: deriveThreadResumeCue(thread),
+  };
+}
+
+export function mapThreadList(response: ListResponse<RuntimeThreadSummary>) {
+  return {
+    items: response.items.map(mapThreadListItem),
+    next_cursor: response.next_cursor,
+    has_more: response.has_more,
+  };
+}
+
+export function mapThreadInputAcceptedResponse(response: RuntimeThreadInputAcceptedResponse) {
+  return {
+    accepted: {
+      thread_id: response.thread.thread_id,
+      turn_id: null,
+      input_item_id: response.accepted_input?.message_id ?? null,
+    },
+    thread: mapThread(response.thread),
+  };
+}
+
+export function mapRequestResponseResult(response: RuntimeRequestResponseResult) {
+  return {
+    request: {
+      request_id: response.request.request_id,
+      status: response.request.status,
+      decision: response.request.decision,
+      responded_at: response.request.responded_at,
+    },
+    thread: mapThread(response.thread),
+  };
+}
+
+function mapPendingRequestSummary(request: RuntimePendingRequestSummary) {
+  return {
+    request_id: request.request_id,
+    thread_id: request.thread_id,
+    turn_id: request.turn_id,
+    item_id: request.item_id,
+    request_kind: request.request_kind,
+    status: request.status,
+    risk_category: request.risk_classification,
+    summary: request.summary,
+    requested_at: request.requested_at,
+  };
+}
+
+function mapLatestResolvedRequest(request: RuntimeLatestResolvedRequestSummary) {
+  return {
+    request_id: request.request_id,
+    thread_id: request.thread_id,
+    turn_id: request.turn_id,
+    item_id: request.item_id,
+    request_kind: request.request_kind,
+    status: request.status,
+    decision: request.decision,
+    requested_at: request.requested_at,
+    responded_at: request.responded_at,
+  };
+}
+
+function mapTimelineItem(item: RuntimeTimelineItem) {
+  return {
+    timeline_item_id: item.timeline_item_id,
+    thread_id: item.thread_id,
+    turn_id: null,
+    item_id: null,
+    sequence: item.sequence,
+    occurred_at: item.occurred_at,
+    kind: item.item_kind,
+    payload: {
+      summary: item.summary,
+      ...(item.request_id ? { request_id: item.request_id } : {}),
+    },
+  };
+}
+
+export function mapTimeline(response: ListResponse<RuntimeTimelineItem>) {
+  return {
+    items: response.items.map(mapTimelineItem),
+    next_cursor: response.next_cursor,
+    has_more: response.has_more,
+  };
+}
+
+export function mapPendingRequestView(view: RuntimeThreadPendingRequestView) {
+  return {
+    thread_id: view.thread_id,
+    pending_request: view.pending_request ? mapPendingRequestSummary(view.pending_request) : null,
+    latest_resolved_request: view.latest_resolved_request
+      ? mapLatestResolvedRequest(view.latest_resolved_request)
+      : null,
+    checked_at: view.checked_at,
+  };
+}
+
+export function mapThreadView(
+  view: RuntimeThreadViewHelper,
+  timeline: ListResponse<RuntimeTimelineItem>,
+) {
+  return {
+    thread: mapThread(view.thread),
+    current_activity: deriveThreadCurrentActivity(view.thread),
+    pending_request: view.pending_request ? mapPendingRequestSummary(view.pending_request) : null,
+    latest_resolved_request: view.latest_resolved_request
+      ? mapLatestResolvedRequest(view.latest_resolved_request)
+      : null,
+    composer: {
+      accepting_user_input: view.thread.derived_hints.accepting_user_input,
+      interrupt_available: view.thread.native_status.thread_status === "active",
+      blocked_by_request: view.thread.derived_hints.has_pending_request,
+    },
+    timeline: mapTimeline(timeline),
+  };
+}
+
+export function mapRequestDetail(detail: RuntimeRequestDetailView) {
+  return {
+    request_id: detail.request_id,
+    thread_id: detail.thread_id,
+    turn_id: detail.turn_id,
+    item_id: detail.item_id,
+    request_kind: detail.request_kind,
+    status: detail.status,
+    risk_category: detail.risk_classification,
+    summary: detail.summary,
+    reason: detail.reason,
+    operation_summary: detail.operation_summary,
+    requested_at: detail.requested_at,
+    responded_at: detail.responded_at,
+    decision: detail.decision,
+    decision_options: {
+      policy_scope_supported: false as const,
+      default_policy_scope: "once" as const,
+    },
+    context: detail.context ?? null,
   };
 }
 

--- a/apps/frontend-bff/src/runtime-types.ts
+++ b/apps/frontend-bff/src/runtime-types.ts
@@ -13,6 +13,127 @@ export interface RuntimeWorkspaceSummary {
   pending_approval_count: number;
 }
 
+export interface RuntimeThreadSummary {
+  thread_id: string;
+  workspace_id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+  native_status: {
+    thread_status: string;
+    active_flags: string[];
+    latest_turn_status: string | null;
+  };
+  derived_hints: {
+    accepting_user_input: boolean;
+    has_pending_request: boolean;
+    blocked_reason: string | null;
+  };
+}
+
+export interface RuntimePendingRequestSummary {
+  request_id: string;
+  thread_id: string;
+  turn_id: string | null;
+  item_id: string;
+  request_kind: string;
+  status: "pending";
+  risk_classification:
+    | "destructive_change"
+    | "external_side_effect"
+    | "network_access"
+    | "privileged_execution";
+  summary: string;
+  requested_at: string;
+}
+
+export interface RuntimeLatestResolvedRequestSummary {
+  request_id: string;
+  thread_id: string;
+  turn_id: string | null;
+  item_id: string;
+  request_kind: string;
+  status: "resolved";
+  decision: "approved" | "denied" | "canceled";
+  requested_at: string;
+  responded_at: string;
+}
+
+export interface RuntimeThreadPendingRequestView {
+  thread_id: string;
+  pending_request: RuntimePendingRequestSummary | null;
+  latest_resolved_request: RuntimeLatestResolvedRequestSummary | null;
+  checked_at: string;
+}
+
+export interface RuntimeRequestDetailView {
+  request_id: string;
+  thread_id: string;
+  turn_id: string | null;
+  item_id: string;
+  request_kind: string;
+  status: "pending" | "resolved";
+  decision: "approved" | "denied" | "canceled" | null;
+  risk_classification:
+    | "destructive_change"
+    | "external_side_effect"
+    | "network_access"
+    | "privileged_execution";
+  operation_summary: string | null;
+  reason: string;
+  summary: string;
+  requested_at: string;
+  responded_at: string | null;
+  context?: Record<string, unknown> | null;
+}
+
+export interface RuntimeTimelineItem {
+  timeline_item_id: string;
+  thread_id: string;
+  sequence: number;
+  item_kind: string;
+  occurred_at: string;
+  summary: string;
+  request_id: string | null;
+}
+
+export interface RuntimeThreadViewHelper {
+  thread: RuntimeThreadSummary;
+  pending_request: RuntimePendingRequestSummary | null;
+  latest_resolved_request: RuntimeLatestResolvedRequestSummary | null;
+  checked_at: string;
+}
+
+export interface RuntimeAcceptedInputProjection {
+  message_id: string;
+  session_id: string;
+  role: "user" | "assistant";
+  content: string;
+  created_at: string;
+  source_item_type: "user_message" | "agent_message";
+}
+
+export interface RuntimeThreadInputAcceptedResponse {
+  thread: RuntimeThreadSummary;
+  accepted_input?: RuntimeAcceptedInputProjection;
+}
+
+export interface RuntimeThreadInterruptResponse {
+  thread: RuntimeThreadSummary;
+}
+
+export interface RuntimeRequestActionSummary {
+  request_id: string;
+  status: "pending" | "resolved";
+  decision: "approved" | "denied" | "canceled" | null;
+  responded_at: string | null;
+}
+
+export interface RuntimeRequestResponseResult {
+  request: RuntimeRequestActionSummary;
+  thread: RuntimeThreadSummary;
+}
+
 export interface RuntimeSessionSummary {
   session_id: string;
   workspace_id: string;

--- a/apps/frontend-bff/src/thread-types.ts
+++ b/apps/frontend-bff/src/thread-types.ts
@@ -1,0 +1,148 @@
+export interface PublicThread {
+  thread_id: string;
+  workspace_id: string;
+  native_status: {
+    thread_status: string;
+    active_flags: string[];
+    latest_turn_status: string | null;
+  };
+  updated_at: string;
+}
+
+export interface PublicCurrentActivity {
+  kind: string;
+  label: string;
+}
+
+export interface PublicThreadCue {
+  kind: string;
+  label: string;
+}
+
+export interface PublicResumeCue {
+  reason_kind: string;
+  priority_band: "highest" | "high" | "medium" | "low";
+  label: string;
+}
+
+export interface PublicThreadListItem extends PublicThread {
+  current_activity: PublicCurrentActivity;
+  badge: PublicThreadCue | null;
+  blocked_cue: PublicThreadCue | null;
+  resume_cue: PublicResumeCue | null;
+}
+
+export interface PublicPendingRequest {
+  request_id: string;
+  thread_id: string;
+  turn_id: string | null;
+  item_id: string;
+  request_kind: string;
+  status: "pending";
+  risk_category:
+    | "destructive_change"
+    | "external_side_effect"
+    | "network_access"
+    | "privileged_execution";
+  summary: string;
+  requested_at: string;
+}
+
+export interface PublicLatestResolvedRequest {
+  request_id: string;
+  thread_id: string;
+  turn_id: string | null;
+  item_id: string;
+  request_kind: string;
+  status: "resolved";
+  decision: "approved" | "denied" | "canceled";
+  requested_at: string;
+  responded_at: string;
+}
+
+export interface PublicPendingRequestView {
+  thread_id: string;
+  pending_request: PublicPendingRequest | null;
+  latest_resolved_request: PublicLatestResolvedRequest | null;
+  checked_at: string;
+}
+
+export interface PublicRequestDetail {
+  request_id: string;
+  thread_id: string;
+  turn_id: string | null;
+  item_id: string;
+  request_kind: string;
+  status: "pending" | "resolved";
+  risk_category:
+    | "destructive_change"
+    | "external_side_effect"
+    | "network_access"
+    | "privileged_execution";
+  summary: string;
+  reason: string;
+  operation_summary: string | null;
+  requested_at: string;
+  responded_at: string | null;
+  decision: "approved" | "denied" | "canceled" | null;
+  decision_options: {
+    policy_scope_supported: false;
+    default_policy_scope: "once";
+  };
+  context: Record<string, unknown> | null;
+}
+
+export interface PublicTimelineItem {
+  timeline_item_id: string;
+  thread_id: string;
+  turn_id: string | null;
+  item_id: string | null;
+  sequence: number;
+  occurred_at: string;
+  kind: string;
+  payload: Record<string, unknown>;
+}
+
+export interface PublicTimeline {
+  items: PublicTimelineItem[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+export interface PublicComposer {
+  accepting_user_input: boolean;
+  interrupt_available: boolean;
+  blocked_by_request: boolean;
+}
+
+export interface PublicThreadView {
+  thread: PublicThread;
+  current_activity: PublicCurrentActivity;
+  pending_request: PublicPendingRequest | null;
+  latest_resolved_request: PublicLatestResolvedRequest | null;
+  composer: PublicComposer;
+  timeline: PublicTimeline;
+}
+
+export interface PublicAcceptedInput {
+  thread_id: string;
+  turn_id: string | null;
+  input_item_id: string | null;
+}
+
+export interface PublicThreadInputAcceptedResponse {
+  accepted: PublicAcceptedInput;
+  thread: PublicThread;
+}
+
+export interface PublicRequestActionSummary {
+  request_id: string;
+  status: "pending" | "resolved";
+  decision: "approved" | "denied" | "canceled" | null;
+  responded_at: string | null;
+}
+
+export interface PublicRequestResponseResult {
+  request: PublicRequestActionSummary;
+  thread: PublicThread;
+}

--- a/apps/frontend-bff/tests/routes.test.ts
+++ b/apps/frontend-bff/tests/routes.test.ts
@@ -6,9 +6,19 @@ import {
   getApproval,
   getApprovalStream,
   getHome,
+  getPendingRequest,
+  getRequestDetail,
   getSessionStream,
+  getThread,
+  getThreadView,
+  getTimeline,
   listEvents,
+  listThreads,
   listWorkspaces,
+  postRequestResponse,
+  postThreadInput,
+  postThreadInterrupt,
+  postWorkspaceInput,
   stopSession,
 } from "../src/handlers";
 
@@ -152,6 +162,697 @@ describe("frontend-bff route handlers", () => {
       ],
       pending_approval_count: 2,
       updated_at: "2026-03-27T05:22:00Z",
+    });
+  });
+
+  it("maps workspace thread list responses to v0.9 thread_list_item", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            thread_id: "thread_001",
+            workspace_id: "ws_alpha",
+            title: "Investigate build",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            native_status: {
+              thread_status: "active",
+              active_flags: ["waitingOnApproval"],
+              latest_turn_status: "inProgress",
+            },
+            derived_hints: {
+              accepting_user_input: false,
+              has_pending_request: true,
+              blocked_reason: "pending_request",
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      }),
+    );
+
+    const response = await listThreads(
+      new Request("http://localhost/api/v1/workspaces/ws_alpha/threads?sort=-updated_at"),
+      "ws_alpha",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/workspaces/ws_alpha/threads?sort=-updated_at",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      items: [
+        {
+          thread_id: "thread_001",
+          workspace_id: "ws_alpha",
+          native_status: {
+            thread_status: "active",
+            active_flags: ["waitingOnApproval"],
+            latest_turn_status: "inProgress",
+          },
+          updated_at: "2026-03-27T05:22:00Z",
+          current_activity: {
+            kind: "waiting_on_approval",
+            label: "Approval required",
+          },
+          badge: {
+            kind: "approval_required",
+            label: "Approval required",
+          },
+          blocked_cue: {
+            kind: "approval_required",
+            label: "Needs your response",
+          },
+          resume_cue: {
+            reason_kind: "waiting_on_approval",
+            priority_band: "highest",
+            label: "Resume here first",
+          },
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+  });
+
+  it("maps thread snapshots to the public thread facade", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        thread_id: "thread_001",
+        workspace_id: "ws_alpha",
+        title: "Investigate build",
+        created_at: "2026-03-27T05:12:34Z",
+        updated_at: "2026-03-27T05:22:00Z",
+        native_status: {
+          thread_status: "idle",
+          active_flags: [],
+          latest_turn_status: "completed",
+        },
+        derived_hints: {
+          accepting_user_input: true,
+          has_pending_request: false,
+          blocked_reason: null,
+        },
+      }),
+    );
+
+    const response = await getThread(
+      new Request("http://localhost/api/v1/threads/thread_001"),
+      "thread_001",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/threads/thread_001",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      thread_id: "thread_001",
+      workspace_id: "ws_alpha",
+      native_status: {
+        thread_status: "idle",
+        active_flags: [],
+        latest_turn_status: "completed",
+      },
+      updated_at: "2026-03-27T05:22:00Z",
+    });
+  });
+
+  it("forwards workspace input requests and maps accepted results to the public shape", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          thread: {
+            thread_id: "thread_002",
+            workspace_id: "ws_alpha",
+            title: "Investigate build",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            native_status: {
+              thread_status: "active",
+              active_flags: [],
+              latest_turn_status: "inProgress",
+            },
+            derived_hints: {
+              accepting_user_input: false,
+              has_pending_request: false,
+              blocked_reason: null,
+            },
+          },
+        },
+        202,
+      ),
+    );
+
+    const response = await postWorkspaceInput(
+      new Request("http://localhost/api/v1/workspaces/ws_alpha/inputs", {
+        method: "POST",
+        body: JSON.stringify({
+          client_request_id: "input_001",
+          content: "Please investigate the build failure.",
+        }),
+      }),
+      "ws_alpha",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/workspaces/ws_alpha/inputs",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          client_request_id: "input_001",
+          content: "Please investigate the build failure.",
+        }),
+      }),
+    );
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      accepted: {
+        thread_id: "thread_002",
+        turn_id: null,
+        input_item_id: null,
+      },
+      thread: {
+        thread_id: "thread_002",
+        workspace_id: "ws_alpha",
+        native_status: {
+          thread_status: "active",
+          active_flags: [],
+          latest_turn_status: "inProgress",
+        },
+        updated_at: "2026-03-27T05:22:00Z",
+      },
+    });
+  });
+
+  it("forwards thread input requests and maps accepted results to the public shape", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          thread: {
+            thread_id: "thread_001",
+            workspace_id: "ws_alpha",
+            title: "Investigate build",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:23:00Z",
+            native_status: {
+              thread_status: "active",
+              active_flags: [],
+              latest_turn_status: "inProgress",
+            },
+            derived_hints: {
+              accepting_user_input: false,
+              has_pending_request: false,
+              blocked_reason: null,
+            },
+          },
+          accepted_input: {
+            message_id: "msg_001",
+            session_id: "thread_001",
+            role: "user",
+            content: "Show me the root cause.",
+            created_at: "2026-03-27T05:23:00Z",
+            source_item_type: "user_message",
+          },
+        },
+        202,
+      ),
+    );
+
+    const response = await postThreadInput(
+      new Request("http://localhost/api/v1/threads/thread_001/inputs", {
+        method: "POST",
+        body: JSON.stringify({
+          client_request_id: "input_002",
+          content: "Show me the root cause.",
+        }),
+      }),
+      "thread_001",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/threads/thread_001/inputs",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          client_request_id: "input_002",
+          content: "Show me the root cause.",
+        }),
+      }),
+    );
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      accepted: {
+        thread_id: "thread_001",
+        turn_id: null,
+        input_item_id: "msg_001",
+      },
+      thread: {
+        thread_id: "thread_001",
+        workspace_id: "ws_alpha",
+        native_status: {
+          thread_status: "active",
+          active_flags: [],
+          latest_turn_status: "inProgress",
+        },
+        updated_at: "2026-03-27T05:23:00Z",
+      },
+    });
+  });
+
+  it("forwards thread interrupts and maps runtime thread wrappers to the public thread facade", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        thread: {
+          thread_id: "thread_001",
+          workspace_id: "ws_alpha",
+          title: "Investigate build",
+          created_at: "2026-03-27T05:12:34Z",
+          updated_at: "2026-03-27T05:24:00Z",
+          native_status: {
+            thread_status: "idle",
+            active_flags: [],
+            latest_turn_status: "interrupted",
+          },
+          derived_hints: {
+            accepting_user_input: true,
+            has_pending_request: false,
+            blocked_reason: null,
+          },
+        },
+      }),
+    );
+
+    const response = await postThreadInterrupt(
+      new Request("http://localhost/api/v1/threads/thread_001/interrupt", {
+        method: "POST",
+      }),
+      "thread_001",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/threads/thread_001/interrupt",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      thread_id: "thread_001",
+      workspace_id: "ws_alpha",
+      native_status: {
+        thread_status: "idle",
+        active_flags: [],
+        latest_turn_status: "interrupted",
+      },
+      updated_at: "2026-03-27T05:24:00Z",
+    });
+  });
+
+  it("forwards request responses and maps resolved request results to the public action shape", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        request: {
+          request_id: "req_001",
+          thread_id: "thread_001",
+          turn_id: "turn_001",
+          item_id: "item_001",
+          request_kind: "approval",
+          status: "resolved",
+          decision: "approved",
+          risk_classification: "external_side_effect",
+          operation_summary: "git push origin main",
+          reason: "Codex requests permission to push changes to remote.",
+          summary: "Run git push",
+          requested_at: "2026-03-27T05:20:00Z",
+          responded_at: "2026-03-27T05:21:00Z",
+          context: null,
+        },
+        thread: {
+          thread_id: "thread_001",
+          workspace_id: "ws_alpha",
+          title: "Investigate build",
+          created_at: "2026-03-27T05:12:34Z",
+          updated_at: "2026-03-27T05:21:00Z",
+          native_status: {
+            thread_status: "active",
+            active_flags: [],
+            latest_turn_status: "inProgress",
+          },
+          derived_hints: {
+            accepting_user_input: false,
+            has_pending_request: false,
+            blocked_reason: "turn_in_progress",
+          },
+        },
+      }),
+    );
+
+    const response = await postRequestResponse(
+      new Request("http://localhost/api/v1/requests/req_001/response", {
+        method: "POST",
+        body: JSON.stringify({
+          client_response_id: "resp_001",
+          decision: "approved",
+        }),
+      }),
+      "req_001",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/requests/req_001/response",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          client_response_id: "resp_001",
+          decision: "approved",
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      request: {
+        request_id: "req_001",
+        status: "resolved",
+        decision: "approved",
+        responded_at: "2026-03-27T05:21:00Z",
+      },
+      thread: {
+        thread_id: "thread_001",
+        workspace_id: "ws_alpha",
+        native_status: {
+          thread_status: "active",
+          active_flags: [],
+          latest_turn_status: "inProgress",
+        },
+        updated_at: "2026-03-27T05:21:00Z",
+      },
+    });
+  });
+
+  it("passes through request response conflict envelopes unchanged", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: {
+            code: "idempotency_conflict",
+            message: "request response id conflicts with an existing decision",
+            details: {
+              request_id: "req_001",
+              client_response_id: "resp_001",
+            },
+          },
+        },
+        409,
+      ),
+    );
+
+    const response = await postRequestResponse(
+      new Request("http://localhost/api/v1/requests/req_001/response", {
+        method: "POST",
+        body: JSON.stringify({
+          client_response_id: "resp_001",
+          decision: "denied",
+        }),
+      }),
+      "req_001",
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "idempotency_conflict",
+        message: "request response id conflicts with an existing decision",
+        details: {
+          request_id: "req_001",
+          client_response_id: "resp_001",
+        },
+      },
+    });
+  });
+
+  it("preserves pending_request null semantics", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        thread_id: "thread_001",
+        pending_request: null,
+        latest_resolved_request: null,
+        checked_at: "2026-03-27T05:22:00Z",
+      }),
+    );
+
+    const response = await getPendingRequest(
+      new Request("http://localhost/api/v1/threads/thread_001/pending_request"),
+      "thread_001",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/threads/thread_001/pending_request",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      thread_id: "thread_001",
+      pending_request: null,
+      latest_resolved_request: null,
+      checked_at: "2026-03-27T05:22:00Z",
+    });
+  });
+
+  it("maps thread_view helper responses to the public aggregate", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          thread: {
+            thread_id: "thread_001",
+            workspace_id: "ws_alpha",
+            title: "Investigate build",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            native_status: {
+              thread_status: "idle",
+              active_flags: [],
+              latest_turn_status: "completed",
+            },
+            derived_hints: {
+              accepting_user_input: true,
+              has_pending_request: false,
+              blocked_reason: null,
+            },
+          },
+          pending_request: null,
+          latest_resolved_request: null,
+          checked_at: "2026-03-27T05:22:00Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              timeline_item_id: "evt_001",
+              thread_id: "thread_001",
+              sequence: 42,
+              item_kind: "message.user",
+              occurred_at: "2026-03-27T05:22:10Z",
+              summary: "user input accepted",
+              request_id: null,
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
+        }),
+      );
+
+    const response = await getThreadView(
+      new Request("http://localhost/api/v1/threads/thread_001/view"),
+      "thread_001",
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://127.0.0.1:3001/api/v1/threads/thread_001/view",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://127.0.0.1:3001/api/v1/threads/thread_001/timeline",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      thread: {
+        thread_id: "thread_001",
+        workspace_id: "ws_alpha",
+        native_status: {
+          thread_status: "idle",
+          active_flags: [],
+          latest_turn_status: "completed",
+        },
+        updated_at: "2026-03-27T05:22:00Z",
+      },
+      current_activity: {
+        kind: "waiting_on_user_input",
+        label: "Waiting for your input",
+      },
+      pending_request: null,
+      latest_resolved_request: null,
+      composer: {
+        accepting_user_input: true,
+        interrupt_available: false,
+        blocked_by_request: false,
+      },
+      timeline: {
+        items: [
+          {
+            timeline_item_id: "evt_001",
+            thread_id: "thread_001",
+            turn_id: null,
+            item_id: null,
+            sequence: 42,
+            occurred_at: "2026-03-27T05:22:10Z",
+            kind: "message.user",
+            payload: {
+              summary: "user input accepted",
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+  });
+
+  it("maps thread timeline responses to public timeline_item projections", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            timeline_item_id: "evt_001",
+            thread_id: "thread_001",
+            sequence: 42,
+            item_kind: "request.started",
+            occurred_at: "2026-03-27T05:22:10Z",
+            summary: "approval requested",
+            request_id: "req_001",
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      }),
+    );
+
+    const response = await getTimeline(
+      new Request("http://localhost/api/v1/threads/thread_001/timeline?sort=-sequence"),
+      "thread_001",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/threads/thread_001/timeline?sort=-sequence",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      items: [
+        {
+          timeline_item_id: "evt_001",
+          thread_id: "thread_001",
+          turn_id: null,
+          item_id: null,
+          sequence: 42,
+          occurred_at: "2026-03-27T05:22:10Z",
+          kind: "request.started",
+          payload: {
+            summary: "approval requested",
+            request_id: "req_001",
+          },
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+  });
+
+  it("maps request detail responses to the public helper facade", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        request_id: "req_001",
+        thread_id: "thread_001",
+        turn_id: "turn_001",
+        item_id: "item_001",
+        request_kind: "approval",
+        status: "pending",
+        decision: null,
+        risk_classification: "external_side_effect",
+        operation_summary: "git push origin main",
+        reason: "Codex requests permission to push changes to remote.",
+        summary: "Run git push",
+        requested_at: "2026-03-27T05:20:00Z",
+        responded_at: null,
+        context: {
+          repo: "tsukushibito/codex-webui",
+        },
+      }),
+    );
+
+    const response = await getRequestDetail(
+      new Request("http://localhost/api/v1/requests/req_001"),
+      "req_001",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3001/api/v1/requests/req_001",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      request_id: "req_001",
+      thread_id: "thread_001",
+      turn_id: "turn_001",
+      item_id: "item_001",
+      request_kind: "approval",
+      status: "pending",
+      risk_category: "external_side_effect",
+      summary: "Run git push",
+      reason: "Codex requests permission to push changes to remote.",
+      operation_summary: "git push origin main",
+      requested_at: "2026-03-27T05:20:00Z",
+      responded_at: null,
+      decision: null,
+      decision_options: {
+        policy_scope_supported: false,
+        default_policy_scope: "once",
+      },
+      context: {
+        repo: "tsukushibito/codex-webui",
+      },
     });
   });
 

--- a/tasks/issue-125-phase-4a-bff-cutover/README.md
+++ b/tasks/issue-125-phase-4a-bff-cutover/README.md
@@ -1,0 +1,87 @@
+# Issue #125 Phase 4A BFF Cutover
+
+## Purpose
+
+- Recover the missing formal evaluator gate for the existing Issue `#125` frontend-bff thread/request REST cutover candidate without expanding into new Phase 4A work.
+
+## Primary issue
+
+- Issue: `#125` https://github.com/tsukushibito/codex-webui/issues/125
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- bounded gate-recovery slice only for the already-implemented v0.9 public REST routes and thread/request helper shaping in `apps/frontend-bff`
+- allowed writes are limited to the approved evaluator scope for thread/request handlers, route files, focused tests, package metadata, `biome.json`, and this README
+- legacy `sessions` / `approvals` routes may remain in place for this slice
+- explicitly out of scope: home aggregation changes, SSE relay work, UI updates, and legacy route retirement
+
+## Exit criteria
+
+- in-scope v0.9 public REST routes and thread/request helper shaping remain present
+- focused Biome passes for the exact in-scope file list
+- `npm test -- tests/routes.test.ts` passes
+- `npm run build` passes
+- the active package records the dedicated pre-push gate outcome and does not resume push-oriented follow-through while `apps/frontend-bff` whole-app `npm run check` remains red
+
+## Work plan
+
+- inspect the existing candidate in the active worktree against the bounded evaluator scope
+- prefer zero product-code changes unless an in-scope validation fails
+- run the required focused checks plus whole-app `npm run check`
+- record exact command lines and whether whole-app check failures are in scope or out of scope
+
+## Artifacts / evidence
+
+- Code under `apps/frontend-bff/`
+- Validation evidence from focused BFF tests and build checks for the gate-recovery slice
+- Working implementation currently staged in the active worktree across:
+  - `apps/frontend-bff/src/handlers.ts`
+  - `apps/frontend-bff/src/mappings.ts`
+  - `apps/frontend-bff/src/runtime-types.ts`
+  - `apps/frontend-bff/src/thread-types.ts`
+  - `apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/inputs/route.ts`
+  - `apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/threads/route.ts`
+  - `apps/frontend-bff/app/api/v1/threads/[threadId]/route.ts`
+  - `apps/frontend-bff/app/api/v1/threads/[threadId]/view/route.ts`
+  - `apps/frontend-bff/app/api/v1/threads/[threadId]/timeline/route.ts`
+  - `apps/frontend-bff/app/api/v1/threads/[threadId]/inputs/route.ts`
+  - `apps/frontend-bff/app/api/v1/threads/[threadId]/interrupt/route.ts`
+  - `apps/frontend-bff/app/api/v1/threads/[threadId]/pending_request/route.ts`
+  - `apps/frontend-bff/app/api/v1/requests/[requestId]/route.ts`
+  - `apps/frontend-bff/app/api/v1/requests/[requestId]/response/route.ts`
+  - `apps/frontend-bff/tests/routes.test.ts`
+
+## Validation commands
+
+- `git -C /workspace/.worktrees/issue-125-phase-4a-bff-cutover status --short`
+- `sed -n '1,260p' /workspace/.worktrees/issue-125-phase-4a-bff-cutover/tasks/issue-125-phase-4a-bff-cutover/README.md`
+- `cd /workspace/.worktrees/issue-125-phase-4a-bff-cutover && node apps/frontend-bff/node_modules/@biomejs/biome/bin/biome check --config-path biome.json apps/frontend-bff/src/handlers.ts apps/frontend-bff/src/mappings.ts apps/frontend-bff/src/runtime-types.ts apps/frontend-bff/src/thread-types.ts apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/inputs/route.ts apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/threads/route.ts apps/frontend-bff/app/api/v1/threads/[threadId]/route.ts apps/frontend-bff/app/api/v1/threads/[threadId]/view/route.ts apps/frontend-bff/app/api/v1/threads/[threadId]/timeline/route.ts apps/frontend-bff/app/api/v1/threads/[threadId]/inputs/route.ts apps/frontend-bff/app/api/v1/threads/[threadId]/interrupt/route.ts apps/frontend-bff/app/api/v1/threads/[threadId]/pending_request/route.ts apps/frontend-bff/app/api/v1/requests/[requestId]/route.ts apps/frontend-bff/app/api/v1/requests/[requestId]/response/route.ts apps/frontend-bff/tests/routes.test.ts`
+- `cd /workspace/.worktrees/issue-125-phase-4a-bff-cutover/apps/frontend-bff && npm test -- tests/routes.test.ts`
+- `cd /workspace/.worktrees/issue-125-phase-4a-bff-cutover/apps/frontend-bff && NEXT_TELEMETRY_DISABLED=1 npm run build`
+- `cd /workspace/.worktrees/issue-125-phase-4a-bff-cutover/apps/frontend-bff && npm run check`
+
+## Whole-app check interpretation
+
+- Treat `apps/frontend-bff` whole-app `npm run check` as a publish-path blocker for the current package while the dedicated pre-push validation gate is red.
+- Use the reported diagnostics to decide the next tracked owner for the unblock slice; do not treat the result as permission to continue `#125` push-oriented follow-through.
+- Current ownership recommendation from the blocked-state handoff: route the next bounded unblock slice to `#138` unless fresh evidence shows the gate is primarily owned by `#127` or `#93`.
+
+## Status / handoff notes
+
+- Status: `in_progress`
+- Notes: Runtime issue `#126` is already merged to `main`, so this package continues from the v0.9 internal thread/request runtime surface. This recovery slice is limited to proving the existing frontend-bff cutover candidate is evaluator-ready within the approved write scope. Focused validation targets only the v0.9 REST routes and helpers listed above, and that bounded scope was evaluator-approved.
+- Pre-push cleanup note: the attempted `#138` legacy-surface unblock found no failing state on a clean `#138` branch. Remaining format-only diagnostics existed in this `#125` integration worktree, so they were handled as `#125` pre-push cleanup.
+- 2026-04-11 publish validation after rebasing onto `origin/main`: focused Biome passed from the repository root; `npm test -- tests/routes.test.ts` passed with 20 tests; `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed after adding the missing `@types/react-dom` dev dependency required by existing React DOM tests; `NEXT_TELEMETRY_DISABLED=1 npm run build` passed; whole-app `npm run check` passed; `git diff --check` passed.
+
+## Archive conditions
+
+- Archive this package when the scoped BFF cutover work is locally complete, validations are recorded, and the active execution metadata no longer needs this package to remain live.


### PR DESCRIPTION
## Summary

- Add the Phase 4A v0.9 frontend-bff thread/request REST route handlers.
- Add public shaping helpers and runtime/public types for threads, timelines, pending requests, and request responses.
- Extend focused route coverage for the new v0.9 REST surface.
- Add the missing React DOM type package required by existing type checks and ignore TypeScript build info artifacts.

## Validation

- `node apps/frontend-bff/node_modules/@biomejs/biome/bin/biome check --config-path biome.json ...focused BFF files...`
- `cd apps/frontend-bff && npm test -- tests/routes.test.ts`
- `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `cd apps/frontend-bff && NEXT_TELEMETRY_DISABLED=1 npm run build`
- `cd apps/frontend-bff && npm run check`
- `git diff --check`

Closes #125