### PR TITLE
fix: default codex runtime to live app-server bridge

### DIFF
--- a/apps/codex-runtime/src/config.ts
+++ b/apps/codex-runtime/src/config.ts
@@ -61,7 +61,7 @@ export function resolveConfig(overrides: Partial<RuntimeConfig> = {}): RuntimeCo
     appServerCwd: overrides.appServerCwd ?? process.env.CODEX_APP_SERVER_CWD,
     appServerBridgeEnabled:
       overrides.appServerBridgeEnabled ??
-      parseBooleanFlag(process.env.CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED, false),
+      parseBooleanFlag(process.env.CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED, true),
     appServerApprovalPolicy:
       overrides.appServerApprovalPolicy ??
       process.env.CODEX_WEBUI_APP_SERVER_APPROVAL_POLICY ??

--- a/apps/codex-runtime/src/domain/app-server/codex-app-server-gateway.ts
+++ b/apps/codex-runtime/src/domain/app-server/codex-app-server-gateway.ts
@@ -60,6 +60,12 @@ export interface NativeSessionEventSink {
       turn_id: string;
     },
   ): Promise<unknown>;
+  convergeSessionWaitingForInput?(
+    sessionId: string,
+    input: {
+      native_event_name: string;
+    },
+  ): Promise<unknown>;
 }
 
 interface PendingRequest {
@@ -76,6 +82,11 @@ interface PendingApprovalRequest {
 interface TurnState {
   hasFinalAssistantMessage: boolean;
   waitingForApproval: boolean;
+}
+
+interface PendingTurnStartConvergence {
+  turnId: string | null;
+  queuedEvents: any[];
 }
 
 function turnStateKey(sessionId: string, turnId: string) {
@@ -109,6 +120,7 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
   private pendingApprovals = new Map<string, PendingApprovalRequest>();
   private itemPhases = new Map<string, string>();
   private turnStates = new Map<string, TurnState>();
+  private pendingTurnStartConvergence = new Map<string, PendingTurnStartConvergence>();
   private eventSink: NativeSessionEventSink | null = null;
   private startPromise: Promise<AppServerSnapshot> | null = null;
   private eventChain = Promise.resolve();
@@ -187,6 +199,11 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
   }
 
   async sendUserMessage(input: SendNativeSessionMessageInput) {
+    this.pendingTurnStartConvergence.set(input.sessionId, {
+      turnId: null,
+      queuedEvents: [],
+    });
+
     const result = await this.sendRequest("turn/start", {
       threadId: input.sessionId,
       input: [
@@ -197,9 +214,34 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
       ],
     });
 
+    const turnId = String(result.turn.id);
+    const pending = this.pendingTurnStartConvergence.get(input.sessionId);
+    if (pending) {
+      pending.turnId = turnId;
+    }
+
     return {
-      turnId: String(result.turn.id),
+      turnId,
     };
+  }
+
+  async acknowledgeTurnStartPersisted(input: { sessionId: string; turnId: string }) {
+    const pending = this.pendingTurnStartConvergence.get(input.sessionId);
+    if (!pending || pending.turnId !== input.turnId) {
+      return;
+    }
+
+    this.pendingTurnStartConvergence.delete(input.sessionId);
+    const replayEvents = this.sortDeferredTurnEvents(pending.queuedEvents);
+    this.eventChain = this.eventChain
+      .then(async () => {
+        for (const event of replayEvents) {
+          await this.handleEvent(event);
+        }
+      })
+      .catch(() => {
+        // Keep replay failures isolated from the request path.
+      });
   }
 
   async cancelPendingApproval(input: { sessionId: string; approvalId: string }) {
@@ -389,14 +431,29 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
 
     const method = String(message.method);
     const params = message.params ?? {};
+    const sessionId = String(params.threadId ?? "");
+    const turnId = String(params.turnId ?? params.turn?.id ?? "");
+
+    if (this.shouldDeferTurnEvent(method, sessionId, turnId)) {
+      this.pendingTurnStartConvergence.get(sessionId)?.queuedEvents.push(message);
+      return;
+    }
 
     if (method === "turn/started") {
-      const sessionId = String(params.threadId ?? "");
-      const turnId = String(params.turn?.id ?? "");
       if (sessionId && turnId) {
         this.turnStates.set(turnStateKey(sessionId, turnId), {
           hasFinalAssistantMessage: false,
           waitingForApproval: false,
+        });
+      }
+      return;
+    }
+
+    if (method === "thread/status/changed") {
+      const statusType = String(params.status?.type ?? "");
+      if (sessionId && statusType === "idle" && this.eventSink.convergeSessionWaitingForInput) {
+        await this.eventSink.convergeSessionWaitingForInput(sessionId, {
+          native_event_name: "thread/status/changed",
         });
       }
       return;
@@ -412,8 +469,6 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
         return;
       }
 
-      const sessionId = String(params.threadId ?? "");
-      const turnId = String(params.turnId ?? "");
       const delta = String(params.delta ?? "");
       if (!sessionId || !turnId || delta.length === 0) {
         return;
@@ -438,8 +493,6 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
         return;
       }
 
-      const sessionId = String(params.threadId ?? "");
-      const turnId = String(params.turnId ?? "");
       const content = String(params.item.text ?? "");
       if (!sessionId || !turnId || content.length === 0) {
         return;
@@ -459,8 +512,6 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
     }
 
     if (method === "item/commandExecution/requestApproval") {
-      const sessionId = String(params.threadId ?? "");
-      const turnId = String(params.turnId ?? "");
       const command = String(params.command ?? "");
       const requestId = Number(message.id);
       if (!sessionId || !turnId || !Number.isFinite(requestId) || command.length === 0) {
@@ -500,8 +551,6 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
     }
 
     if (method === "turn/completed") {
-      const sessionId = String(params.threadId ?? "");
-      const turnId = String(params.turn?.id ?? "");
       const status = String(params.turn?.status ?? "");
       if (!sessionId || !turnId) {
         return;
@@ -513,9 +562,8 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
 
       if (
         status === "completed" &&
-        state &&
-        !state.hasFinalAssistantMessage &&
-        !state.waitingForApproval &&
+        !state?.hasFinalAssistantMessage &&
+        !state?.waitingForApproval &&
         this.eventSink.completeTurnWithoutAssistantMessage
       ) {
         logLiveChatDebug("app-server", "turn completed without assistant message", {
@@ -527,6 +575,58 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
         });
       }
     }
+  }
+
+  private shouldDeferTurnEvent(method: string, sessionId: string, turnId: string) {
+    if (!sessionId) {
+      return false;
+    }
+
+    const pending = this.pendingTurnStartConvergence.get(sessionId);
+    if (!pending) {
+      return false;
+    }
+
+    switch (method) {
+      case "turn/started":
+      case "thread/status/changed":
+      case "item/started":
+      case "item/agentMessage/delta":
+      case "item/completed":
+      case "item/commandExecution/requestApproval":
+      case "turn/completed":
+        return pending.turnId === null || pending.turnId === turnId;
+      default:
+        return false;
+    }
+  }
+
+  private sortDeferredTurnEvents(events: any[]) {
+    const eventPriority = (message: any) => {
+      const method = String(message.method);
+      if (method === "thread/status/changed") {
+        return String(message.params?.status?.type ?? "") === "idle" ? 5 : 0;
+      }
+
+      switch (method) {
+        case "turn/started":
+          return 1;
+        case "item/started":
+          return 2;
+        case "item/agentMessage/delta":
+          return 3;
+        case "item/completed":
+          return 4;
+        case "item/commandExecution/requestApproval":
+          return 4;
+        case "turn/completed":
+          return 6;
+        default:
+          return 0;
+      }
+    };
+
+    return [...events].sort((left, right) => eventPriority(left) - eventPriority(right));
   }
 
   private ensureTurnState(sessionId: string, turnId: string) {

--- a/apps/codex-runtime/src/domain/sessions/session-service.ts
+++ b/apps/codex-runtime/src/domain/sessions/session-service.ts
@@ -120,6 +120,10 @@ function firstRequiredRow<T>(rows: T[], notFound: () => never) {
   return row;
 }
 
+type TurnStartConvergenceGateway = NativeSessionGateway & {
+  acknowledgeTurnStartPersisted?: (input: { sessionId: string; turnId: string }) => Promise<void>;
+};
+
 export class SessionService {
   constructor(
     private readonly database: RuntimeDatabase,
@@ -129,6 +133,15 @@ export class SessionService {
     private readonly sessionEventPublisher: SessionEventPublisher,
     private readonly now: () => Date = () => new Date(),
   ) {}
+
+  private async acknowledgeTurnStartPersisted(sessionId: string, turnId: string) {
+    await (
+      this.nativeSessionGateway as TurnStartConvergenceGateway
+    ).acknowledgeTurnStartPersisted?.({
+      sessionId,
+      turnId,
+    });
+  }
 
   subscribeSessionEvents(sessionId: string, listener: (event: SessionEventProjection) => void) {
     return this.sessionEventPublisher.subscribeSessionEvents(sessionId, listener);
@@ -999,6 +1012,7 @@ export class SessionService {
           toStatus: "running",
         });
       })();
+      await this.acknowledgeTurnStartPersisted(sessionId, nativeTurn.turnId);
     } catch (error) {
       try {
         this.markSessionRecoveryPending({
@@ -1370,6 +1384,65 @@ export class SessionService {
         occurredAt: completedAt,
         fromStatus: session.status as SessionStatus,
         toStatus: "waiting_input",
+      });
+    })();
+
+    return this.getSession(sessionId);
+  }
+
+  async convergeSessionWaitingForInput(
+    sessionId: string,
+    input: {
+      native_event_name: string;
+    },
+  ) {
+    const session = firstRequiredRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, sessionId))
+        .limit(1)
+        .all(),
+      () => {
+        throw new RuntimeError(404, "session_not_found", "session was not found", {
+          session_id: sessionId,
+        });
+      },
+    );
+
+    if (session.status !== "running") {
+      return this.getSession(sessionId);
+    }
+
+    const updatedAt = toIsoString(this.now());
+
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .update(sessions)
+        .set({
+          status: "waiting_input",
+          updatedAt,
+          currentTurnId: null,
+          pendingAssistantMessageId: null,
+          appSessionOverlayState: "open",
+        })
+        .where(eq(sessions.sessionId, sessionId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          updatedAt,
+        })
+        .where(eq(workspaces.workspaceId, session.workspaceId))
+        .run();
+
+      this.appendSessionStatusChangedEvent({
+        sessionId,
+        occurredAt: updatedAt,
+        fromStatus: session.status as SessionStatus,
+        toStatus: "waiting_input",
+        nativeEventName: input.native_event_name,
       });
     })();
 

