### PR TITLE
docs: update ngrok remote browser access docs

### DIFF
--- a/docs/codex_webui_dev_container_onboarding.md
+++ b/docs/codex_webui_dev_container_onboarding.md
@@ -1,6 +1,6 @@
 # Codex WebUI dev container onboarding
 
-Last updated: 2026-04-05
+Last updated: 2026-04-13
 
 ## 1. Purpose
 
@@ -11,7 +11,7 @@ It covers:
 - the repo-root `Dockerfile`
 - the repo-root `docker-compose.yml`
 - the `code tunnel` helper for remote development access
-- the `devtunnel` flow for WebUI verification
+- the ngrok flow for WebUI verification
 
 This is an onboarding and operational guide. It does not replace the maintained product requirements or API specifications under `docs/requirements/` and `docs/specs/`.
 
@@ -22,7 +22,6 @@ The repository root includes the following development entrypoints:
 - `Dockerfile`: development image for this repository
 - `docker-compose.yml`: recommended way to run the dev container
 - `scripts/start-tunnel.sh`: starts `code tunnel`
-- `scripts/start-codex-webui.sh`: starts `codex-runtime`, `frontend-bff`, and `devtunnel`
 - `scripts/doctor.sh`: validates the development container toolchain
 
 The container is intended to mount this repository as `/workspace`.
@@ -71,7 +70,7 @@ Inside the container:
 scripts/doctor.sh
 ```
 
-This checks the expected CLI/toolchain installation, including `code`, `codex`, `devtunnel`, Node.js, Python, Rust, and Vulkan tooling.
+This checks the expected CLI/toolchain installation, including `code`, `codex`, `ngrok`, Node.js, Python, Rust, and Vulkan tooling.
 
 When you run a Vulkan workload directly inside the container, prefer the helper wrapper so an NVIDIA ICD manifest can be synthesized when the graphics libraries are mounted but the manifest is missing:
 
@@ -91,73 +90,63 @@ scripts/start-tunnel.sh
 
 This wrapper is intentionally separate from the WebUI launcher. It is for development access, not for exposing the application to a browser.
 
-## 5. WebUI verification with Dev Tunnel
+## 5. WebUI verification with ngrok
 
-Use `devtunnel` when you want to verify the WebUI from a remote browser, including smartphone access.
+Use `ngrok` when you want to verify the WebUI from a remote browser, including smartphone access.
 
 ### 5.1 One-time tunnel setup
 
 Inside the container:
 
 ```bash
-devtunnel user login
-devtunnel create
-devtunnel port create <tunnel-id> -p 3000 --protocol http
+ngrok config add-authtoken <token>
 ```
 
-The current non-interactive launcher expects an existing persistent tunnel ID.
-
-For an interactive launch, run:
+Set Basic Auth credentials for the remote-browser boundary. A simple shell export is usually enough:
 
 ```bash
-scripts/start-codex-webui.sh --interactive
+export NGROK_BASIC_AUTH="<user>:<password>"
 ```
 
-This prompts before startup so you can choose whether to host through Dev Tunnel at all. If you choose to host, the launcher lets you pick an existing tunnel or create a new one before the server processes start. When the selected tunnel does not have port `3000`, the launcher offers to create it.
+The supported workflow does not require a fixed public URL or a reserved hostname. A free-plan ngrok URL is acceptable as long as it is available for the current verification session.
 
-### 5.2 Start the full WebUI stack
+### 5.2 Start the local WebUI stack
+
+Start the local services on `127.0.0.1` using the app-local commands documented in `apps/codex-runtime/README.md` and `apps/frontend-bff/README.md`.
+
+The local browser-facing port remains `3000`, and the runtime stays on `3001`.
+
+### 5.3 Expose the browser entrypoint with ngrok
 
 Inside the container:
 
 ```bash
-CODEX_WEBUI_DEVTUNNEL_ID=<tunnel-id> scripts/start-codex-webui.sh
+ngrok http 3000 --basic-auth="$NGROK_BASIC_AUTH"
 ```
 
-By default the launcher does the following:
+The ngrok URL is the public browser entrypoint for the active session. It fronts only `frontend-bff`; `codex-runtime` and the App Server remain private on the container network.
 
-- starts `codex-runtime` on port `3001`
-- starts `frontend-bff` on port `3000`
-- points the BFF at `http://127.0.0.1:3001`
-- enables the runtime app-server bridge for real thread execution
-- clears test-only `CODEX_APP_SERVER_*` overrides by default and runs `codex app-server`
-- hosts the BFF through `devtunnel`
+### 5.4 Verify access
 
-For a launch that decides about Dev Tunnel usage at runtime, use `scripts/start-codex-webui.sh --interactive` instead.
+Verify both desktop and smartphone access against the ngrok URL:
 
