### PR TITLE
feat: switch WebUI launcher from DevTunnels to ngrok

### DIFF
--- a/scripts/start-codex-webui.sh
+++ b/scripts/start-codex-webui.sh
@@ -13,44 +13,32 @@ FRONTEND_PORT="${CODEX_WEBUI_FRONTEND_PORT:-3000}"
 WORKSPACE_ROOT="${CODEX_WEBUI_WORKSPACE_ROOT:-${RUNTIME_DIR}/var/workspaces}"
 DATABASE_PATH="${CODEX_WEBUI_DATABASE_PATH:-${RUNTIME_DIR}/var/data/codex-runtime.sqlite}"
 RUNTIME_BASE_URL="${CODEX_WEBUI_RUNTIME_BASE_URL:-http://127.0.0.1:${RUNTIME_PORT}}"
-DEVTUNNEL_ID="${CODEX_WEBUI_DEVTUNNEL_ID:-}"
-DEVTUNNEL_HOST_ARGS="${CODEX_WEBUI_DEVTUNNEL_HOST_ARGS:-}"
 STARTUP_TIMEOUT_SECONDS="${CODEX_WEBUI_STARTUP_TIMEOUT_SECONDS:-60}"
 APP_SERVER_BRIDGE_ENABLED="${CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED:-1}"
 LOG_FILE="${CODEX_WEBUI_LOG_FILE:-}"
-INTERACTIVE_MODE=false
-USE_DEVTUNNEL=false
 DEBUG_LIVE_CHAT=false
-ORIGINAL_STDIN_IS_TTY=0
-ORIGINAL_STDOUT_IS_TTY=0
-
-if [[ -t 0 ]]; then
-  ORIGINAL_STDIN_IS_TTY=1
-fi
-
-if [[ -t 1 ]]; then
-  ORIGINAL_STDOUT_IS_TTY=1
-fi
 
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/start-codex-webui.sh [--interactive] [--debug-live-chat] [--log-file PATH] [--help]
+  scripts/start-codex-webui.sh [--debug-live-chat] [--log-file PATH] [--help]
 
 Options:
-  --interactive      Prompt before startup to decide whether to host through Dev Tunnel
   --debug-live-chat  Enable live-chat debug logs for runtime and frontend
-  --log-file         Append combined launcher, runtime, frontend, and tunnel output to PATH
+  --log-file         Append combined launcher, runtime, and frontend output to PATH
   --help             Show this help text
