### PR TITLE
feat(frontend-bff): cut over home resume aggregation

### DIFF
--- a/apps/frontend-bff/src/handlers.ts
+++ b/apps/frontend-bff/src/handlers.ts
@@ -20,6 +20,7 @@ import {
   mapThread,
   mapThreadInputAcceptedResponse,
   mapThreadList,
+  mapThreadListItem,
   mapThreadView,
   mapTimeline,
   mapWorkspace,
@@ -32,7 +33,6 @@ import type {
   RuntimeApprovalProjection,
   RuntimeApprovalResolveResult,
   RuntimeApprovalStreamEventProjection,
-  RuntimeApprovalSummary,
   RuntimeMessageProjection,
   RuntimeRequestDetailView,
   RuntimeRequestResponseResult,
@@ -47,11 +47,42 @@ import type {
   RuntimeTimelineItem,
   RuntimeWorkspaceSummary,
 } from "./runtime-types";
+import type { PublicThreadListItem } from "./thread-types";
 
 const runtimeClient = new RuntimeClient();
 
 function latestTimestamp(values: string[]) {
-  return values.reduce((latest, value) => (value > latest ? value : latest));
+  return values.reduce((latest, value) => (value > latest ? value : latest), "");
+}
+
+function homeResumePriority(item: PublicThreadListItem) {
+  switch (item.current_activity.kind) {
+    case "waiting_on_approval":
+      return 0;
+    case "system_error":
+      return 1;
+    case "latest_turn_failed":
+      return 2;
+    default:
+      return item.resume_cue?.reason_kind === "active_thread" ? 3 : 4;
+  }
+}
+
+function compareHomeResumeCandidates(left: PublicThreadListItem, right: PublicThreadListItem) {
+  const priorityDifference = homeResumePriority(left) - homeResumePriority(right);
+  if (priorityDifference !== 0) {
+    return priorityDifference;
+  }
+
+  if (left.updated_at !== right.updated_at) {
+    return right.updated_at.localeCompare(left.updated_at);
+  }
+
+  if (left.workspace_id !== right.workspace_id) {
+    return left.workspace_id.localeCompare(right.workspace_id);
+  }
+
+  return left.thread_id.localeCompare(right.thread_id);
 }
 
 function forwardSearch(request: Request) {
@@ -242,28 +273,41 @@ export async function listWorkspaces(request: Request) {
 
 export async function getHome(_request: Request) {
   try {
-    const [workspaceResult, approvalSummaryResult] = await Promise.all([
-      runtimeClient.requestJson<ListResponse<RuntimeWorkspaceSummary>>("/api/v1/workspaces"),
-      runtimeClient.requestJson<RuntimeApprovalSummary>("/api/v1/approvals/summary"),
-    ]);
+    const workspaceResult =
+      await runtimeClient.requestJson<ListResponse<RuntimeWorkspaceSummary>>("/api/v1/workspaces");
 
     if (isErrorEnvelope(workspaceResult.body)) {
       return passthroughRuntimeError(workspaceResult.status, workspaceResult.body);
     }
 
-    if (isErrorEnvelope(approvalSummaryResult.body)) {
-      return passthroughRuntimeError(approvalSummaryResult.status, approvalSummaryResult.body);
+    const workspaces = workspaceResult.body.items.map(mapWorkspace);
+    const threadResults = await Promise.all(
+      workspaceResult.body.items.map((workspace) =>
+        runtimeClient.requestJson<ListResponse<RuntimeThreadSummary>>(
+          `/api/v1/workspaces/${workspace.workspace_id}/threads?sort=-updated_at`,
+        ),
+      ),
+    );
+
+    const runtimeThreadError = threadResults.find((result) => isErrorEnvelope(result.body));
+    if (runtimeThreadError && isErrorEnvelope(runtimeThreadError.body)) {
+      return passthroughRuntimeError(runtimeThreadError.status, runtimeThreadError.body);
     }
 
-    const workspaces = workspaceResult.body.items.map(mapWorkspace);
+    const resumeCandidates = threadResults
+      .flatMap((result) => result.body.items)
+      .map(mapThreadListItem)
+      .filter((thread) => thread.resume_cue !== null)
+      .sort(compareHomeResumeCandidates);
+
     const updatedAt = latestTimestamp([
-      approvalSummaryResult.body.updated_at,
       ...workspaces.map((workspace) => workspace.updated_at),
+      ...resumeCandidates.map((thread) => thread.updated_at),
     ]);
 
     const response: HomeResponse = {
       workspaces,
-      pending_approval_count: approvalSummaryResult.body.pending_approval_count,
+      resume_candidates: resumeCandidates,
       updated_at: updatedAt,
     };
 

--- a/apps/frontend-bff/src/home-view.tsx
+++ b/apps/frontend-bff/src/home-view.tsx
@@ -40,6 +40,10 @@ function workspaceChatHref(workspaceId: string, sessionId?: string) {
   return `/chat?${params.toString()}`;
 }
 
+function formatResumeLabel(label: string) {
+  return label.replaceAll("_", " ");
+}
+
 export function HomeView({
   home,
   errorMessage,
@@ -58,12 +62,12 @@ export function HomeView({
             <p className="eyebrow">codex-webui</p>
             <h1>Home</h1>
             <p className="hero-copy">
-              Manage workspaces, see active sessions, and jump toward Chat or Approval from a
-              smartphone-first shell.
+              Manage workspaces, see active sessions, and resume the threads that need attention
+              from a smartphone-first shell.
             </p>
             <div className="hero-metrics">
               <span className="metric-chip">
-                Pending approvals: {home?.pending_approval_count ?? 0}
+                Resume candidates: {home?.resume_candidates.length ?? 0}
               </span>
               <span className="metric-chip">Workspaces: {home?.workspaces.length ?? 0}</span>
               <span className="metric-chip">
@@ -114,6 +118,52 @@ export function HomeView({
         </section>
 
         {errorMessage ? <p className="error-banner">{errorMessage}</p> : null}
+
+        <section className="workspace-grid">
+          {home?.resume_candidates.map((thread) => (
+            <article className="workspace-card" key={thread.thread_id}>
+              <header>
+                <div className="workspace-meta-row">
+                  <p className="eyebrow">Resume candidate</p>
+                  <span className="status-badge warning">
+                    {formatResumeLabel(thread.current_activity.label)}
+                  </span>
+                </div>
+                <h2>{thread.thread_id}</h2>
+                <p className="workspace-meta">Updated {formatTimestamp(thread.updated_at)}</p>
+              </header>
+
+              <p className="workspace-status">
+                {thread.blocked_cue?.label ?? thread.current_activity.label}
+                {thread.resume_cue ? ` ${thread.resume_cue.label}.` : null}
+              </p>
+
+              <div className="hero-metrics">
+                <span className="metric-chip">Workspace: {thread.workspace_id}</span>
+                <span className="metric-chip">
+                  Priority: {thread.resume_cue?.priority_band ?? "none"}
+                </span>
+              </div>
+
+              <div className="workspace-actions">
+                <Link className="primary-link" href={workspaceChatHref(thread.workspace_id)}>
+                  Resume in Chat
+                </Link>
+                <Link className="secondary-link" href="/approvals">
+                  Review approvals
+                </Link>
+              </div>
+            </article>
+          ))}
+
+          {!isLoading && home && home.resume_candidates.length === 0 ? (
+            <article className="workspace-card">
+              <p className="empty-state">
+                No resume candidates right now. Pick a workspace below to start or continue work.
+              </p>
+            </article>
+          ) : null}
+        </section>
 
         <section className="workspace-grid">
           {isLoading && !home ? (

--- a/apps/frontend-bff/src/runtime-types.ts
+++ b/apps/frontend-bff/src/runtime-types.ts
@@ -1,3 +1,5 @@
+import type { PublicThreadListItem } from "./thread-types";
+
 export interface RuntimeWorkspaceSummary {
   workspace_id: string;
   workspace_name: string;
@@ -237,7 +239,7 @@ export interface HomeResponse {
     } | null;
     pending_approval_count: number;
   }>;
-  pending_approval_count: number;
+  resume_candidates: PublicThreadListItem[];
   updated_at: string;
 }
 

--- a/apps/frontend-bff/tests/home-data.test.ts
+++ b/apps/frontend-bff/tests/home-data.test.ts
@@ -25,7 +25,35 @@ describe("home data access", () => {
             pending_approval_count: 0,
           },
         ],
-        pending_approval_count: 1,
+        resume_candidates: [
+          {
+            thread_id: "thread_approval",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "active",
+              active_flags: ["waitingOnApproval"],
+              latest_turn_status: "inProgress",
+            },
+            updated_at: "2026-03-27T05:23:00Z",
+            current_activity: {
+              kind: "waiting_on_approval",
+              label: "Approval required",
+            },
+            badge: {
+              kind: "approval_required",
+              label: "Approval required",
+            },
+            blocked_cue: {
+              kind: "approval_required",
+              label: "Needs your response",
+            },
+            resume_cue: {
+              reason_kind: "waiting_on_approval",
+              priority_band: "highest",
+              label: "Resume here first",
+            },
+          },
+        ],
         updated_at: "2026-03-27T05:22:00Z",
       }),
     );
@@ -38,7 +66,7 @@ describe("home data access", () => {
         accept: "application/json",
       },
     });
-    expect(result.pending_approval_count).toBe(1);
+    expect(result.resume_candidates).toHaveLength(1);
     expect(result.workspaces[0]?.workspace_name).toBe("alpha");
   });
 

--- a/apps/frontend-bff/tests/home-view.test.tsx
+++ b/apps/frontend-bff/tests/home-view.test.tsx
@@ -40,7 +40,35 @@ describe("HomeView", () => {
               pending_approval_count: 2,
             },
           ],
-          pending_approval_count: 3,
+          resume_candidates: [
+            {
+              thread_id: "thread_approval",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "active",
+                active_flags: ["waitingOnApproval"],
+                latest_turn_status: "inProgress",
+              },
+              updated_at: "2026-03-27T05:23:00Z",
+              current_activity: {
+                kind: "waiting_on_approval",
+                label: "Approval required",
+              },
+              badge: {
+                kind: "approval_required",
+                label: "Approval required",
+              },
+              blocked_cue: {
+                kind: "approval_required",
+                label: "Needs your response",
+              },
+              resume_cue: {
+                reason_kind: "waiting_on_approval",
+                priority_band: "highest",
+                label: "Resume here first",
+              },
+            },
+          ],
           updated_at: "2026-03-27T05:22:00Z",
         }}
         isLoading={false}
@@ -52,7 +80,9 @@ describe("HomeView", () => {
       />,
     );
 
-    expect(markup).toContain("Pending approvals: 3");
+    expect(markup).toContain("Resume candidates: 1");
+    expect(markup).toContain("Resume in Chat");
+    expect(markup).toContain("Needs your response");
     expect(markup).toContain("alpha");
     expect(markup).toContain("Go to Chat");
     expect(markup).toContain("Review approvals");

--- a/apps/frontend-bff/tests/routes.test.ts
+++ b/apps/frontend-bff/tests/routes.test.ts
@@ -110,7 +110,7 @@ describe("frontend-bff route handlers", () => {
     });
   });
 
-  it("combines workspace summaries and approval summary for the Home response", async () => {
+  it("combines workspace summaries and per-workspace threads for the Home response", async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock
       .mockResolvedValueOnce(
@@ -137,13 +137,97 @@ describe("frontend-bff route handlers", () => {
       )
       .mockResolvedValueOnce(
         jsonResponse({
-          pending_approval_count: 2,
-          updated_at: "2026-03-27T05:22:00Z",
+          items: [
+            {
+              thread_id: "thread_active",
+              workspace_id: "ws_alpha",
+              title: "Still running",
+              created_at: "2026-03-27T05:10:00Z",
+              updated_at: "2026-03-27T05:24:00Z",
+              native_status: {
+                thread_status: "active",
+                active_flags: [],
+                latest_turn_status: "inProgress",
+              },
+              derived_hints: {
+                accepting_user_input: false,
+                has_pending_request: false,
+                blocked_reason: "turn_in_progress",
+              },
+            },
+            {
+              thread_id: "thread_approval",
+              workspace_id: "ws_alpha",
+              title: "Needs approval",
+              created_at: "2026-03-27T05:11:00Z",
+              updated_at: "2026-03-27T05:23:00Z",
+              native_status: {
+                thread_status: "active",
+                active_flags: ["waitingOnApproval"],
+                latest_turn_status: "inProgress",
+              },
+              derived_hints: {
+                accepting_user_input: false,
+                has_pending_request: true,
+                blocked_reason: "pending_request",
+              },
+            },
+            {
+              thread_id: "thread_failed",
+              workspace_id: "ws_alpha",
+              title: "Failed turn",
+              created_at: "2026-03-27T05:09:00Z",
+              updated_at: "2026-03-27T05:25:00Z",
+              native_status: {
+                thread_status: "idle",
+                active_flags: [],
+                latest_turn_status: "failed",
+              },
+              derived_hints: {
+                accepting_user_input: true,
+                has_pending_request: false,
+                blocked_reason: null,
+              },
+            },
+            {
+              thread_id: "thread_idle",
+              workspace_id: "ws_alpha",
+              title: "Idle thread",
+              created_at: "2026-03-27T05:08:00Z",
+              updated_at: "2026-03-27T05:26:00Z",
+              native_status: {
+                thread_status: "idle",
+                active_flags: [],
+                latest_turn_status: "completed",
+              },
+              derived_hints: {
+                accepting_user_input: true,
+                has_pending_request: false,
+                blocked_reason: null,
+              },
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
         }),
       );
 
     const response = await getHome(new Request("http://localhost/api/v1/home"));
 
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://127.0.0.1:3001/api/v1/workspaces",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://127.0.0.1:3001/api/v1/workspaces/ws_alpha/threads?sort=-updated_at",
+      expect.objectContaining({
+        cache: "no-store",
+      }),
+    );
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       workspaces: [
@@ -160,8 +244,128 @@ describe("frontend-bff route handlers", () => {
           pending_approval_count: 1,
         },
       ],
-      pending_approval_count: 2,
-      updated_at: "2026-03-27T05:22:00Z",
+      resume_candidates: [
+        {
+          thread_id: "thread_approval",
+          workspace_id: "ws_alpha",
+          native_status: {
+            thread_status: "active",
+            active_flags: ["waitingOnApproval"],
+            latest_turn_status: "inProgress",
+          },
+          updated_at: "2026-03-27T05:23:00Z",
+          current_activity: {
+            kind: "waiting_on_approval",
+            label: "Approval required",
+          },
+          badge: {
+            kind: "approval_required",
+            label: "Approval required",
+          },
+          blocked_cue: {
+            kind: "approval_required",
+            label: "Needs your response",
+          },
+          resume_cue: {
+            reason_kind: "waiting_on_approval",
+            priority_band: "highest",
+            label: "Resume here first",
+          },
+        },
+        {
+          thread_id: "thread_failed",
+          workspace_id: "ws_alpha",
+          native_status: {
+            thread_status: "idle",
+            active_flags: [],
+            latest_turn_status: "failed",
+          },
+          updated_at: "2026-03-27T05:25:00Z",
+          current_activity: {
+            kind: "latest_turn_failed",
+            label: "Latest turn failed",
+          },
+          badge: {
+            kind: "latest_turn_failed",
+            label: "Failed",
+          },
+          blocked_cue: {
+            kind: "latest_turn_failed",
+            label: "Needs attention",
+          },
+          resume_cue: {
+            reason_kind: "latest_turn_failed",
+            priority_band: "high",
+            label: "Resume soon",
+          },
+        },
+        {
+          thread_id: "thread_active",
+          workspace_id: "ws_alpha",
+          native_status: {
+            thread_status: "active",
+            active_flags: [],
+            latest_turn_status: "inProgress",
+          },
+          updated_at: "2026-03-27T05:24:00Z",
+          current_activity: {
+            kind: "running",
+            label: "Running",
+          },
+          badge: null,
+          blocked_cue: null,
+          resume_cue: {
+            reason_kind: "active_thread",
+            priority_band: "medium",
+            label: "Active now",
+          },
+        },
+      ],
+      updated_at: "2026-03-27T05:25:00Z",
+    });
+  });
+
+  it("returns the first runtime error encountered during workspace thread fan-out for Home", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              workspace_id: "ws_alpha",
+              workspace_name: "alpha",
+              directory_name: "alpha",
+              created_at: "2026-03-27T05:12:34Z",
+              updated_at: "2026-03-27T05:21:00Z",
+              active_session_id: null,
+              active_session_summary: null,
+              pending_approval_count: 0,
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: {
+              code: "session_not_found",
+              message: "thread list missing",
+            },
+          },
+          404,
+        ),
+      );
+
+    const response = await getHome(new Request("http://localhost/api/v1/home"));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "session_not_found",
+        message: "thread list missing",
+      },
     });
   });
 