-The launcher also creates the runtime workspace/data directories under `apps/codex-runtime/var/` when needed.
-
-### 5.3 Default URLs
-
-Local URLs:
-
-- WebUI: `http://127.0.0.1:3000/`
-- Runtime API: `http://127.0.0.1:3001/api/v1/`
-
-The public URL comes from the configured Dev Tunnel.
+- open the ngrok URL in a desktop browser
+- confirm the ngrok Basic Auth prompt appears before the UI
+- confirm the WebUI loads successfully after authentication
+- open the same URL from a smartphone browser
+- confirm the local `http://127.0.0.1:3000/` URL still works inside the container for debugging
+- if the ngrok session restarts, use the new public URL; no fixed public URL is required
 
 ## 6. Useful environment variables
 
-The main variables used by `scripts/start-codex-webui.sh` are:
-
-- `CODEX_WEBUI_DEVTUNNEL_ID`: required persistent Dev Tunnel ID
-  - required for the non-interactive tunnel-hosted path
+- `NGROK_AUTHTOKEN`: optional shell-side convenience variable for the ngrok auth token
+- `NGROK_BASIC_AUTH`: optional shell-side convenience variable for the ngrok Basic Auth credential pair
 - `CODEX_WEBUI_RUNTIME_PORT`: defaults to `3001`
 - `CODEX_WEBUI_FRONTEND_PORT`: defaults to `3000`
 - `CODEX_WEBUI_WORKSPACE_ROOT`: optional override for the runtime workspace root
 - `CODEX_WEBUI_DATABASE_PATH`: optional override for the runtime SQLite path
 - `CODEX_WEBUI_RUNTIME_BASE_URL`: optional override for the BFF runtime base URL
 - `CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED`: optional override for the runtime bridge flag
-- `CODEX_WEBUI_DEVTUNNEL_HOST_ARGS`: optional extra args for `devtunnel host`
 
 ## 7. Direct Docker usage
 
@@ -173,7 +162,7 @@ Use `docker-compose.yml` unless you have a specific reason not to.
 
 ## 8. Troubleshooting
 
-### 8.1 `devtunnel` command not found
+### 8.1 `ngrok` command not found
 
 Rebuild the image:
 
@@ -181,22 +170,23 @@ Rebuild the image:
 docker compose up -d --build dev
 ```
 
-### 8.2 `CODEX_WEBUI_DEVTUNNEL_ID` is missing
+### 8.2 ngrok authentication is missing
 
-Create a persistent tunnel first, then export the tunnel ID before starting `scripts/start-codex-webui.sh`.
-If you want to decide at launch time instead, use `scripts/start-codex-webui.sh --interactive`.
+Export `NGROK_AUTHTOKEN` or run `ngrok config add-authtoken <token>` before starting the tunnel.
 
-### 8.3 The launcher says port `3000` is missing on the tunnel
+### 8.3 ngrok cannot reach port `3000`
 
 Run:
 
 ```bash
