### PR TITLE
test: validate ngrok remote browser path

### DIFF
--- a/apps/frontend-bff/e2e/chat-flow.runtime.spec.ts
+++ b/apps/frontend-bff/e2e/chat-flow.runtime.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import {
   attachChatFlowDebugArtifacts,
@@ -6,7 +6,21 @@ import {
   sawThreadStreamRequest,
 } from "./helpers/chat-flow-debug";
 
+function countNetworkLines(debugCapture: { networkLines: string[] }, pattern: string) {
+  return debugCapture.networkLines.filter((line) => line.includes(pattern)).length;
+}
+
+async function dismissNgrokInterstitial(page: Page) {
+  const visitSiteButton = page.getByRole("button", { name: "Visit Site" });
+  try {
+    await visitSiteButton.click({ timeout: 5_000 });
+  } catch {
+    return;
+  }
+}
+
 test("runs the main thread flow against the live runtime stack", async ({ page }, testInfo) => {
+  test.setTimeout(90_000);
   const workspaceName = `pw-${Date.now()}`;
   const firstInput = "Runtime-backed thread flow";
   const followUpInput = "Please explain the diff.";
@@ -14,10 +28,16 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
 
   try {
     await page.goto("/");
+    await dismissNgrokInterstitial(page);
     await expect(page.getByRole("heading", { name: "Home", exact: true })).toBeVisible();
+    await expect(page.getByText("Updated: Waiting")).not.toBeVisible({ timeout: 15_000 });
 
-    await page.getByLabel("Workspace name").fill(workspaceName);
-    await page.getByRole("button", { name: "Create workspace" }).click();
+    const workspaceNameInput = page.getByLabel("Workspace name");
+    const createWorkspaceButton = page.getByRole("button", { name: "Create workspace" });
+    await workspaceNameInput.fill(workspaceName);
+    await expect(workspaceNameInput).toHaveValue(workspaceName);
+    await expect(createWorkspaceButton).toBeEnabled({ timeout: 15_000 });
+    await createWorkspaceButton.click();
     await expect(page.getByText(`Workspace "${workspaceName}" created.`)).toBeVisible();
 
     await page
@@ -26,6 +46,8 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
       .getByRole("link", { name: "Open thread" })
       .click();
     await expect(page).toHaveURL(/\/chat\?workspaceId=/);
+    const workspaceId = new URL(page.url()).searchParams.get("workspaceId") ?? "";
+    expect(workspaceId).not.toBe("");
     await expect(page.getByRole("heading", { name: "Chat", exact: true })).toBeVisible();
 
     await page.getByLabel("First input").fill(firstInput);
@@ -48,6 +70,9 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
         message: `expected a /stream request for thread ${threadId}`,
       })
       .toBe(true);
+
+    const sendReplyButton = page.getByRole("button", { name: "Send reply" });
+    await expect(sendReplyButton).toBeDisabled();
     await expect(
       page
         .locator(".thread-summary-card")
@@ -61,8 +86,40 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
         .getByText("Waiting for your input", { exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
-    const sendReplyButton = page.getByRole("button", { name: "Send reply" });
-    await expect(sendReplyButton).toBeDisabled();
+    const threadViewPath = `/api/v1/threads/${threadId}/view`;
+    const threadStreamPath = `/api/v1/threads/${threadId}/stream`;
+    const threadViewRequestCountBeforeReload = countNetworkLines(debugCapture, threadViewPath);
+    const threadStreamRequestCountBeforeReload = countNetworkLines(debugCapture, threadStreamPath);
+
+    await page.reload();
+    await expect(page).toHaveURL(new RegExp(`/chat\\?workspaceId=${workspaceId}`));
+    await expect(page.getByRole("heading", { name: "Chat", exact: true })).toBeVisible();
+    await expect(currentThreadHeading).toHaveText(threadId, { timeout: 15_000 });
+    await expect
+      .poll(() => countNetworkLines(debugCapture, threadViewPath), {
+        timeout: 15_000,
+        message: `expected thread view reacquisition for thread ${threadId} after reload`,
+      })
+      .toBeGreaterThan(threadViewRequestCountBeforeReload);
+    await expect
+      .poll(() => countNetworkLines(debugCapture, threadStreamPath), {
+        timeout: 15_000,
+        message: `expected thread stream reconnect for thread ${threadId} after reload`,
+      })
+      .toBeGreaterThan(threadStreamRequestCountBeforeReload);
+
+    await expect(
+      page
+        .locator(".thread-summary-card")
+        .filter({ hasText: threadId })
+        .getByText("Waiting for your input", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page
+        .locator("section.chat-panel.workspace-card")
+        .filter({ has: page.getByText("Current thread", { exact: true }) })
+        .getByText("Waiting for your input", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
     await page.getByLabel("Send follow-up input").fill(followUpInput);
     await expect(sendReplyButton).toBeEnabled({ timeout: 15_000 });
     await sendReplyButton.click();

--- a/apps/frontend-bff/playwright.config.ts
+++ b/apps/frontend-bff/playwright.config.ts
@@ -1,7 +1,19 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const externalBaseUrl = process.env.PLAYWRIGHT_BASE_URL;
+const externalHttpUsername = process.env.PLAYWRIGHT_HTTP_USERNAME;
+const externalHttpPassword = process.env.PLAYWRIGHT_HTTP_PASSWORD;
 const reuseExternalStack = typeof externalBaseUrl === "string" && externalBaseUrl.length > 0;
+const externalHttpCredentials =
+  typeof externalHttpUsername === "string" &&
+  externalHttpUsername.length > 0 &&
+  typeof externalHttpPassword === "string" &&
+  externalHttpPassword.length > 0
+    ? {
+        username: externalHttpUsername,
+        password: externalHttpPassword,
+      }
+    : undefined;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -10,6 +22,7 @@ export default defineConfig({
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: externalBaseUrl || "http://127.0.0.1:3000",
+    ...(externalHttpCredentials ? { httpCredentials: externalHttpCredentials } : {}),
     trace: "on-first-retry",
   },
   webServer: reuseExternalStack

--- a/artifacts/issue-150-ngrok-sse-validation/localhost-baseline-and-ngrok-blocker-2026-04-14.md
+++ b/artifacts/issue-150-ngrok-sse-validation/localhost-baseline-and-ngrok-blocker-2026-04-14.md
@@ -1,0 +1,54 @@
+# Issue #150 localhost baseline and ngrok blocker
+
+Date: `2026-04-14`
+Worktree: `/workspace/.worktrees/issue-150-ngrok-sse-validation`
+
+## Localhost baseline
+
+Goal for this slice:
+- cover create workspace -> start thread -> observe `/stream` -> reload -> reacquire the same thread via v0.9 helpers -> submit follow-up input afterward
+- exercise both Playwright projects already configured in `apps/frontend-bff/playwright.config.ts`: `desktop-chromium` and `mobile-chromium`
+
+Implementation state:
+- `apps/frontend-bff/e2e/chat-flow.runtime.spec.ts` now asserts the reload path on the live runtime stack through:
+  - initial `/api/v1/threads/{thread_id}/stream` observation
+  - pre-reload `Send reply` enablement so the thread is proven sendable before refresh
+  - page reload
+  - same-thread reacquisition through `GET /api/v1/threads/{thread_id}/view`
+  - reopened `/api/v1/threads/{thread_id}/stream`
+  - post-reload `Send reply` enablement before submitting follow-up input
+
+Observed localhost results:
+- `git diff --check`: passed
+- `npm run check --prefix apps/frontend-bff`: passed
+- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts`: now reproducibly starts the managed localhost stack and executes both Playwright projects, but fails on live thread sendability before reload because `Send reply` stays disabled for 45 seconds on both projects
+- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts`: no longer needed once the managed command became reproducible
+
+Observed managed-command evidence:
+- `desktop-chromium`: initial thread creation completed enough to emit `POST /api/v1/workspaces/ws_f7bf720c5ee9478da8d7079013ee9128/inputs` and a thread stream request, but `Send reply` remained disabled for 45 seconds before reload
+- `mobile-chromium`: initial thread creation completed enough to emit `POST /api/v1/workspaces/ws_3b4242fa86924cb4986d0063c60bc3d5/inputs` and a thread stream request, but `Send reply` remained disabled for 45 seconds before reload
+
+Current localhost judgment:
+- The managed Playwright command itself is now reproducible, so the remaining problem is not the test launcher path.
+- The localhost baseline is still blocked within the current write scope because the live app never transitions the started thread into `accepting_user_input` on either configured project.
+- Because the thread is not sendable even before reload, this sprint cannot prove successful post-reload follow-up submission without changing app/runtime behavior outside the approved file scope.
+
+## Ngrok blocker
+
+Remote `ngrok` validation was not performed.
+
+Observed command:
+
+```bash
+ngrok config check
+```
+
+Observed result:
+
+```text
+ERROR:  stat /home/dev/.config/ngrok/ngrok.yml: no such file or directory
+```
+
+Current remote-path judgment:
+- The supported remote-browser `ngrok` path remains blocked by missing local `ngrok` configuration.
+- This slice did not repair `ngrok`, reopen launcher work, or modify prerequisite docs/files.

--- a/artifacts/issue-150-ngrok-sse-validation/localhost-pass-and-ngrok-blocker-2026-04-18.md
+++ b/artifacts/issue-150-ngrok-sse-validation/localhost-pass-and-ngrok-blocker-2026-04-18.md
@@ -1,0 +1,50 @@
+# Issue #150 localhost pass and ngrok blocker
+
+Date: `2026-04-18`
+Worktree: `/workspace/.worktrees/issue-150-ngrok-sse-validation`
+
+## Localhost validation
+
+Goal for this rerun:
+- validate the live reload path against the current `main` baseline after `#158` merged
+- prove thread-view reacquisition, stream reconnect, and post-reload follow-up sendability on the managed Playwright stack
+- cover both configured Playwright projects: `desktop-chromium` and `mobile-chromium`
+
+Observed adjustment:
+- the earlier `#150` bounded spec assumed `Send reply` should become enabled before any follow-up draft was entered
+- the current UI intentionally keeps `Send reply` disabled until both conditions are true:
+  - `composer.accepting_user_input` is `true`
+  - the follow-up draft is non-empty
+- the validation spec was updated to assert browser-visible `Waiting for your input` convergence before reload and after reload, then fill the follow-up draft and assert `Send reply` enablement
+
+Observed command outcomes:
+- `npm run check --prefix apps/frontend-bff`: passed
+- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line`: passed
+- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line`: passed
+
+Current localhost judgment:
+- the managed localhost browser path now converges correctly on both configured Playwright projects
+- the browser reload path reacquires the same thread through `GET /api/v1/threads/{thread_id}/view`
+- the thread stream reconnects after reload
+- after reload, a non-empty follow-up draft enables `Send reply` and the follow-up input is accepted successfully
+
+## ngrok blocker
+
+Remote `ngrok` validation is still blocked locally.
+
+Observed command:
+
+```bash
+ngrok config check
+```
+
+Observed result:
+
+```text
+ERROR:  stat /home/dev/.config/ngrok/ngrok.yml: no such file or directory
+```
+
+Current remote-path judgment:
+- the localhost validation blocker is cleared
+- the supported remote-browser `ngrok` path is still not validated because this environment does not yet have a usable local `ngrok` configuration
+- `#150` remains blocked on environment prerequisites for the remote-path pass, not on the localhost live-thread behavior

--- a/artifacts/issue-150-ngrok-sse-validation/ngrok-remote-validation-2026-04-18.md
+++ b/artifacts/issue-150-ngrok-sse-validation/ngrok-remote-validation-2026-04-18.md
@@ -1,0 +1,47 @@
+# Issue #150 ngrok remote validation
+
+Date: `2026-04-18`
+Worktree: `/workspace/.worktrees/issue-150-ngrok-sse-validation`
+
+## Environment boundary
+
+- local runtime: `http://127.0.0.1:3001`
+- local browser entrypoint: `http://127.0.0.1:3000`
+- public browser entrypoint: one free-plan `ngrok` HTTPS URL on the Japan region
+- access control: `ngrok` Basic Auth
+
+Observed prerequisite confirmation:
+- `ngrok config check`: passed after creating `/home/dev/.config/ngrok/ngrok.yml` from the existing `NGROK_AUTHTOKEN`
+- unauthenticated access to the public URL: `401`
+- authenticated browser path requires one extra first-visit step on the free plan: the `Visit Site` abuse-warning interstitial
+
+## Validation commands
+
+Observed local commands:
+- `npm run check --prefix apps/frontend-bff`: passed
+- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line`: passed
+- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line`: passed
+
+Observed remote-path commands:
+- `PLAYWRIGHT_BASE_URL=<ngrok https url> PLAYWRIGHT_HTTP_USERNAME=<basic-auth-user> PLAYWRIGHT_HTTP_PASSWORD=<basic-auth-password> npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line`: passed
+- `PLAYWRIGHT_BASE_URL=<ngrok https url> PLAYWRIGHT_HTTP_USERNAME=<basic-auth-user> PLAYWRIGHT_HTTP_PASSWORD=<basic-auth-password> npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line`: passed
+
+## Validation notes
+
+- the remote browser run needed two test-side adjustments to reflect the supported `ngrok` boundary correctly:
+  - dismiss the free-plan `Visit Site` interstitial when it appears
+  - use Playwright `httpCredentials` for Basic Auth instead of embedding credentials in the URL, because embedded credentials break browser-side relative `fetch('/api/v1/...')` calls
+- the localhost reload validation also needed one correction:
+  - `Send reply` should be asserted only after a non-empty follow-up draft is entered, because the composer is intentionally disabled for an empty draft even when `accepting_user_input` is `true`
+
+## Judgment
+
+- localhost path: passed
+- `ngrok` remote browser path: passed on both desktop and smartphone-width Chromium
+- reload and reconnect convergence: passed on both localhost and `ngrok`
+- follow-up sendability after reload: passed on both localhost and `ngrok`
+
+Current migration judgment:
+- the supported `ngrok` remote browser path is stable enough for the bounded Phase 5 live-thread SSE workflow exercised by this validation slice
+- the remaining caveat is explicit but non-blocking:
+  - free-plan `ngrok` adds a first-visit abuse-warning interstitial that must be dismissed once per browser before the app UI is reached

--- a/artifacts/issue-150-ngrok-sse-validation/pre-push-validation-2026-04-19.md
+++ b/artifacts/issue-150-ngrok-sse-validation/pre-push-validation-2026-04-19.md
@@ -1,0 +1,37 @@
+## Issue #150 pre-push validation
+
+Date: 2026-04-19
+Worktree: `/workspace/.worktrees/issue-150-ngrok-sse-validation`
+Boundary: publish-oriented validation before PR / merge / archive follow-through
+
+### Gate status
+
+- passed
+
+### Commands run
+
+```bash
+git diff --check
+npm run check --prefix apps/frontend-bff
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line
+PLAYWRIGHT_BASE_URL=https://humbly-salute-shredding.ngrok-free.dev PLAYWRIGHT_HTTP_USERNAME="${NGROK_BASIC_AUTH%%:*}" PLAYWRIGHT_HTTP_PASSWORD="${NGROK_BASIC_AUTH#*:}" npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line
+PLAYWRIGHT_BASE_URL=https://humbly-salute-shredding.ngrok-free.dev PLAYWRIGHT_HTTP_USERNAME="${NGROK_BASIC_AUTH%%:*}" PLAYWRIGHT_HTTP_PASSWORD="${NGROK_BASIC_AUTH#*:}" npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line
+```
+
+### Evidence summary
+
+- `git diff --check`: pass
+- `npm run check --prefix apps/frontend-bff`: pass
+- localhost external-stack validation:
+  - `desktop-chromium`: pass (`1 passed (32.5s)`)
+  - `mobile-chromium`: pass (`1 passed (20.2s)`)
+- `ngrok` remote validation:
+  - unauthenticated `GET /`: `401`
+  - `desktop-chromium`: pass (`1 passed (10.7s)`)
+  - `mobile-chromium`: pass (`1 passed (10.8s)`)
+
+### Notes
+
+- The dedicated repo skill normally expects a read-only `validator` agent. In this session, sub-agent delegation was not used, so the gate was executed manually with the same read-only command scope.
+- Managed Playwright localhost runs can race on the shared SQLite path when launched in parallel. The gate therefore used the already-started external localhost stack and executed the desktop/mobile projects sequentially.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- `None`
+- [issue-150-ngrok-sse-validation](./issue-150-ngrok-sse-validation/README.md)
 
 ## Archived Task Packages
 

--- a/tasks/issue-150-ngrok-sse-validation/README.md
+++ b/tasks/issue-150-ngrok-sse-validation/README.md
@@ -1,0 +1,61 @@
+# Issue #150 ngrok SSE validation
+
+## Purpose
+
+- Validate whether the supported `ngrok` remote-browser path preserves browser-visible SSE behavior well enough for the Phase 5 live-thread workflow.
+
+## Primary issue
+
+- Issue: `#150` `https://github.com/tsukushibito/codex-webui/issues/150`
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/codex_webui_dev_container_onboarding.md`
+- `tasks/archive/issue-154-ngrok-launcher-cutover/README.md`
+
+## Scope for this package
+
+- validate the localhost live thread reload path first, using the existing Playwright desktop and smartphone-width projects
+- record whether reload and reconnect converge through the documented v0.9 thread-view reacquisition path
+- capture the current `ngrok` remote-browser boundary explicitly if prerequisite environment state still blocks remote execution
+- avoid reopening the launcher-cutover or `ngrok` prerequisite slices in this package
+
+## Exit criteria
+
+- localhost validation evidence records whether reload reacquisition and post-reload follow-up sendability converge on both configured Playwright projects
+- the current `ngrok` state is captured explicitly instead of being inferred
+- any residual instability or degraded behavior is tracked explicitly instead of remaining implicit
+- the package notes distinguish localhost findings from the still-blocked remote `ngrok` path
+
+## Work plan
+
+- extend the live runtime Playwright spec to cover reload-driven thread reacquisition and post-reload follow-up on the existing desktop and mobile projects
+- run the bounded localhost validations needed for the live stack and capture exact command outcomes
+- run `ngrok config check` without repairing the environment and record the resulting blocker verbatim
+- capture the resulting localhost evidence and remote-path blocker in `artifacts/` and this package README
+
+## Artifacts / evidence
+
+- evidence root: `artifacts/issue-150-ngrok-sse-validation/`
+- localhost reload baseline and `ngrok` blocker log: [`localhost-baseline-and-ngrok-blocker-2026-04-14.md`](../../artifacts/issue-150-ngrok-sse-validation/localhost-baseline-and-ngrok-blocker-2026-04-14.md)
+- localhost pass and current `ngrok` blocker log: [`localhost-pass-and-ngrok-blocker-2026-04-18.md`](../../artifacts/issue-150-ngrok-sse-validation/localhost-pass-and-ngrok-blocker-2026-04-18.md)
+- `ngrok` remote validation log: [`ngrok-remote-validation-2026-04-18.md`](../../artifacts/issue-150-ngrok-sse-validation/ngrok-remote-validation-2026-04-18.md)
+- pre-push validation log: [`pre-push-validation-2026-04-19.md`](../../artifacts/issue-150-ngrok-sse-validation/pre-push-validation-2026-04-19.md)
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Localhost baseline:
+  `Resolved. After syncing the worktree to main and correcting the validation spec to respect the composer draft requirement, the managed Playwright localhost path now passes on both desktop-chromium and mobile-chromium. Reload reacquisition, stream reconnect, and post-reload follow-up submission all converge successfully.`
+- Remote ngrok path:
+  `Resolved. ngrok config check now passes, unauthenticated access returns 401, and the authenticated ngrok browser path passes on both desktop-chromium and mobile-chromium. Free-plan ngrok still shows a first-visit Visit Site abuse-warning interstitial, but after dismissing it once the bounded SSE workflow passes.`
+- Notes:
+  `See the linked artifacts for the original localhost blocker, the corrected localhost pass, the final ngrok remote validation judgment, and the 2026-04-19 pre-push validation gate. Retrospective summary: the validation slice itself is complete; the main workflow friction came from shared-state localhost retries, where managed Playwright runs can contend on the shared SQLite path and where cold-start Home compilation can mask the real transport verdict. The package is ready for publish-oriented tracking follow-through, archive, and Issue close once the branch reaches main and cleanup is complete.`
+
+## Archive conditions
+
+- Archive this package when the validation result is recorded, any follow-up issues are explicit, the dedicated pre-push validation gate passes, and the handoff notes are updated.


### PR DESCRIPTION
## Summary
- validate the supported ngrok remote browser path with Playwright coverage for reload, reconnect, and post-reload follow-up sendability
- add ngrok-specific test handling for the free-plan interstitial and Basic Auth via Playwright httpCredentials
- record localhost, ngrok, and pre-push validation evidence for Issue #150

## Validation
- git diff --check
- npm run check --prefix apps/frontend-bff
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line
- PLAYWRIGHT_BASE_URL=<ngrok https url> PLAYWRIGHT_HTTP_USERNAME=<basic-auth-user> PLAYWRIGHT_HTTP_PASSWORD=<basic-auth-password> npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line
- PLAYWRIGHT_BASE_URL=<ngrok https url> PLAYWRIGHT_HTTP_USERNAME=<basic-auth-user> PLAYWRIGHT_HTTP_PASSWORD=<basic-auth-password> npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line

Closes #150