+
+Environment:
+  NGROK_BASIC_AUTH=user:pass               Optional Basic Auth pair for a separate ngrok session
+
+After local startup is ready, start remote browser access separately with:
+  ngrok http 3000 --basic-auth="$NGROK_BASIC_AUTH"
 EOF
 }
 
 parse_args() {
   while (($# > 0)); do
     case "$1" in
-      --interactive)
-        INTERACTIVE_MODE=true
-        ;;
       --debug-live-chat)
         DEBUG_LIVE_CHAT=true
         ;;
@@ -114,65 +102,6 @@ setup_logging() {
   log "writing combined logs to ${LOG_FILE}"
 }
 
-prompt_yes_no() {
-  local prompt="$1"
-  local default_answer="${2:-yes}"
-  local suffix=" [y/n]"
-  local reply
-
-  case "${default_answer}" in
-    yes)
-      suffix=" [Y/n]"
-      ;;
-    no)
-      suffix=" [y/N]"
-      ;;
-    *)
-      fail "invalid default answer: ${default_answer}"
-      ;;
-  esac
-
-  while true; do
-    read -r -p "${prompt}${suffix} " reply || fail "prompt cancelled"
-    reply="${reply:-${default_answer}}"
-
-    case "${reply,,}" in
-      y|yes)
-        return 0
-        ;;
-      n|no)
-        return 1
-        ;;
-      *)
-        echo "Please answer yes or no."
-        ;;
-    esac
-  done
-}
-
-prompt_choice() {
-  local prompt="$1"
-  local max_choice="$2"
-  local reply
-
-  while true; do
-    read -r -p "${prompt} " reply || fail "prompt cancelled"
-
-    if [[ "${reply}" =~ ^[0-9]+$ ]] && (( reply >= 1 && reply <= max_choice )); then
-      printf '%s\n' "${reply}"
-      return 0
-    fi
-
-    echo "Please enter a number between 1 and ${max_choice}."
-  done
-}
-
-require_tty() {
-  if (( ORIGINAL_STDIN_IS_TTY == 0 || ORIGINAL_STDOUT_IS_TTY == 0 )); then
-    fail "interactive mode requires an attached TTY"
-  fi
-}
-
 require_command() {
   local command="$1"
 
@@ -234,143 +163,6 @@ wait_for_http() {
   fail "timed out waiting for ${label} at ${url}"
 }
 
-devtunnel_json() {
-  local output
-
-  if ! output="$(devtunnel "$@" -j)"; then
-    fail "devtunnel $* failed"
-  fi
-
-  printf '%s\n' "${output}"
-}
-
-list_dev_tunnels() {
-  devtunnel_json list | node --input-type=module -e '
-    let input = "";
-    process.stdin.setEncoding("utf8");
-    process.stdin.on("data", (chunk) => {
-      input += chunk;
-    });
-    process.stdin.on("end", () => {
-      const data = JSON.parse(input || "{}");
-      const tunnels = Array.isArray(data.tunnels) ? data.tunnels : [];
-
-      for (const tunnel of tunnels) {
-        const tunnelId = typeof tunnel.tunnelId === "string" ? tunnel.tunnelId : "";
-        const parsedPortCount = Number(tunnel.portCount);
-        const portCount = Number.isFinite(parsedPortCount) ? parsedPortCount : 0;
-        const description =
-          typeof tunnel.description === "string" && tunnel.description.length > 0
-            ? tunnel.description.replace(/\t/g, " ")
-            : "";
-
-        if (tunnelId.length > 0) {
-          console.log([tunnelId, portCount, description].join("\t"));
-        }
-      }
-    });
-  '
-}
-
-choose_dev_tunnel() {
-  local configured_tunnel="${DEVTUNNEL_ID}"
-  local -a tunnel_rows=()
-  local tunnel_id port_count description choice create_new selected_new_id
-  local row tunnel_output
-
-  if [[ -n "${configured_tunnel}" ]]; then
-    if devtunnel show "${configured_tunnel}" >/dev/null 2>&1; then
-      if prompt_yes_no "Use configured Dev Tunnel ${configured_tunnel}?" "yes"; then
-        return 0
-      fi
-    else
-      echo "[codex-webui] configured Dev Tunnel ${configured_tunnel} was not found or is not accessible"
-    fi
-  fi
-
-  if ! tunnel_output="$(list_dev_tunnels)"; then
-    fail "failed to load available Dev Tunnels"
-  fi
-
-  while IFS=$'\t' read -r tunnel_id port_count description; do
-    if [[ -n "${tunnel_id}" ]]; then
-      tunnel_rows+=("${tunnel_id}"$'\t'"${port_count}"$'\t'"${description}")
-    fi
-  done <<<"${tunnel_output}"
-
-  if (( ${#tunnel_rows[@]} == 0 )); then
-    if prompt_yes_no "No existing Dev Tunnels were found. Create a new one now?" "yes"; then
-      create_new=true
-    else
-      fail "cannot use Dev Tunnel without an existing tunnel or a new tunnel"
-    fi
-  else
-    echo "Available Dev Tunnels:"
-  fi
-
-  if (( ${#tunnel_rows[@]} > 0 )); then
-    local index=1
-    for row in "${tunnel_rows[@]}"; do
-      IFS=$'\t' read -r tunnel_id port_count description <<<"${row}"
-      if [[ -n "${description}" ]]; then
-        echo "  ${index}) ${tunnel_id} (ports: ${port_count}, description: ${description})"
-      else
-        echo "  ${index}) ${tunnel_id} (ports: ${port_count})"
-      fi
-      index=$((index + 1))
-    done
-    echo "  ${index}) Create a new tunnel"
-
-    choice="$(prompt_choice "Select a tunnel [1-${index}]" "${index}")"
-    if (( choice == index )); then
-      create_new=true
-    else
-      IFS=$'\t' read -r tunnel_id port_count description <<<"${tunnel_rows[choice-1]}"
-      DEVTUNNEL_ID="${tunnel_id}"
-    fi
-  fi
-
-  if [[ "${create_new:-false}" == true ]]; then
-    while true; do
-      read -r -p "Enter a new Dev Tunnel ID: " selected_new_id || fail "prompt cancelled"
-      if [[ -z "${selected_new_id}" ]]; then
-        echo "Tunnel ID cannot be empty."
-        continue
-      fi
-
-      if [[ ! "${selected_new_id}" =~ ^[A-Za-z0-9._-]+$ ]]; then
-        echo "Tunnel ID may only contain letters, numbers, dots, underscores, and hyphens."
-        continue
-      fi
-
-      DEVTUNNEL_ID="${selected_new_id}"
-      if ! devtunnel create "${DEVTUNNEL_ID}" >/dev/null; then
-        fail "failed to create Dev Tunnel ${DEVTUNNEL_ID}"
-      fi
-      break
-    done
-  fi
-}
-
-ensure_dev_tunnel_port() {
-  if devtunnel port show "${DEVTUNNEL_ID}" -p "${FRONTEND_PORT}" >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if [[ "${INTERACTIVE_MODE}" != true ]]; then
-    fail "dev tunnel ${DEVTUNNEL_ID} does not have port ${FRONTEND_PORT}; run 'devtunnel port create ${DEVTUNNEL_ID} -p ${FRONTEND_PORT} --protocol http'"
-  fi
-
-  if prompt_yes_no "Dev Tunnel ${DEVTUNNEL_ID} does not have port ${FRONTEND_PORT}. Create it now?" "yes"; then
-    if ! devtunnel port create "${DEVTUNNEL_ID}" -p "${FRONTEND_PORT}" --protocol http >/dev/null; then
-      fail "failed to create port ${FRONTEND_PORT} on Dev Tunnel ${DEVTUNNEL_ID}"
-    fi
-    return 0
-  fi
-
-  fail "dev tunnel ${DEVTUNNEL_ID} does not have port ${FRONTEND_PORT}"
-}
-
 start_runtime() {
   log "starting codex-runtime on ${RUNTIME_HOST}:${RUNTIME_PORT}"
   (
@@ -405,15 +197,6 @@ trap cleanup EXIT INT TERM
 parse_args "$@"
 setup_logging
 
-if [[ "${INTERACTIVE_MODE}" == true ]]; then
-  require_tty
-  if prompt_yes_no "Use a Dev Tunnel for this run?" "yes"; then
-    USE_DEVTUNNEL=true
-  fi
-elif [[ -n "${DEVTUNNEL_ID}" ]]; then
-  USE_DEVTUNNEL=true
-fi
-
 require_directory "${REPO_ROOT}"
 require_directory "${RUNTIME_DIR}"
 require_directory "${FRONTEND_DIR}"
@@ -425,18 +208,6 @@ require_command curl
 require_command npm
 require_command codex
 
-if [[ "${USE_DEVTUNNEL}" == true ]]; then
-  require_command devtunnel
-
-  if [[ "${INTERACTIVE_MODE}" == true ]]; then
-    choose_dev_tunnel
-  elif [[ -z "${DEVTUNNEL_ID}" ]]; then
-    fail "set CODEX_WEBUI_DEVTUNNEL_ID to an existing persistent dev tunnel id"
-  fi
-
-  ensure_dev_tunnel_port
-fi
-
 mkdir -p "${WORKSPACE_ROOT}" "$(dirname "${DATABASE_PATH}")"
 
 start_runtime
@@ -447,26 +218,10 @@ wait_for_http "http://127.0.0.1:${FRONTEND_PORT}/" "frontend-bff" "${PIDS[1]}"
 
 log "local UI: http://127.0.0.1:${FRONTEND_PORT}/"
 log "runtime API: http://127.0.0.1:${RUNTIME_PORT}/api/v1/"
-
-if [[ "${USE_DEVTUNNEL}" == true ]]; then
-  log "hosting dev tunnel ${DEVTUNNEL_ID} for port ${FRONTEND_PORT}"
-  if [[ -n "${DEVTUNNEL_HOST_ARGS}" ]]; then
-    # shellcheck disable=SC2206
-    tunnel_args=( ${DEVTUNNEL_HOST_ARGS} )
-  else
-    tunnel_args=()
-  fi
-
-  (
-    exec devtunnel host "${DEVTUNNEL_ID}" "${tunnel_args[@]}"
-  ) > >(sed -u 's/^/[devtunnel] /') 2> >(sed -u 's/^/[devtunnel] /' >&2) &
-  PIDS+=("$!")
-
-  log "press Ctrl-C to stop runtime, frontend, and tunnel"
-else
-  log "Dev Tunnel disabled for this run"
-  log "press Ctrl-C to stop runtime and frontend"
-fi
+log "launcher mode: local-only startup"
+log 'for remote browser access, run separately: ngrok http 3000 --basic-auth="$NGROK_BASIC_AUTH"'
+log "the launcher does not start or verify ngrok in this flow"
+log "press Ctrl-C to stop runtime and frontend"
 
 wait -n "${PIDS[@]}"
 exit $?

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-154-ngrok-launcher-cutover](./archive/issue-154-ngrok-launcher-cutover/README.md)
 - [issue-153-ngrok-prereqs-doctor](./archive/issue-153-ngrok-prereqs-doctor/README.md)
 - [issue-152-ngrok-doc-sync](./archive/issue-152-ngrok-doc-sync/README.md)
 - [issue-125-phase-4a-bff-cutover](./archive/issue-125-phase-4a-bff-cutover/README.md)

--- a/tasks/archive/issue-154-ngrok-launcher-cutover/README.md
+++ b/tasks/archive/issue-154-ngrok-launcher-cutover/README.md
@@ -1,0 +1,54 @@
+# Issue #154 ngrok launcher cutover
+
+## Purpose
+
+- Replace the legacy DevTunnels-based launcher path with the supported `ngrok`-based remote-browser flow while preserving a clear local-only startup mode.
+
+## Primary issue
+
+- Issue: `#154` `Switch WebUI launch flow from DevTunnels to ngrok`
+
+## Source docs
+
+- `scripts/start-codex-webui.sh`
+- `docs/codex_webui_dev_container_onboarding.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `tasks/archive/issue-153-ngrok-prereqs-doctor/README.md`
+
+## Scope for this package
+
+- replace the current `devtunnel`-specific launcher assumptions in `scripts/start-codex-webui.sh`
+- define the launcher-facing `ngrok` and `ngrok Basic Auth` environment inputs for the supported remote-browser path
+- separate the supported local-only and `ngrok` launch modes clearly enough for follow-on validation to target them explicitly
+- record any intentionally deferred `devtunnel` cleanup that remains outside this slice
+
+## Exit criteria
+
+- `scripts/start-codex-webui.sh` no longer requires `devtunnel` for the supported remote-browser path
+- the launcher exposes a concrete local-only path and a concrete `ngrok` path with explicit input requirements
+- targeted validation shows the updated launcher surface is internally consistent
+- any residual legacy cleanup is linked explicitly instead of remaining implicit
+
+## Work plan
+
+- inspect the current launcher flow and the prerequisite/document changes already landed in `#152` and `#153`
+- implement the bounded launcher changes for `ngrok`
+- run targeted static and script-surface validation for the changed launcher behavior
+- update handoff notes with any remaining manual or external validation boundary
+
+## Artifacts / evidence
+
+- `bash -n scripts/start-codex-webui.sh`
+- `scripts/start-codex-webui.sh --help`
+- `rg -n 'devtunnel|DEVTUNNEL|ngrok|NGROK_BASIC_AUTH' scripts/start-codex-webui.sh docs/codex_webui_dev_container_onboarding.md`
+- dedicated pre-push validation gate: `git status --short --branch`, `git diff --check`, `git diff --stat`, `bash -n scripts/start-codex-webui.sh`, `scripts/start-codex-webui.sh --help`, and the targeted `rg` check
+- manual verification passed on `2026-04-14` in the Docker-backed/dev-container environment: `codex-runtime` reached `http://127.0.0.1:3001/api/v1/workspaces`, `frontend-bff` reached `http://127.0.0.1:3000/`, and the launcher emitted the expected local-only / separate-ngrok guidance
+
+## Status / handoff notes
+
+- Status: `archive-ready; pre-push gate passed; manual launcher verification passed`
+- Notes: `scripts/start-codex-webui.sh` now runs only the local runtime and frontend startup flow, removes active DevTunnel prompts/helpers/hosting branches, and points users to a separate ngrok command after local readiness. Sprint approval and the dedicated pre-push validation gate both passed with no remaining `devtunnel` matches in the launcher script and no diff-format errors. Manual verification also passed on `2026-04-14` in the intended Docker-backed/dev-container environment. Completion retrospective for this archive boundary: the issue split from #152/#153 kept the launcher scope bounded and reusable, while the main workflow problem was a read-only evaluator that created a stray .tmp handoff file; that side effect was quarantined and a clean evaluator rerun produced the final approval. Root README.md still mentions devtunnel in the launcher repo-map bullet; treat that as adjacent doc drift outside this bounded launcher slice unless closure work decides to absorb it explicitly.`
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate passes, and the handoff notes are updated.


### PR DESCRIPTION
## Summary
- remove DevTunnels-specific flow from `scripts/start-codex-webui.sh`
- keep the launcher as a local-only runtime/frontend startup path
- archive the task package with the final validation and manual verification notes

## Why
- the supported remote-browser workflow has moved to a separate `ngrok` command after local startup
- Issue #154 tracks the launcher cutover from DevTunnels to ngrok

## Validation
- `git diff --check`
- `bash -n scripts/start-codex-webui.sh`
- `scripts/start-codex-webui.sh --help`
- `rg -n 'devtunnel|DEVTUNNEL|ngrok|NGROK_BASIC_AUTH' scripts/start-codex-webui.sh docs/codex_webui_dev_container_onboarding.md`
- manual verification in the Docker-backed dev container: launcher reached `http://127.0.0.1:3001/api/v1/workspaces` and `http://127.0.0.1:3000/`

Closes #154