-devtunnel port create <tunnel-id> -p 3000 --protocol http
+ngrok http 3000 --basic-auth="$NGROK_BASIC_AUTH"
 ```
+
+If the browser still cannot load the UI, confirm the frontend is listening on `127.0.0.1:3000` inside the container.
 
 ### 8.4 The runtime fails because the workspace root does not exist
 
-The launcher creates the default workspace root for you. If you override `CODEX_WEBUI_WORKSPACE_ROOT`, make sure the target path is valid and writable inside the container.
+The local startup process creates the default workspace root for you. If you override `CODEX_WEBUI_WORKSPACE_ROOT`, make sure the target path is valid and writable inside the container.
 
 ### 8.5 `vulkaninfo` only shows `llvmpipe`
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -29,6 +29,26 @@ After the heading, keep the body concise:
 
 ## Entries
 
+## [2026-04-13] restructure | Issue #152 ngrok doc sync
+
+Source:
+
+- planner-approved docs-only sprint for Issue #152
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/codex_webui_dev_container_onboarding.md`
+
+Updated:
+
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/codex_webui_dev_container_onboarding.md`
+- `docs/log.md`
+
+Notes:
+
+- synchronized the maintained supported-browser path to ngrok and recorded ngrok Basic Auth as the access-control boundary
+- rewrote the onboarding flow to describe ngrok-based remote browser verification instead of Dev Tunnel
+- deferred code, task-state, and roadmap updates to later implementation work
+
 ## [2026-04-13] query | GitHub intake command pitfalls for Project audits
 
 Source:

--- a/docs/requirements/codex_webui_mvp_requirements_v0_9.md
+++ b/docs/requirements/codex_webui_mvp_requirements_v0_9.md
@@ -4,6 +4,8 @@
 
 This document defines the requirements for CodexWebUI v0.9, reorganized around the **public contract of Codex App Server**.
 
+The supported remote-browser path for v0.9 is ngrok. ngrok Basic Auth is the access-control boundary for browser access, while OAuth / SSO / app-owned accounts remain out of scope for MVP.
+
 The primary goal of v0.9 is to provide a natural UX, close to Codex CLI / TUI, in PC and smartphone web browsers.  
 To achieve that, WebUI must not introduce a thick, independent conversation state machine. Instead, it must treat the **native conversation model exposed by Codex App Server as the primary domain**, and keep WebUI-specific concepts limited to workspace handling and the minimum browser-facing facade concepts required.
 
@@ -63,7 +65,7 @@ WebUI must not foreground its own `thread create / start` as a primary concept.
 - support for both PC and smartphone
 - conversation, execution, approval, and confirmation flows backed by Codex App Server
 - workspace operations limited to directories under `/workspaces`
-- browser access through Dev Tunnel
+- browser access through ngrok
 
 ### 3.2 Out of scope
 - turning the product into a general-purpose IDE
@@ -79,9 +81,11 @@ WebUI must not foreground its own `thread create / start` as a primary concept.
 ### 3.3 System and operational boundaries
 - the only externally exposed entry point must be `frontend-bff` or an equivalent facade backend
 - `codex-runtime` must not be exposed externally
-- authentication is delegated to Dev Tunnel, and WebUI-specific authentication / authorization is out of scope for MVP
+- authentication is delegated to ngrok Basic Auth, and WebUI-specific authentication / authorization is out of scope for MVP
 - the product assumes a single user and does not handle consistency or access control for concurrent multi-user actions
-- the security boundary is Dev Tunnel and host-side operations; fine-grained in-app authorization is not an MVP requirement
+- the security boundary is ngrok Basic Auth and host-side operations; fine-grained in-app authorization is not an MVP requirement
+- the supported remote-browser path does not require a fixed public URL; free-plan ngrok endpoints may change between sessions, and the workflow only assumes the currently assigned public URL is usable for the active session
+- OAuth, SSO, and app-owned account management are out of scope for MVP
 - although this document is UX-focused, the public boundary, authentication responsibility, and single-user assumption are treated as fixed conditions
 
 ---
@@ -122,7 +126,7 @@ Concrete field names, response shapes, and transport-level representations may b
 - WebUI does not replace the App Server source of truth
 - the WebUI backend handles only operational concepts not present in App Server and browser-facing reshaping
 - App Server may allow multiple active threads, and WebUI must not restrict that unnecessarily
-- the only external entry point is the WebUI behind Dev Tunnel; runtime and App Server are not exposed directly
+- the only external entry point is the WebUI behind ngrok; runtime and App Server are not exposed directly
 - MVP assumes a single user and does not handle concurrent editing / approval coordination across multiple users
 
 ---
@@ -345,7 +349,7 @@ The priority is that users can return directly to the necessary thread from the 
 - ensures client request idempotency
 - detects and assists convergence of partial failures
 - stores or derives thread-scoped ordering metadata
-- provides the minimum public boundary as the Dev Tunnel-facing entry point
+- provides the minimum public boundary as the ngrok-facing entry point
 
 #### Frontend
 - constructs thread view
@@ -357,7 +361,7 @@ The priority is that users can return directly to the necessary thread from the 
 ### 10.3 Public boundary
 - only `frontend-bff` or an equivalent facade backend may be exposed externally
 - `codex-runtime` and App Server are for internal communication only
-- MVP does not add app-specific authentication; authentication is delegated to Dev Tunnel
+- MVP does not add app-specific authentication; authentication is delegated to ngrok Basic Auth
 
 ---
 
@@ -757,7 +761,7 @@ The backend must satisfy at least the following:
 - only the browser-facing facade may be exposed externally
 - runtime and App Server must not be exposed directly to the browser
 - MVP assumes a single user and does not handle conflict resolution for multi-user usage
-- authentication assumes Dev Tunnel, and additional in-app authentication is not part of the mandatory requirements
+- authentication assumes ngrok Basic Auth, and additional in-app authentication is not part of the mandatory requirements
 
 ---
 
@@ -804,7 +808,7 @@ v0.9 MVP is considered established when the following are satisfied:
 - browser UX based on REST + SSE
 - minimum app-owned metadata for idempotency and reconnect convergence
 - thread-scoped ordering foundation
-- Dev Tunnel-based public boundary
+- ngrok-based public boundary
 
 ### 22.2 Should
 - stronger thread list UX
@@ -865,6 +869,6 @@ The following are not goals in v0.9:
 - a canonical-feed-like helper projection may be retained, but it must not become a substitute source of truth for App Server full history
 - the system must have a thread-scoped stable ordering foundation, and REST reacquisition is authoritative after reconnect
 - request helpers are assumed to remain reachable from thread context for pending requests and just-resolved requests
-- the facade backend is the only public entry point, and authentication is delegated to Dev Tunnel
+- the facade backend is the only public entry point, and authentication is delegated to ngrok Basic Auth
 - the single-user assumption is a fixed condition in v0.9
 - `App Server Contract Matrix v0.9` is a prerequisite artifact before implementation starts

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,10 +69,11 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- [issue-93-playwright-thread-followup](./issue-93-playwright-thread-followup/README.md)
+- `None`
 
 ## Archived Task Packages
 
+- [issue-152-ngrok-doc-sync](./archive/issue-152-ngrok-doc-sync/README.md)
 - [issue-125-phase-4a-bff-cutover](./archive/issue-125-phase-4a-bff-cutover/README.md)
 - [issue-135-read-only-fallback-rules](./archive/issue-135-read-only-fallback-rules/README.md)
 - [issue-134-orchestrator-run-semantics](./archive/issue-134-orchestrator-run-semantics/README.md)

--- a/tasks/archive/issue-152-ngrok-doc-sync/README.md
+++ b/tasks/archive/issue-152-ngrok-doc-sync/README.md
@@ -1,0 +1,53 @@
+# Issue 152 ngrok doc sync
+
+## Purpose
+
+- Update the maintained requirements and onboarding docs so the supported remote browser path is `ngrok`, not `Dev Tunnel`.
+
+## Primary issue
+
+- Issue: `#152` https://github.com/tsukushibito/codex-webui/issues/152
+
+## Source docs
+
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/codex_webui_dev_container_onboarding.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/README.md`
+
+## Scope for this package
+
+- replace maintained requirements wording that still assumes `Dev Tunnel`
+- replace maintained onboarding guidance so the remote browser workflow is `ngrok`-based
+- record the fixed migration assumptions for `ngrok Basic Auth`, `OAuth` out of scope, free-plan constraints, and no fixed public URL requirement
+- update wiki navigation or log entries if the maintained docs materially change
+
+## Exit criteria
+
+- the maintained requirements and onboarding docs both describe `ngrok` as the supported remote browser path
+- the auth boundary is documented as `ngrok Basic Auth`, with `OAuth` explicitly out of scope
+- stale `DevTunnel` / `Dev Tunnel` wording is removed from the supported maintained path, or any deferred cleanup is named explicitly
+- any required `docs/index.md` or `docs/log.md` maintenance for this doc change is included
+
+## Work plan
+
+- audit the maintained docs for current `Dev Tunnel` assumptions and decide which wording changes belong in this slice
+- update the requirements doc to reflect the `ngrok` remote browser boundary and access-control assumptions
+- update the onboarding doc to describe `ngrok`-based remote browser verification and current operating assumptions
+- refresh wiki index and log entries if the maintained docs change discoverability or maintenance history
+- run focused doc checks and git diff review for the touched files
+
+## Artifacts / evidence
+
+- `git diff --stat`
+- `git diff --check`
+- `rg -n "Dev Tunnel|DevTunnel|devtunnel" docs/requirements/codex_webui_mvp_requirements_v0_9.md docs/codex_webui_dev_container_onboarding.md`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: Requirements and onboarding docs now describe `ngrok` as the supported remote browser path and record `ngrok Basic Auth`, `OAuth` out of scope, free-plan URL churn, and no fixed public URL requirement. The dedicated pre-push validation gate passed with `git status --short`, `git diff --check`, `git diff --stat`, and a stale-wording `rg` that returned no matches. The completion retrospective for this archive boundary found two workflow notes: a stale archived-package reference had been left in `tasks/README.md`, and an early parallel worktree-setup helper raced before the worktree path existed. Neither blocks archive, and no immediate skill or doc update is required from this slice. The next step is PR / merge / cleanup / Issue close follow-through.
+
+## Archive conditions
+
+- Archive this package after the doc slice is locally complete, the dedicated pre-push validation gate passes, and the handoff notes are updated.


### PR DESCRIPTION
## Summary

- update the maintained v0.9 requirements doc to use `ngrok` as the supported remote browser path
- rewrite dev-container onboarding guidance around `ngrok` remote browser verification
- archive the Issue `#152` local task package and reconcile `tasks/README.md`

## Validation

- `git status --short`
- `git diff --check`
- `git diff --stat`
- `rg -n "Dev Tunnel|DevTunnel|devtunnel" docs/requirements/codex_webui_mvp_requirements_v0_9.md docs/codex_webui_dev_container_onboarding.md`

Closes #152