--- a/apps/codex-runtime/src/domain/threads/thread-service.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-service.ts
@@ -194,6 +194,10 @@ function firstRow<T>(rows: T[]) {
   return rows[0] ?? null;
 }
 
+type TurnStartConvergenceGateway = NativeSessionGateway & {
+  acknowledgeTurnStartPersisted?: (input: { sessionId: string; turnId: string }) => Promise<void>;
+};
+
 function asRuntimeError(error: unknown) {
   return error instanceof RuntimeError ? error : null;
 }
@@ -295,6 +299,15 @@ export class ThreadService {
     private readonly nativeSessionGateway: NativeSessionGateway,
     private readonly now: () => Date = () => new Date(),
   ) {}
+
+  private async acknowledgeTurnStartPersisted(sessionId: string, turnId: string) {
+    await (
+      this.nativeSessionGateway as TurnStartConvergenceGateway
+    ).acknowledgeTurnStartPersisted?.({
+      sessionId,
+      turnId,
+    });
+  }
 
   async listThreads(workspaceId: string) {
     await this.workspaceRegistry.getWorkspace(workspaceId);
@@ -1041,6 +1054,7 @@ export class ThreadService {
           toStatus: "running",
         });
       })();
+      await this.acknowledgeTurnStartPersisted(threadId, nativeTurn.turnId);
     } catch (error) {
       try {
         this.markThreadRecoveryPending(

--- a/apps/codex-runtime/tests/config.test.ts
+++ b/apps/codex-runtime/tests/config.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveConfig } from "../src/config.js";
+
+const originalBridgeFlag = process.env.CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED;
+
+afterEach(() => {
+  if (originalBridgeFlag === undefined) {
+    delete process.env.CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED;
+    return;
+  }
+
+  process.env.CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED = originalBridgeFlag;
+});
+
+describe("runtime config", () => {
+  it("enables the app-server bridge by default", () => {
+    delete process.env.CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED;
+
+    expect(resolveConfig().appServerBridgeEnabled).toBe(true);
+  });
+
+  it("allows the bridge to be disabled explicitly", () => {
+    process.env.CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED = "false";
+
+    expect(resolveConfig().appServerBridgeEnabled).toBe(false);
+  });
+});

--- a/apps/codex-runtime/tests/fixtures/fake-codex-app-server.mjs
+++ b/apps/codex-runtime/tests/fixtures/fake-codex-app-server.mjs
@@ -4,6 +4,8 @@ const protocolVersion = "2025-03-26";
 let threadCounter = 1;
 let turnCounter = 1;
 let itemCounter = 1;
+const turnStartMode =
+  process.argv.find((arg) => arg.startsWith("--turn-start-mode="))?.split("=")[1] ?? "normal";
 
 function send(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
@@ -67,17 +69,7 @@ lineReader.on("line", (line) => {
     const prompt = String(message.params?.input?.[0]?.text ?? "");
     const finalText = `Synthetic assistant response for: ${prompt}`;
 
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        turn: {
-          id: turnId,
-        },
-      },
-    });
-
-    setTimeout(() => {
+    const emitTurnCompletion = () => {
       send({
         jsonrpc: "2.0",
         method: "turn/started",
@@ -136,7 +128,33 @@ lineReader.on("line", (line) => {
           },
         },
       });
-    }, 10);
+    };
+
+    if (turnStartMode === "pre_ack_completion") {
+      emitTurnCompletion();
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          turn: {
+            id: turnId,
+          },
+        },
+      });
+      return;
+    }
+
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        turn: {
+          id: turnId,
+        },
+      },
+    });
+
+    setTimeout(emitTurnCompletion, 10);
     return;
   }
 

