### PR TITLE
Phase 4B: Cut over the browser UI to the v0.9 thread-first interaction model

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -281,28 +281,43 @@ input {
   gap: 14px;
 }
 
-.session-list,
+.thread-list,
 .chat-message-list,
 .chat-event-list {
   display: grid;
   gap: 12px;
 }
 
-.session-summary-card {
+.thread-list {
+  max-height: 28rem;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.thread-summary-card {
   display: grid;
   gap: 8px;
   width: 100%;
   border: 1px solid var(--panel-border);
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.62);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(255, 252, 245, 0.72));
   padding: 14px;
   text-align: left;
   cursor: pointer;
 }
 
-.session-summary-card.active {
+.thread-summary-card.active {
   border-color: rgba(184, 77, 36, 0.4);
   background: rgba(243, 223, 209, 0.45);
+}
+
+.request-detail-card {
+  display: grid;
+  gap: 12px;
+  border: 1px solid rgba(143, 91, 20, 0.18);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 14px;
 }
 
 .chat-composer {
@@ -344,12 +359,12 @@ input {
 
 .chat-message p,
 .chat-event p,
-.approval-signal {
+.request-signal {
   margin: 0;
   line-height: 1.5;
 }
 
-.approval-signal {
+.request-signal {
   border-radius: 16px;
   background: rgba(143, 91, 20, 0.12);
   color: var(--warning);
@@ -396,42 +411,6 @@ input {
   gap: 14px;
 }
 
-.approval-layout .hero-card,
-.approval-layout > .error-banner,
-.approval-layout > .status-message {
-  grid-column: 1 / -1;
-}
-
-.approval-list {
-  max-height: 32rem;
-  overflow-y: auto;
-}
-
-.approval-empty-card,
-.approval-detail-card {
-  min-height: 18rem;
-}
-
-.approval-detail-grid,
-.approval-context-grid {
-  display: grid;
-  gap: 12px;
-}
-
-.approval-context {
-  display: grid;
-  gap: 10px;
-}
-
-.approval-context-row {
-  display: grid;
-  gap: 4px;
-  padding: 12px 14px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.66);
-  word-break: break-word;
-}
-
 .text-link {
   color: var(--accent-strong);
   font-weight: 700;
@@ -445,9 +424,5 @@ input {
 
   .hero-body {
     padding: 28px;
-  }
-
-  .approval-detail-grid {
-    grid-template-columns: 1fr 1fr;
   }
 }

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -206,7 +206,7 @@ export function ChatView({
                 </button>
               </div>
 
-              <div className="session-list">
+              <div className="thread-list">
                 {isLoadingThreads ? <p className="workspace-status">Loading threads...</p> : null}
 
                 {!isLoadingThreads && threads.length === 0 ? (
@@ -219,8 +219,8 @@ export function ChatView({
                   <button
                     className={
                       selectedThreadId === thread.thread_id
-                        ? "session-summary-card active"
-                        : "session-summary-card"
+                        ? "thread-summary-card active"
+                        : "thread-summary-card"
                     }
                     key={thread.thread_id}
                     onClick={() => onSelectThread(thread.thread_id)}
@@ -260,7 +260,7 @@ export function ChatView({
               </header>
 
               {selectedThreadView?.pending_request ? (
-                <div className="approval-detail-card">
+                <div className="request-detail-card">
                   <div className="workspace-meta-row">
                     <strong>Pending request</strong>
                     <span className={requestBadgeClass(selectedRequestDetail)}>
@@ -302,7 +302,7 @@ export function ChatView({
                   </div>
                 </div>
               ) : selectedThreadView?.latest_resolved_request ? (
-                <p className="approval-signal">
+                <p className="request-signal">
                   Latest request: {selectedThreadView.latest_resolved_request.decision}
                 </p>
               ) : null}

--- a/apps/frontend-bff/src/home-view.tsx
+++ b/apps/frontend-bff/src/home-view.tsx
@@ -13,7 +13,7 @@ export interface HomeViewProps {
   onCreateWorkspace: () => void;
 }
 
-function formatSessionStatus(status: string) {
+function formatThreadStatus(status: string) {
   return status.replaceAll("_", " ");
 }
 
@@ -76,7 +76,7 @@ export function HomeView({
             </div>
             <div className="hero-actions">
               <Link className="primary-link" href="/chat">
-                Open Chat shell
+                Open thread shell
               </Link>
               <Link className="secondary-link" href="/">
                 Refresh Home
@@ -90,7 +90,7 @@ export function HomeView({
             <p className="eyebrow">Create workspace</p>
             <h2>Start from Home</h2>
             <p className="field-hint">
-              Create a workspace, then move into Chat when a session is ready.
+              Create a workspace, then move into Chat when the first thread is ready.
             </p>
           </header>
           <div className="create-form">
@@ -150,10 +150,10 @@ export function HomeView({
                   className="primary-link"
                   href={workspaceChatHref(thread.workspace_id, thread.thread_id)}
                 >
-                  Resume in Chat
+                  Resume thread
                 </Link>
                 <Link className="secondary-link" href="/">
-                  Back to Home
+                  Refresh Home
                 </Link>
               </div>
             </article>
@@ -184,8 +184,8 @@ export function HomeView({
           ) : null}
 
           {home?.workspaces.map((workspace) => {
-            const activeSession = workspace.active_session_summary;
-            const statusClassName = activeSession ? "status-badge success" : "status-badge warning";
+            const activeThread = workspace.active_session_summary;
+            const statusClassName = activeThread ? "status-badge success" : "status-badge warning";
 
             return (
               <article className="workspace-card" key={workspace.workspace_id}>
@@ -193,9 +193,7 @@ export function HomeView({
                   <div className="workspace-meta-row">
                     <p className="eyebrow">Workspace</p>
                     <span className={statusClassName}>
-                      {activeSession
-                        ? formatSessionStatus(activeSession.status)
-                        : "No active session"}
+                      {activeThread ? formatThreadStatus(activeThread.status) : "No active thread"}
                     </span>
                   </div>
                   <h2>{workspace.workspace_name}</h2>
@@ -203,16 +201,16 @@ export function HomeView({
                 </header>
 
                 <p className="workspace-status">
-                  {activeSession
-                    ? `Active thread ${activeSession.session_id} last moved at ${formatTimestamp(
-                        activeSession.last_message_at,
+                  {activeThread
+                    ? `Active thread ${activeThread.session_id} last moved at ${formatTimestamp(
+                        activeThread.last_message_at,
                       )}.`
                     : "This workspace is ready for its first thread."}
                 </p>
 
                 <div className="hero-metrics">
                   <span className="metric-chip">
-                    Pending requests: {workspace.pending_approval_count}
+                    Request queue: {workspace.pending_approval_count}
                   </span>
                   <span className="metric-chip">ID: {workspace.workspace_id}</span>
                 </div>
@@ -220,9 +218,9 @@ export function HomeView({
                 <div className="workspace-actions">
                   <Link
                     className="primary-link"
-                    href={workspaceChatHref(workspace.workspace_id, activeSession?.session_id)}
+                    href={workspaceChatHref(workspace.workspace_id, activeThread?.session_id)}
                   >
-                    Go to Chat
+                    Open thread
                   </Link>
                   <Link className="secondary-link" href="/">
                     Stay on Home

--- a/apps/frontend-bff/tests/home-view.test.tsx
+++ b/apps/frontend-bff/tests/home-view.test.tsx
@@ -81,12 +81,12 @@ describe("HomeView", () => {
     );
 
     expect(markup).toContain("Resume candidates: 1");
-    expect(markup).toContain("Resume in Chat");
+    expect(markup).toContain("Resume thread");
     expect(markup).toContain("Needs your response");
     expect(markup).toContain("alpha");
-    expect(markup).toContain("Go to Chat");
-    expect(markup).toContain("Open Chat shell");
-    expect(markup).toContain("Pending requests: 2");
+    expect(markup).toContain("Open thread");
+    expect(markup).toContain("Open thread shell");
+    expect(markup).toContain("Request queue: 2");
     expect(markup).toContain("Create workspace");
   });
 });

--- a/tasks/archive/issue-127-thread-first-cutover/README.md
+++ b/tasks/archive/issue-127-thread-first-cutover/README.md
@@ -1,0 +1,53 @@
+# Phase 4B: Cut over the browser UI to the v0.9 thread-first interaction model
+
+## Purpose
+
+- Replace the current session-first Chat and standalone Approval UI with the maintained v0.9 thread-first browser UX.
+
+## Primary issue
+
+- Issue: [#127](https://github.com/tsukushibito/codex-webui/issues/127)
+
+## Source docs
+
+- [docs/codex_webui_mvp_roadmap_v0_1.md](/workspace/docs/codex_webui_mvp_roadmap_v0_1.md)
+- [docs/requirements/codex_webui_mvp_requirements_v0_9.md](/workspace/docs/requirements/codex_webui_mvp_requirements_v0_9.md)
+- [docs/specs/codex_webui_public_api_v0_9.md](/workspace/docs/specs/codex_webui_public_api_v0_9.md)
+- [apps/frontend-bff/README.md](/workspace/apps/frontend-bff/README.md)
+
+## Scope for this package
+
+- Rework Home around workspace selection, resume candidates, and thread list cues.
+- Rework the main interaction surface around `thread_view`, `timeline`, `current_activity`, `composer`, and thread-context request helpers.
+- Make first user input the canonical new-thread start path from the browser.
+- Present pending and just-resolved request information from thread context instead of a standalone approval domain flow.
+- Converge reconnect behavior on REST reacquisition of `thread_view`, `timeline`, and request helper state.
+- Keep smartphone usability as a first-class constraint during the cutover.
+
+## Exit criteria
+
+- Browser interaction follows the v0.9 thread-first model.
+- Request response actions are reachable from thread context with minimum confirmation information.
+- Desktop and smartphone layouts no longer depend on the old session/approval UI model.
+
+## Work plan
+
+- Inspect the current Home, Chat, and shared thread/request view models in `apps/frontend-bff`.
+- Update browser data-loading and state management to use the v0.9 thread-first contract.
+- Revise the UI components and route wiring to remove session-first assumptions.
+- Add or update focused tests for the new browser flow and reconnect behavior.
+
+## Artifacts / evidence
+
+- Local validation outputs from `apps/frontend-bff`.
+- Any screenshots or manual notes needed to confirm desktop and smartphone layout behavior.
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: Home and Chat now present a thread-first browser shell with thread/request wording, request-context actions, and reconnect-friendly thread lists. Validation passed with `npm run check`, `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`, `npm test`, and `npm run build`. The remaining work is publish-oriented follow-through for the branch / PR path.
+- Notes: Workflow was straightforward once the active package and worktree were created; the main drift to avoid next time is starting UI execution without first normalizing the issue/package links.
+
+## Archive conditions
+
+- Archive this package after the slice is locally complete, the pre-push validation gate has passed, and the work has been merged to `main` with the Issue tracking updated.


### PR DESCRIPTION
## Summary

- Refresh Home and Chat copy and structure around thread-first navigation.
- Rename thread/request UI surfaces away from session/approval framing.
- Update the browser shell to keep workspace resume and request context visible.

## Validation

- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm test
- npm run build

## Tracking

- Active task package was archived at `tasks/archive/issue-127-thread-first-cutover/README.md`
- Closes #127