--- a/tasks/archive/issue-136-home-resume-cutover/README.md
+++ b/tasks/archive/issue-136-home-resume-cutover/README.md
@@ -1,0 +1,67 @@
+# Issue #136 Home Resume Cutover
+
+## Purpose
+
+- Cut over the Home aggregation path to v0.9 `resume_candidates` and thread-centric helper summaries.
+
+## Primary issue
+
+- Issue: `#136` `Phase 4A-2: Cut over frontend-bff home aggregation and resume candidate shaping`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- replace approval-counter-first Home shaping with v0.9 `resume_candidates`
+- align Home and thread-list summaries with `thread_list_item` and helper semantics
+- preserve the documented resume priority ordering in BFF shaping
+- keep stream relays and broader legacy route retirement out of scope for this package
+
+## Exit criteria
+
+- `GET /api/v1/home` emits `resume_candidates` instead of using approval counters as the primary browser signal
+- Home aggregation and related tests align with the maintained v0.9 public API shapes
+- the remaining stream-relay and legacy-surface retirement work stays isolated to `#137` and `#138`
+
+## Work plan
+
+- inspect the maintained v0.9 Home and thread-list shapes against the current `frontend-bff` handlers and mappings
+- update BFF runtime/public mappings and Home aggregation helpers for `resume_candidates`
+- update Home-facing types, tests, and any browser code that still assumes approval-centric Home data
+- validate with focused `frontend-bff` checks before handing off to implementation execution
+
+## Artifacts / evidence
+
+- Verified in `apps/frontend-bff`:
+- `npm run check`
+- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+- `npm test -- tests/routes.test.ts tests/home-data.test.ts tests/home-view.test.tsx`
+- `npm run build`
+- Sprint evaluator verdict: `approved`
+- Pre-push validation gate: `passed`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: `GET /api/v1/home` now aggregates workspace thread summaries into v0.9 `resume_candidates` and no longer depends on `/api/v1/approvals/summary`.
+- Retrospective:
+  - Completion boundary: package archive, not Issue close
+  - Contract check:
+    - Satisfied: home aggregation no longer uses approval-counter-first shaping
+    - Satisfied: `resume_candidates` shape and ordering align with the maintained v0.9 helper model
+    - Satisfied: stream relay and broader legacy-surface retirement remained out of scope for this package
+    - Not applicable: Issue close; branch is not yet on `main`
+  - What worked: the slice stayed bounded to `frontend-bff` home aggregation, focused tests were enough to prove the cutover, and the dedicated pre-push gate passed cleanly
+  - Workflow problems: the orchestration run originally stopped after `work-packages` without the required post-handoff intake; the worker also corrected a local `node_modules` symlink outside the planned write scope
+  - Improvements to adopt: keep the orchestration loop strict about fresh post-handoff intake before any terminal run event; preserve worktree-local dependency plumbing before validation starts
+  - Skill candidates or skill updates: none beyond the already recorded orchestration anomaly
+  - Follow-up updates: archive this package, keep Issue `#136` and Project item `In Progress`, and continue with publish-oriented follow-through from the existing worktree/branch
+
+## Archive conditions
+
+- Archive this package after the `#136` slice is locally complete, the dedicated pre-push validation gate passes, and the handoff notes are updated.


### PR DESCRIPTION
Closes #136.

Cut over the public home aggregation path to v0.9 resume_candidates and update the frontend-bff home shaping/tests accordingly.