--- a/apps/codex-runtime/tests/thread-routes.test.ts
+++ b/apps/codex-runtime/tests/thread-routes.test.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { buildApp } from "../src/app.js";
-import { approvals, sessionEvents, sessions, workspaces } from "../src/db/schema.js";
+import { approvals, messages, sessionEvents, sessions, workspaces } from "../src/db/schema.js";
 import type { NativeSessionGateway } from "../src/domain/sessions/native-session-gateway.js";
 import { RuntimeError } from "../src/errors.js";
 import { createTempDatabase, createTempWorkspaceRoot } from "./helpers.js";
@@ -58,18 +59,14 @@ class StubNativeSessionGateway implements NativeSessionGateway {
 }
 
 class FailingSendNativeSessionGateway extends StubNativeSessionGateway {
-  override async sendUserMessage(
-    _input: { sessionId: string; content: string },
-  ): Promise<{ turnId: string }> {
-    throw new RuntimeError(
-      502,
-      "app_server_request_failed",
-      "turn is already running",
-      {
-        rpc_method: "turn/start",
-        rpc_error_code: "invalid_state",
-      },
-    );
+  override async sendUserMessage(_input: {
+    sessionId: string;
+    content: string;
+  }): Promise<{ turnId: string }> {
+    throw new RuntimeError(502, "app_server_request_failed", "turn is already running", {
+      rpc_method: "turn/start",
+      rpc_error_code: "invalid_state",
+    });
   }
 }
 
@@ -119,6 +116,23 @@ function createSseReader(response: Response) {
   };
 }
 
+async function waitForAssertion(assertion: () => Promise<void>, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      await assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+
+  throw lastError;
+}
+
 describe("thread routes", () => {
   it("lists threads from the v0.9 workspace thread route", async () => {
     const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
@@ -129,6 +143,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -197,6 +212,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -253,6 +269,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -324,6 +341,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -389,6 +407,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -598,6 +617,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -738,6 +758,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -772,6 +793,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -886,6 +908,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -919,6 +942,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -982,6 +1006,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -1049,6 +1074,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -1132,6 +1158,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -1232,6 +1259,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -1339,6 +1367,7 @@ describe("thread routes", () => {
       config: {
         workspaceRoot,
         databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
         appServerCommand: process.execPath,
         appServerArgs: ["-e", "process.exit(0)"],
       },
@@ -1395,6 +1424,187 @@ describe("thread routes", () => {
         }),
       ]),
     );
+
+    await app.close();
+  });
+
+  it("converges a first-input-started thread after pre-ack assistant completion delivery", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: true,
+        appServerCommand: process.execPath,
+        appServerArgs: [
+          fileURLToPath(new URL("./fixtures/fake-codex-app-server.mjs", import.meta.url)),
+          "--turn-start-mode=pre_ack_completion",
+        ],
+      },
+      database,
+    });
+
+    const workspaceResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/workspaces",
+      payload: {
+        workspace_name: "alpha",
+      },
+    });
+
+    expect(workspaceResponse.statusCode).toBe(201);
+    const workspaceId = workspaceResponse.json().workspace_id as string;
+
+    const startResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/workspaces/${workspaceId}/inputs`,
+      payload: {
+        client_request_id: "req_pre_ack_001",
+        content: "Plan the runtime cutover",
+      },
+    });
+
+    expect(startResponse.statusCode).toBe(202);
+    const threadId = startResponse.json().thread.thread_id as string;
+
+    await waitForAssertion(async () => {
+      const persistedSession = database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, threadId))
+        .limit(1)
+        .all()[0];
+
+      expect(persistedSession).toMatchObject({
+        sessionId: threadId,
+        status: "waiting_input",
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+      });
+
+      const threadResponse = await app.inject({
+        method: "GET",
+        url: `/api/v1/threads/${threadId}`,
+      });
+      expect(threadResponse.statusCode).toBe(200);
+      expect(threadResponse.json()).toMatchObject({
+        thread_id: threadId,
+        native_status: {
+          thread_status: "idle",
+          latest_turn_status: "completed",
+          active_flags: [],
+        },
+        derived_hints: {
+          accepting_user_input: true,
+          has_pending_request: false,
+          blocked_reason: null,
+        },
+      });
+
+      const viewResponse = await app.inject({
+        method: "GET",
+        url: `/api/v1/threads/${threadId}/view`,
+      });
+      expect(viewResponse.statusCode).toBe(200);
+      expect(viewResponse.json()).toMatchObject({
+        thread: {
+          thread_id: threadId,
+          native_status: {
+            thread_status: "idle",
+          },
+          derived_hints: {
+            accepting_user_input: true,
+          },
+        },
+        pending_request: null,
+      });
+
+      const listResponse = await app.inject({
+        method: "GET",
+        url: `/api/v1/workspaces/${workspaceId}/threads`,
+      });
+      expect(listResponse.statusCode).toBe(200);
+      expect(listResponse.json()).toMatchObject({
+        items: [
+          expect.objectContaining({
+            thread_id: threadId,
+            native_status: expect.objectContaining({
+              thread_status: "idle",
+            }),
+            derived_hints: expect.objectContaining({
+              accepting_user_input: true,
+            }),
+          }),
+        ],
+      });
+      expect(listResponse.json().items).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            thread_id: threadId,
+            native_status: expect.objectContaining({
+              thread_status: "running",
+            }),
+          }),
+        ]),
+      );
+
+      const storedMessages = database.db
+        .select()
+        .from(messages)
+        .where(eq(messages.sessionId, threadId))
+        .all();
+      expect(storedMessages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+          }),
+          expect.objectContaining({
+            role: "assistant",
+            content: "Synthetic assistant response for: Plan the runtime cutover",
+          }),
+        ]),
+      );
+    });
+
+    const messageRows = database.db
+      .select()
+      .from(sessionEvents)
+      .where(eq(sessionEvents.sessionId, threadId))
+      .all();
+    expect(messageRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "message.user",
+        }),
+        expect.objectContaining({
+          eventType: "message.assistant.completed",
+        }),
+      ]),
+    );
+
+    const followUpResponse = await app.inject({
+      method: "POST",
+      url: `/api/v1/threads/${threadId}/inputs`,
+      payload: {
+        client_request_id: "req_pre_ack_followup_001",
+        content: "Continue the runtime cutover",
+      },
+    });
+
+    expect(followUpResponse.statusCode).toBe(202);
+    expect(followUpResponse.json()).toMatchObject({
+      thread: {
+        thread_id: threadId,
+      },
+      accepted_input: {
+        session_id: threadId,
+        role: "user",
+        content: "Continue the runtime cutover",
+      },
+    });
 
     await app.close();
   });

--- a/apps/frontend-bff/app/api/v1/threads/[threadId]/view/route.ts
+++ b/apps/frontend-bff/app/api/v1/threads/[threadId]/view/route.ts
@@ -1,5 +1,8 @@
 import { getThreadView } from "../../../../../../src/handlers";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export async function GET(request: Request, context: { params: Promise<{ threadId: string }> }) {
   const { threadId } = await context.params;
   return getThreadView(request, threadId);

--- a/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/threads/route.ts
+++ b/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/threads/route.ts
@@ -1,5 +1,8 @@
 import { listThreads } from "../../../../../../src/handlers";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export async function GET(request: Request, context: { params: Promise<{ workspaceId: string }> }) {
   const { workspaceId } = await context.params;
   return listThreads(request, workspaceId);

--- a/apps/frontend-bff/e2e/chat-flow.runtime.spec.ts
+++ b/apps/frontend-bff/e2e/chat-flow.runtime.spec.ts
@@ -62,28 +62,34 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
     ).toBeVisible({ timeout: 15_000 });
 
     const sendReplyButton = page.getByRole("button", { name: "Send reply" });
-    if (await sendReplyButton.isEnabled()) {
-      await page.getByLabel("Send follow-up input").fill(followUpInput);
-      await sendReplyButton.click();
-      await expect(page.getByText("Input accepted. Waiting for thread updates.")).toBeVisible({
-        timeout: 15_000,
-      });
-      await expect(page.getByText(followUpInput)).toBeVisible({ timeout: 15_000 });
-      await expect(
-        page
-          .locator(".thread-summary-card")
-          .filter({ hasText: threadId })
-          .getByText("Waiting for your input", { exact: true }),
-      ).toBeVisible({ timeout: 15_000 });
-      await expect(
-        page
-          .locator("section.chat-panel.workspace-card")
-          .filter({ has: page.getByText("Current thread", { exact: true }) })
-          .getByText("Waiting for your input", { exact: true }),
-      ).toBeVisible({ timeout: 15_000 });
-    } else {
-      await expect(sendReplyButton).toBeDisabled();
-    }
+    await expect(sendReplyButton).toBeDisabled();
+    await page.getByLabel("Send follow-up input").fill(followUpInput);
+    await expect(sendReplyButton).toBeEnabled({ timeout: 15_000 });
+    await sendReplyButton.click();
+    await expect(page.getByText("Input accepted. Waiting for thread updates.")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page
+        .locator("article")
+        .filter({
+          has: page.getByText("message.user", { exact: true }),
+          hasText: followUpInput,
+        })
+        .first(),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page
+        .locator(".thread-summary-card")
+        .filter({ hasText: threadId })
+        .getByText("Waiting for your input", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page
+        .locator("section.chat-panel.workspace-card")
+        .filter({ has: page.getByText("Current thread", { exact: true }) })
+        .getByText("Waiting for your input", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
 
     const interruptThreadButton = page.getByRole("button", { name: "Interrupt thread" });
     if (await interruptThreadButton.isEnabled()) {

--- a/apps/frontend-bff/playwright.config.ts
+++ b/apps/frontend-bff/playwright.config.ts
@@ -17,17 +17,17 @@ export default defineConfig({
     : [
         {
           command:
-            "mkdir -p ../codex-runtime/var/playwright/workspaces ../codex-runtime/var/playwright/data && HOST=127.0.0.1 PORT=3001 CODEX_WEBUI_WORKSPACE_ROOT=../codex-runtime/var/playwright/workspaces CODEX_WEBUI_DATABASE_PATH=../codex-runtime/var/playwright/data/codex-runtime.sqlite CODEX_APP_SERVER_COMMAND=node CODEX_APP_SERVER_ARGS='-e process.exit(0)' npm run dev --prefix ../codex-runtime",
+            "rm -rf ../codex-runtime/var/playwright && mkdir -p ../codex-runtime/var/playwright/workspaces ../codex-runtime/var/playwright/data && HOST=127.0.0.1 PORT=3001 CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED=true CODEX_WEBUI_WORKSPACE_ROOT=../codex-runtime/var/playwright/workspaces CODEX_WEBUI_DATABASE_PATH=../codex-runtime/var/playwright/data/codex-runtime.sqlite CODEX_APP_SERVER_COMMAND=node CODEX_APP_SERVER_ARGS='tests/fixtures/fake-codex-app-server.mjs --turn-start-mode=pre_ack_completion' npm run dev --prefix ../codex-runtime",
           url: "http://127.0.0.1:3001/api/v1/workspaces",
-          reuseExistingServer: true,
-          timeout: 120_000,
+          reuseExistingServer: false,
+          timeout: 180_000,
         },
         {
           command:
             "CODEX_WEBUI_RUNTIME_BASE_URL=http://127.0.0.1:3001 npm run dev -- --hostname 127.0.0.1 --port 3000",
           url: "http://127.0.0.1:3000/",
-          reuseExistingServer: true,
-          timeout: 120_000,
+          reuseExistingServer: false,
+          timeout: 180_000,
         },
       ],
   projects: [

--- a/apps/frontend-bff/src/chat-page-client.tsx
+++ b/apps/frontend-bff/src/chat-page-client.tsx
@@ -42,6 +42,8 @@ function upsertStreamEvent(
 }
 
 const ACTIVE_THREAD_REFRESH_INTERVAL_MS = 1500;
+const POST_START_READY_REFRESH_INTERVAL_MS = 400;
+const POST_START_READY_REFRESH_ATTEMPTS = 8;
 
 export function ChatPageClient() {
   const searchParams = useSearchParams();
@@ -71,6 +73,7 @@ export function ChatPageClient() {
   const activeThreadRefreshTimerRef = useRef<number | null>(null);
   const threadListRefreshIdRef = useRef(0);
   const selectedThreadRefreshIdRef = useRef(0);
+  const selectedThreadIdRef = useRef<string | null>(initialThreadId);
 
   function updateSelectedThreadId(
     nextThreadId: string | null,
@@ -83,7 +86,41 @@ export function ChatPageClient() {
       next_thread_id: nextThreadId,
       ...details,
     });
+    selectedThreadIdRef.current = nextThreadId;
     setSelectedThreadId(nextThreadId);
+  }
+
+  async function convergeStartedThreadSendability(threadId: string) {
+    for (let attempt = 0; attempt < POST_START_READY_REFRESH_ATTEMPTS; attempt += 1) {
+      if (selectedThreadIdRef.current !== threadId) {
+        return;
+      }
+
+      const bundle = await refreshSelectedThread(threadId);
+      if (!bundle) {
+        return;
+      }
+
+      if (bundle.view.composer.accepting_user_input) {
+        await refreshThreads(threadId);
+        return;
+      }
+
+      if (
+        bundle.view.current_activity.kind !== "running" ||
+        bundle.view.pending_request !== null ||
+        bundle.view.composer.blocked_by_request
+      ) {
+        await refreshThreads(threadId);
+        return;
+      }
+
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, POST_START_READY_REFRESH_INTERVAL_MS);
+      });
+    }
+
+    await refreshThreads(threadId);
   }
 
   async function refreshThreads(preferredThreadId?: string | null) {
@@ -180,6 +217,10 @@ export function ChatPageClient() {
   useEffect(() => {
     void refreshThreads(initialThreadId);
   }, [workspaceId, initialThreadId]);
+
+  useEffect(() => {
+    selectedThreadIdRef.current = selectedThreadId;
+  }, [selectedThreadId]);
 
   useEffect(() => {
     logLiveChatDebug("chat-stream", "selectedThreadId effect fired", {
@@ -368,11 +409,9 @@ export function ChatPageClient() {
       });
       setNewThreadInput("");
       setStatusMessage(`Started thread ${result.thread.thread_id}.`);
-      await refreshThreads(result.thread.thread_id);
-      logLiveChatDebug("chat-stream", "selecting created thread", {
-        thread_id: result.thread.thread_id,
-      });
       updateSelectedThreadId(result.thread.thread_id, "create_thread_success");
+      await refreshThreads(result.thread.thread_id);
+      void convergeStartedThreadSendability(result.thread.thread_id);
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Failed to start a new thread.");
     } finally {

--- a/apps/frontend-bff/src/handlers.ts
+++ b/apps/frontend-bff/src/handlers.ts
@@ -260,7 +260,6 @@ function createSseRelayStream<TInput, TOutput>(
         } catch (error) {
           cleanup();
           if (signal.aborted) {
-            controller.close();
             return;
           }
 

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -392,6 +392,300 @@ describe("ChatPageClient", () => {
     expect(container.textContent).toContain("Continue with the fix.");
   });
 
+  it("converges a newly started thread back to sendable follow-up input without reload", async () => {
+    const originalThreadId = searchParams.get("threadId");
+    searchParams.delete("threadId");
+    let startedThreadViewLoads = 0;
+    let followUpSubmitted = false;
+
+    const startedThreadRunningView = buildThreadView({
+      thread: {
+        thread_id: "thread_new",
+        workspace_id: "ws_alpha",
+        native_status: {
+          thread_status: "running",
+          active_flags: ["turn_active"],
+          latest_turn_status: "running",
+        },
+        updated_at: "2026-03-27T05:23:00Z",
+      },
+      current_activity: {
+        kind: "running",
+        label: "Running",
+      },
+      composer: {
+        accepting_user_input: false,
+        interrupt_available: true,
+        blocked_by_request: false,
+      },
+      timeline: {
+        items: [
+          {
+            timeline_item_id: "evt_new_001",
+            thread_id: "thread_new",
+            turn_id: "turn_new_001",
+            item_id: "item_new_001",
+            sequence: 1,
+            occurred_at: "2026-03-27T05:23:00Z",
+            kind: "message.user",
+            payload: {
+              summary: "user input accepted",
+              content: "Start a new thread.",
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+    const startedThreadReadyView = buildThreadView({
+      thread: {
+        thread_id: "thread_new",
+        workspace_id: "ws_alpha",
+        native_status: {
+          thread_status: "waiting_input",
+          active_flags: [],
+          latest_turn_status: null,
+        },
+        updated_at: "2026-03-27T05:23:04Z",
+      },
+      current_activity: {
+        kind: "waiting_on_user_input",
+        label: "Waiting for your input",
+      },
+      composer: {
+        accepting_user_input: true,
+        interrupt_available: false,
+        blocked_by_request: false,
+      },
+      timeline: {
+        items: [
+          {
+            timeline_item_id: "evt_new_001",
+            thread_id: "thread_new",
+            turn_id: "turn_new_001",
+            item_id: "item_new_001",
+            sequence: 1,
+            occurred_at: "2026-03-27T05:23:00Z",
+            kind: "message.user",
+            payload: {
+              summary: "user input accepted",
+              content: "Start a new thread.",
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+    const followUpRunningView = buildThreadView({
+      thread: {
+        thread_id: "thread_new",
+        workspace_id: "ws_alpha",
+        native_status: {
+          thread_status: "running",
+          active_flags: ["turn_active"],
+          latest_turn_status: "running",
+        },
+        updated_at: "2026-03-27T05:23:08Z",
+      },
+      current_activity: {
+        kind: "running",
+        label: "Running",
+      },
+      composer: {
+        accepting_user_input: false,
+        interrupt_available: true,
+        blocked_by_request: false,
+      },
+      timeline: {
+        items: [
+          {
+            timeline_item_id: "evt_new_001",
+            thread_id: "thread_new",
+            turn_id: "turn_new_001",
+            item_id: "item_new_001",
+            sequence: 1,
+            occurred_at: "2026-03-27T05:23:00Z",
+            kind: "message.user",
+            payload: {
+              summary: "user input accepted",
+              content: "Start a new thread.",
+            },
+          },
+          {
+            timeline_item_id: "evt_new_002",
+            thread_id: "thread_new",
+            turn_id: "turn_new_002",
+            item_id: "item_new_002",
+            sequence: 2,
+            occurred_at: "2026-03-27T05:23:08Z",
+            kind: "message.user",
+            payload: {
+              summary: "user input accepted",
+              content: "Please explain the diff.",
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+
+    chatDataMocks.listWorkspaceThreads
+      .mockResolvedValueOnce({
+        items: [],
+        next_cursor: null,
+        has_more: false,
+      })
+      .mockResolvedValue({
+        items: [
+          buildThreadListItem({
+            thread_id: "thread_new",
+            native_status: {
+              thread_status: "waiting_input",
+              active_flags: [],
+              latest_turn_status: null,
+            },
+            current_activity: {
+              kind: "waiting_on_user_input",
+              label: "Waiting for your input",
+            },
+          }),
+        ],
+        next_cursor: null,
+        has_more: false,
+      });
+    chatDataMocks.startThreadFromChat.mockResolvedValue(
+      buildAcceptedInputResponse({
+        accepted: {
+          thread_id: "thread_new",
+          turn_id: "turn_new_001",
+          input_item_id: "item_new_001",
+        },
+        thread: {
+          thread_id: "thread_new",
+          workspace_id: "ws_alpha",
+          native_status: {
+            thread_status: "running",
+            active_flags: ["turn_active"],
+            latest_turn_status: "running",
+          },
+          updated_at: "2026-03-27T05:23:00Z",
+        },
+      }),
+    );
+    chatDataMocks.loadChatThreadBundle.mockImplementation(async () => ({
+      view: followUpSubmitted
+        ? followUpRunningView
+        : startedThreadViewLoads++ === 0
+          ? startedThreadRunningView
+          : startedThreadReadyView,
+      pendingRequestDetail: null,
+    }));
+    chatDataMocks.sendThreadInput.mockImplementation(async () => {
+      followUpSubmitted = true;
+
+      return buildAcceptedInputResponse({
+        accepted: {
+          thread_id: "thread_new",
+          turn_id: "turn_new_002",
+          input_item_id: "item_new_002",
+        },
+        thread: {
+          thread_id: "thread_new",
+          workspace_id: "ws_alpha",
+          native_status: {
+            thread_status: "running",
+            active_flags: ["turn_active"],
+            latest_turn_status: "running",
+          },
+          updated_at: "2026-03-27T05:23:08Z",
+        },
+      });
+    });
+
+    try {
+      await act(async () => {
+        root.render(<ChatPageClient />);
+      });
+      await flushUi();
+
+      const firstInputTextarea = container.querySelector("#thread-input");
+      expect(firstInputTextarea).not.toBeNull();
+
+      await act(async () => {
+        const setTextareaValue = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
+
+        setTextareaValue?.call(firstInputTextarea as HTMLTextAreaElement, "Start a new thread.");
+        firstInputTextarea!.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      await flushUi();
+
+      const startThreadButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Start new thread",
+      );
+      expect(startThreadButton).not.toBeUndefined();
+
+      await act(async () => {
+        startThreadButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await flushUi();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+      await flushUi();
+
+      expect(container.textContent).toContain("Started thread thread_new.");
+      expect(container.textContent).toContain("Waiting for your input");
+
+      const followUpTextarea = container.querySelector("#message-input");
+      expect(followUpTextarea).not.toBeNull();
+
+      const sendButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Send reply",
+      );
+      expect(sendButton).not.toBeUndefined();
+      expect((sendButton as HTMLButtonElement).disabled).toBe(true);
+
+      await act(async () => {
+        const setTextareaValue = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
+
+        setTextareaValue?.call(followUpTextarea as HTMLTextAreaElement, "Please explain the diff.");
+        followUpTextarea!.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      await flushUi();
+
+      expect((sendButton as HTMLButtonElement).disabled).toBe(false);
+
+      await act(async () => {
+        sendButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await flushUi();
+
+      expect(chatDataMocks.sendThreadInput).toHaveBeenCalledWith(
+        "thread_new",
+        "Please explain the diff.",
+        expect.stringMatching(/^input_followup_/),
+      );
+      expect(container.textContent).toContain("Input accepted. Waiting for thread updates.");
+      expect(container.textContent).toContain("Please explain the diff.");
+    } finally {
+      if (originalThreadId) {
+        searchParams.set("threadId", originalThreadId);
+      } else {
+        searchParams.delete("threadId");
+      }
+    }
+  });
+
   it("responds to a pending request from thread context instead of the approvals page", async () => {
     const pendingRequestDetail = buildPendingRequestDetail();
     chatDataMocks.listWorkspaceThreads.mockResolvedValue({

--- a/artifacts/issue-158-post-start-sendability/managed-playwright-validation-2026-04-18.md
+++ b/artifacts/issue-158-post-start-sendability/managed-playwright-validation-2026-04-18.md
@@ -1,0 +1,59 @@
+# Issue 158 Managed Playwright Validation
+
+Date: `2026-04-18`
+Issue: `#158`
+Worktree: `.worktrees/issue-158-post-start-sendability`
+
+## Summary
+
+The browser-path defect was reproducible because the managed Playwright stack launched `codex-runtime` without `CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED=true`. That meant the runtime used `SyntheticNativeSessionGateway`, so first-input starts stayed in `running` forever and never exercised the live app-server convergence code.
+
+After enabling the bridge and switching the managed app-server command to the repo fake fixture with `--turn-start-mode=pre_ack_completion`, the localhost browser path converged back to `Waiting for your input` before reload on both configured Playwright projects.
+
+## Evidence
+
+### Reproduction before harness fix
+
+- Manual BFF API polling against the managed stack showed `thread_view.current_activity.kind = "running"` and `composer.accepting_user_input = false` for more than 12 seconds after the first input.
+- The persisted session row remained `status = "running"` with a non-null `current_turn_id`.
+- The timeline only showed:
+  - `session.status_changed` `created -> running`
+  - `session.status_changed` `running -> waiting_input`
+  - `message.user`
+  - `session.status_changed` `waiting_input -> running`
+
+### Root cause check
+
+- Starting the same stack with:
+  - `CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED=true`
+  - `CODEX_APP_SERVER_COMMAND=node`
+  - `CODEX_APP_SERVER_ARGS='tests/fixtures/fake-codex-app-server.mjs --turn-start-mode=pre_ack_completion'`
+- Manual API polling then converged within 1 second to:
+  - thread list `current_activity.kind = "waiting_on_user_input"`
+  - thread view `current_activity.kind = "waiting_on_user_input"`
+  - `composer.accepting_user_input = true`
+  - timeline includes `message.assistant.completed` and the final `session.status_changed` back to `waiting_input`
+
+### Final validation
+
+Ran from the active worktree:
+
+```bash
+npm run check --prefix apps/frontend-bff
+npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --project=mobile-chromium
+```
+
+Results:
+
+- `npm run check --prefix apps/frontend-bff`: pass
+- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --project=mobile-chromium`: pass
+
+Managed Playwright result:
+
+- `desktop-chromium`: pass
+- `mobile-chromium`: pass
+
+## Notes
+
+- One intermediate external-stack Playwright run failed after the convergence fix because `getByText(followUpInput)` matched both the user message and the synthetic assistant echo. The final test uses an exact-text assertion for the follow-up user message.
+- The managed Playwright config now uses `reuseExistingServer: false` for both web servers so the validation does not silently attach to unrelated local servers.

--- a/artifacts/issue-158-post-start-sendability/pre-push-validation-2026-04-18.md
+++ b/artifacts/issue-158-post-start-sendability/pre-push-validation-2026-04-18.md
@@ -1,0 +1,36 @@
+# Issue 158 Pre-Push Validation
+
+Date: `2026-04-18`
+Issue: `#158`
+Worktree: `.worktrees/issue-158-post-start-sendability`
+
+## Gate status
+
+Passed
+
+## Commands run
+
+```bash
+npm run check --prefix apps/codex-runtime
+npm run test --prefix apps/codex-runtime -- tests/config.test.ts tests/runtime-lifecycle.test.ts tests/thread-routes.test.ts
+npm run check --prefix apps/frontend-bff
+npm run test --prefix apps/frontend-bff -- tests/chat-page-client.test.tsx
+npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --project=mobile-chromium
+```
+
+## Evidence summary
+
+- `apps/codex-runtime` Biome check: pass
+- `apps/codex-runtime` focused test set: pass
+  - includes `tests/config.test.ts` to pin `CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED` default-on behavior
+  - includes `tests/thread-routes.test.ts` to cover the pre-ack convergence path
+- `apps/frontend-bff` Biome check: pass
+- `apps/frontend-bff` focused unit test: pass
+- managed Playwright runtime flow: pass
+  - `desktop-chromium`: pass
+  - `mobile-chromium`: pass
+
+## Notes
+
+- The managed Playwright launcher now resets `apps/codex-runtime/var/playwright` before startup so the fake app-server's deterministic `thread_live_*` ids do not collide with stale SQLite state across runs.
+- The follow-up browser assertion is scoped to `message.user` timeline articles so duplicate assistant echo text does not produce strict-locator noise.

--- a/docs/codex_webui_dev_container_onboarding.md
+++ b/docs/codex_webui_dev_container_onboarding.md
@@ -149,7 +149,7 @@ Verify both desktop and smartphone access against the ngrok URL:
 - `CODEX_WEBUI_WORKSPACE_ROOT`: optional override for the runtime workspace root
 - `CODEX_WEBUI_DATABASE_PATH`: optional override for the runtime SQLite path
 - `CODEX_WEBUI_RUNTIME_BASE_URL`: optional override for the BFF runtime base URL
-- `CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED`: optional override for the runtime bridge flag
+- `CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED`: optional override for the runtime bridge flag; defaults to enabled, set it to `false` only when you intentionally want the synthetic gateway path
 
 ## 7. Direct Docker usage
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- `None`
+- [issue-158-post-start-sendability](./issue-158-post-start-sendability/README.md)
 
 ## Archived Task Packages
 

--- a/tasks/issue-158-post-start-sendability/README.md
+++ b/tasks/issue-158-post-start-sendability/README.md
@@ -1,0 +1,55 @@
+# Issue 158 Post-Start Sendability
+
+## Purpose
+
+- Restore pre-reload thread sendability after the canonical first-input start on the live v0.9 browser path.
+
+## Primary issue
+
+- Issue: `#158 https://github.com/tsukushibito/codex-webui/issues/158`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+
+## Scope for this package
+
+- Reproduce why `Send reply` stays disabled after the first-input start on the managed localhost browser path.
+- Fix the runtime, BFF, frontend, or cross-layer convergence defect that keeps `composer.accepting_user_input` from returning to `true`.
+- Add focused regression coverage for the post-start sendability path on both configured Playwright projects.
+- Leave remote-path validation itself to `#150` after this implementation defect is cleared.
+
+## Exit criteria
+
+- A newly started live thread becomes browser-sendable before reload on the managed localhost path.
+- `Send reply` enables before reload on both `desktop-chromium` and `mobile-chromium`.
+- Focused regression coverage proves the pre-reload sendability path and protects against the observed disabled-state regression.
+- `#150` can resume localhost validation without carrying this fix inline.
+
+## Work plan
+
+- Reproduce the failure in the active worktree and identify the layer that prevents sendability convergence.
+- Implement the bounded fix in the affected app/runtime surface and update focused coverage.
+- Re-run the managed Playwright flow plus touched-suite checks and record the evidence.
+- Prepare archive and close handoff only after the dedicated pre-push validation gate passes.
+
+## Artifacts / evidence
+
+- Planned evidence root: `artifacts/issue-158-post-start-sendability/`
+- Local validation memo: `artifacts/issue-158-post-start-sendability/managed-playwright-validation-2026-04-18.md`
+- Expected touched areas:
+  - `apps/frontend-bff/e2e/`
+  - `apps/frontend-bff/src/`
+  - `apps/frontend-bff/tests/`
+  - `apps/codex-runtime/` if runtime-side convergence is implicated
+
+## Status / handoff notes
+
+- Status: `in progress`
+- Notes: `Local reproduction showed the managed Playwright stack was starting codex-runtime without CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED, so the browser path never exercised the app-server convergence flow. The active slice now enables the live bridge for the managed stack, uses the fake app-server fixture for deterministic first-turn completion, and keeps the browser assertion scoped to the exact follow-up user message. Parent validation issue #150 can resume after this slice reaches main.`
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate passes, and the handoff notes are updated.


### PR DESCRIPTION
## Summary
- default `codex-runtime` to the live app-server bridge instead of the synthetic gateway path
- keep synthetic-only runtime tests explicit while making the managed Playwright stack deterministic and isolated per run
- preserve and document the post-start sendability evidence for #158

## Validation
- npm run check --prefix apps/codex-runtime
- npm run test --prefix apps/codex-runtime -- tests/config.test.ts tests/runtime-lifecycle.test.ts tests/thread-routes.test.ts
- npm run check --prefix apps/frontend-bff
- npm run test --prefix apps/frontend-bff -- tests/chat-page-client.test.tsx
- npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --project=mobile-chromium

Closes #158