### PR TITLE
feat(frontend-bff): freeze browser state matrix

### DIFF
--- a/apps/frontend-bff/src/browser-state-matrix.ts
+++ b/apps/frontend-bff/src/browser-state-matrix.ts
@@ -1,0 +1,181 @@
+export type BrowserCriticalStateId =
+  | "home_overview"
+  | "workspace_thread_navigation"
+  | "thread_list_item"
+  | "thread_view"
+  | "timeline"
+  | "pending_request"
+  | "request_detail"
+  | "request_response"
+  | "thread_stream"
+  | "global_notifications";
+
+export type BrowserStateProjectionKind = "canonical" | "display" | "helper" | "transport";
+
+export type BrowserStateOrderingBasis =
+  | "none"
+  | "updated_at"
+  | "requested_at"
+  | "responded_at"
+  | "thread_id+sequence"
+  | "refresh_trigger_only";
+
+export interface BrowserCriticalStateMatrixEntry {
+  state_id: BrowserCriticalStateId;
+  public_source: string;
+  public_read_model_type: string;
+  canonical: boolean;
+  ordering_basis: BrowserStateOrderingBasis;
+  projection_kind: BrowserStateProjectionKind;
+  canonical_model: "thread" | null;
+  notes: readonly string[];
+  request_kind_values?: readonly string[];
+}
+
+export interface BrowserAdjacentCompatibilityBehavior {
+  route_family: string;
+  classification: "non_browser_critical_compatibility";
+  follow_up_issue: 168;
+  reason: string;
+}
+
+export const browserCriticalStateMatrix = [
+  {
+    state_id: "home_overview",
+    public_source: "GET /api/v1/home",
+    public_read_model_type: "HomeResponse",
+    canonical: false,
+    ordering_basis: "updated_at",
+    projection_kind: "display",
+    canonical_model: "thread",
+    notes: [
+      "Overview state is assembled for browser resume choices from workspace summaries and thread list items.",
+    ],
+  },
+  {
+    state_id: "workspace_thread_navigation",
+    public_source: "GET /api/v1/threads/{thread_id}",
+    public_read_model_type: "PublicThread",
+    canonical: true,
+    ordering_basis: "updated_at",
+    projection_kind: "canonical",
+    canonical_model: "thread",
+    notes: [
+      "Workspace navigation resolves the selected thread snapshot as canonical thread state.",
+    ],
+  },
+  {
+    state_id: "thread_list_item",
+    public_source: "GET /api/v1/workspaces/{workspace_id}/threads",
+    public_read_model_type: "PublicThreadListItem",
+    canonical: false,
+    ordering_basis: "updated_at",
+    projection_kind: "display",
+    canonical_model: "thread",
+    notes: [
+      "current_activity, badge, blocked_cue, and resume_cue are non-canonical display cues derived from thread state.",
+    ],
+  },
+  {
+    state_id: "thread_view",
+    public_source: "GET /api/v1/threads/{thread_id}/view",
+    public_read_model_type: "PublicThreadView",
+    canonical: false,
+    ordering_basis: "thread_id+sequence",
+    projection_kind: "helper",
+    canonical_model: "thread",
+    notes: [
+      "thread_view is an aggregate helper; thread is canonical while current_activity, composer, request helpers, and timeline are projections.",
+      "composer.accepting_user_input is a display hint only and is not final input authority.",
+    ],
+  },
+  {
+    state_id: "timeline",
+    public_source: "GET /api/v1/threads/{thread_id}/timeline",
+    public_read_model_type: "PublicTimeline",
+    canonical: false,
+    ordering_basis: "thread_id+sequence",
+    projection_kind: "transport",
+    canonical_model: "thread",
+    notes: [
+      "Timeline convergence with the stream is keyed by thread_id plus sequence.",
+      "Timeline items are not a replacement for the canonical thread snapshot.",
+    ],
+  },
+  {
+    state_id: "pending_request",
+    public_source: "GET /api/v1/threads/{thread_id}/pending-request",
+    public_read_model_type: "PublicPendingRequestView",
+    canonical: false,
+    ordering_basis: "requested_at",
+    projection_kind: "helper",
+    canonical_model: "thread",
+    request_kind_values: ["approval"],
+    notes: ["Pending request state is a helper view anchored to a thread."],
+  },
+  {
+    state_id: "request_detail",
+    public_source: "GET /api/v1/requests/{request_id}",
+    public_read_model_type: "PublicRequestDetail",
+    canonical: false,
+    ordering_basis: "requested_at",
+    projection_kind: "helper",
+    canonical_model: "thread",
+    request_kind_values: ["approval"],
+    notes: ["Request detail is a helper view for the thread-context response surface."],
+  },
+  {
+    state_id: "request_response",
+    public_source: "POST /api/v1/requests/{request_id}/response",
+    public_read_model_type: "PublicRequestResponseResult",
+    canonical: false,
+    ordering_basis: "responded_at",
+    projection_kind: "helper",
+    canonical_model: "thread",
+    request_kind_values: ["approval"],
+    notes: ["Request responses return a helper summary plus the canonical thread snapshot."],
+  },
+  {
+    state_id: "thread_stream",
+    public_source: "GET /api/v1/threads/{thread_id}/stream",
+    public_read_model_type: "PublicThreadStreamEvent",
+    canonical: false,
+    ordering_basis: "thread_id+sequence",
+    projection_kind: "transport",
+    canonical_model: "thread",
+    notes: [
+      "Thread stream events converge with timeline items by thread_id plus sequence.",
+      "Stream events trigger refresh and incremental display; they do not supersede the canonical thread snapshot.",
+    ],
+  },
+  {
+    state_id: "global_notifications",
+    public_source: "GET /api/v1/notifications/stream",
+    public_read_model_type: "PublicNotificationEvent",
+    canonical: false,
+    ordering_basis: "refresh_trigger_only",
+    projection_kind: "transport",
+    canonical_model: null,
+    notes: [
+      "notification_event is a non-authoritative refresh trigger.",
+      "notification_event is not a strict ordering source and carries no sequence semantics.",
+    ],
+  },
+] as const satisfies readonly BrowserCriticalStateMatrixEntry[];
+
+export const browserAdjacentCompatibilityBehaviors = [
+  {
+    route_family: "/api/v1/workspaces/{workspace_id}/sessions and /api/v1/sessions/{session_id}/*",
+    classification: "non_browser_critical_compatibility",
+    follow_up_issue: 168,
+    reason:
+      "Legacy session route behavior remains available but is outside the browser-critical v0.9 matrix.",
+  },
+  {
+    route_family: "/api/v1/approvals*",
+    classification: "non_browser_critical_compatibility",
+    follow_up_issue: 168,
+    reason:
+      "Standalone approval route behavior remains available but request helpers are the browser-critical v0.9 surface.",
+  },
+] as const satisfies readonly BrowserAdjacentCompatibilityBehavior[];

--- a/apps/frontend-bff/src/mappings.ts
+++ b/apps/frontend-bff/src/mappings.ts
@@ -19,6 +19,7 @@ import type {
   RuntimeTimelineItem,
   RuntimeWorkspaceSummary,
 } from "./runtime-types";
+import type { PublicNotificationEvent } from "./thread-types";
 
 function deriveCanStart(session: RuntimeSessionSummary, activeSessionId: string | null) {
   if (session.status !== "created") {
@@ -471,7 +472,7 @@ export function mapApprovalStreamEvent(event: RuntimeApprovalStreamEventProjecti
   };
 }
 
-export function mapNotificationEvent(event: RuntimeNotificationEvent) {
+export function mapNotificationEvent(event: RuntimeNotificationEvent): PublicNotificationEvent {
   return {
     thread_id: event.thread_id,
     event_type: event.event_type,

--- a/apps/frontend-bff/src/thread-types.ts
+++ b/apps/frontend-bff/src/thread-types.ts
@@ -162,3 +162,10 @@ export interface PublicThreadStreamEvent {
   occurred_at: string;
   payload: Record<string, unknown>;
 }
+
+export interface PublicNotificationEvent {
+  thread_id: string;
+  event_type: string;
+  occurred_at: string;
+  high_priority: boolean;
+}

--- a/apps/frontend-bff/tests/browser-state-matrix.test.ts
+++ b/apps/frontend-bff/tests/browser-state-matrix.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type BrowserCriticalStateId,
+  type BrowserCriticalStateMatrixEntry,
+  browserAdjacentCompatibilityBehaviors,
+  browserCriticalStateMatrix,
+} from "../src/browser-state-matrix";
+import { mapNotificationEvent } from "../src/mappings";
+
+const requiredStateIds: BrowserCriticalStateId[] = [
+  "home_overview",
+  "workspace_thread_navigation",
+  "thread_list_item",
+  "thread_view",
+  "timeline",
+  "pending_request",
+  "request_detail",
+  "request_response",
+  "thread_stream",
+  "global_notifications",
+];
+
+function matrixEntry(stateId: BrowserCriticalStateId): BrowserCriticalStateMatrixEntry {
+  const entry = browserCriticalStateMatrix.find((item) => item.state_id === stateId);
+  expect(entry).toBeDefined();
+
+  return entry!;
+}
+
+function searchableMatrixText() {
+  const collected: string[] = [];
+
+  function collect(value: unknown, key = "") {
+    if (key === "request_kind_values") {
+      return;
+    }
+
+    if (typeof value === "string") {
+      collected.push(value);
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        collect(item);
+      }
+      return;
+    }
+
+    if (value && typeof value === "object") {
+      for (const [nextKey, nextValue] of Object.entries(value)) {
+        collect(nextValue, nextKey);
+      }
+    }
+  }
+
+  collect(browserCriticalStateMatrix);
+
+  return collected.join("\n").toLowerCase();
+}
+
+describe("browser-critical state matrix", () => {
+  it("covers each browser-critical v0.9 state once with typed contract fields", () => {
+    expect(browserCriticalStateMatrix.map((entry) => entry.state_id)).toEqual(requiredStateIds);
+
+    for (const entry of browserCriticalStateMatrix) {
+      expect(entry.public_source).toMatch(/^GET |^POST /);
+      expect(entry.public_read_model_type).toMatch(/^[A-Z]/);
+      expect(typeof entry.canonical).toBe("boolean");
+      expect(entry.ordering_basis.length).toBeGreaterThan(0);
+      expect(entry.projection_kind.length).toBeGreaterThan(0);
+      expect(entry.notes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("freezes canonical and non-canonical projection rules", () => {
+    expect(matrixEntry("workspace_thread_navigation")).toMatchObject({
+      canonical: true,
+      canonical_model: "thread",
+      projection_kind: "canonical",
+      public_read_model_type: "PublicThread",
+    });
+
+    for (const stateId of [
+      "thread_view",
+      "timeline",
+      "pending_request",
+      "request_detail",
+      "request_response",
+      "thread_stream",
+      "global_notifications",
+    ] satisfies BrowserCriticalStateId[]) {
+      expect(matrixEntry(stateId).canonical).toBe(false);
+    }
+
+    expect(matrixEntry("thread_list_item")).toMatchObject({
+      canonical: false,
+      projection_kind: "display",
+    });
+    expect(matrixEntry("thread_view").notes.join(" ")).toContain(
+      "composer.accepting_user_input is a display hint only",
+    );
+  });
+
+  it("uses thread_id plus sequence for stream and timeline convergence", () => {
+    expect(matrixEntry("timeline")).toMatchObject({
+      ordering_basis: "thread_id+sequence",
+      projection_kind: "transport",
+    });
+    expect(matrixEntry("thread_stream")).toMatchObject({
+      ordering_basis: "thread_id+sequence",
+      projection_kind: "transport",
+    });
+  });
+
+  it("keeps notification_event as a refresh trigger without canonical ordering semantics", () => {
+    const entry = matrixEntry("global_notifications");
+
+    expect(entry).toMatchObject({
+      public_read_model_type: "PublicNotificationEvent",
+      canonical: false,
+      ordering_basis: "refresh_trigger_only",
+      projection_kind: "transport",
+      canonical_model: null,
+    });
+    expect(entry.notes.join(" ")).toContain("non-authoritative refresh trigger");
+    expect(entry.notes.join(" ")).toContain("carries no sequence semantics");
+  });
+
+  it("maps notification events to refresh-trigger fields only", () => {
+    const mapped = mapNotificationEvent({
+      thread_id: "thread_001",
+      event_type: "thread.updated",
+      occurred_at: "2026-04-21T05:00:00Z",
+      high_priority: true,
+    });
+
+    expect(mapped).toEqual({
+      thread_id: "thread_001",
+      event_type: "thread.updated",
+      occurred_at: "2026-04-21T05:00:00Z",
+      high_priority: true,
+    });
+    expect(mapped).not.toHaveProperty("sequence");
+    expect(mapped).not.toHaveProperty("canonical");
+    expect(mapped).not.toHaveProperty("state");
+  });
+
+  it("keeps primary legacy session and standalone approval vocabulary out of the matrix", () => {
+    const text = searchableMatrixText();
+
+    expect(text).not.toMatch(/(^|[^a-z])sessions?([^a-z]|$)|\/sessions?\b|session_/);
+    expect(text).not.toMatch(/(^|[^a-z])approvals?([^a-z]|$)|\/approvals?\b|approval_/);
+
+    expect(matrixEntry("pending_request").request_kind_values).toContain("approval");
+    expect(matrixEntry("request_detail").request_kind_values).toContain("approval");
+    expect(matrixEntry("request_response").request_kind_values).toContain("approval");
+  });
+
+  it("marks legacy route families as compatibility behavior for follow-up 168", () => {
+    expect(
+      browserAdjacentCompatibilityBehaviors.every(
+        (behavior) =>
+          behavior.classification === "non_browser_critical_compatibility" &&
+          behavior.follow_up_issue === 168,
+      ),
+    ).toBe(true);
+    expect(browserAdjacentCompatibilityBehaviors.map((behavior) => behavior.route_family)).toEqual([
+      "/api/v1/workspaces/{workspace_id}/sessions and /api/v1/sessions/{session_id}/*",
+      "/api/v1/approvals*",
+    ]);
+  });
+});

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-164-ui-state-matrix](./archive/issue-164-ui-state-matrix/README.md)
 - [issue-150-ngrok-sse-validation](./archive/issue-150-ngrok-sse-validation/README.md)
 - [issue-158-post-start-sendability](./archive/issue-158-post-start-sendability/README.md)
 - [issue-154-ngrok-launcher-cutover](./archive/issue-154-ngrok-launcher-cutover/README.md)

--- a/tasks/archive/issue-164-ui-state-matrix/README.md
+++ b/tasks/archive/issue-164-ui-state-matrix/README.md
@@ -1,0 +1,71 @@
+# Issue 164 UI State Matrix
+
+## Purpose
+
+- Freeze the browser UI state matrix and browser-critical contract vocabulary before the broader Phase 4B thread-first UI refresh.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/164
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Confirm the browser-facing state matrix for the v0.9 UI across home, navigation, thread view, timeline, request helpers, detail surfaces, and global notifications.
+- Align browser-critical frontend/BFF vocabulary around `thread`, `thread_view`, `timeline`, `request`, `request_detail`, `notification_event`, and helper display models.
+- Quarantine remaining legacy `session` and standalone `approval` terminology from browser-critical paths when it affects Phase 4B execution.
+- Recheck `current_activity`, `badge`, `blocked_cue`, `resume_cue`, and `composer` derivation against the maintained v0.9 docs.
+- Preserve `thread_id + sequence` as the ordering basis for stream and timeline convergence.
+
+## Exit criteria
+
+- Major browser states have explicit supporting v0.9 read models and endpoints in implementation-facing types, mappings, handlers, tests, or maintained package notes.
+- `composer` remains a display hint and is not treated as final input authority.
+- Global notifications are represented as refresh triggers rather than canonical state.
+- Browser-critical types and tests no longer require the v0.8 session/approval worldview as the primary path.
+- Any remaining legacy route or handler behavior is either non-browser-critical or clearly tracked for retirement in follow-up issue #168.
+
+## Work plan
+
+- Inspect frontend-bff runtime/public types, mapping helpers, handlers, and UI tests for browser-critical legacy vocabulary.
+- Add or refine a compact browser state matrix in the implementation surface that future Phase 4B slices can test against.
+- Adjust type names, fixtures, and route/UI tests where they pull the UI back to session-first or standalone approval-first behavior.
+- Run focused frontend-bff validation, then broaden to the app's recommended checks if the slice touches shared surfaces.
+- Update this package with evidence, run pre-push validation, archive the package, publish through PR, and close #164 only after the work reaches `main`.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-21T04-52-59Z-issue-164-close/events.ndjson`
+- Local validation evidence from `apps/frontend-bff`:
+  - `node ./node_modules/vitest/vitest.mjs run tests/browser-state-matrix.test.ts` passed: 1 file, 7 tests.
+  - Evaluator ran `node ./node_modules/vitest/vitest.mjs run tests/browser-state-matrix.test.ts tests/routes.test.ts tests/chat-page-client.test.tsx` and it passed: 3 files, 38 tests.
+  - `npm run check` passed: Biome checked 67 files.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - `npm test` passed: 9 files, 53 tests.
+  - `npm run build` passed: Next.js production build completed.
+- Dedicated pre-push validation passed with the same targeted Vitest, Biome, TypeScript, full test, and production build command set.
+
+## Status / handoff notes
+
+- Status: `ready for archive`
+- Active branch: `issue-164-ui-state-matrix`
+- Active worktree: `.worktrees/issue-164-ui-state-matrix`
+- Notes: Added a typed `frontend-bff` browser-critical state matrix and focused guard tests. Legacy `/sessions` and `/approvals` route families remain compatibility behavior tracked for follow-up #168. Sprint evaluator approved the slice and dedicated pre-push validation passed.
+- Completion retrospective:
+  - Completion boundary: package archive only; Issue close is blocked until PR merge, parent checkout sync, worktree cleanup, and final Project/Issue tracking.
+  - Contract check: package exit criteria satisfied by the matrix module, notification event type, focused tests, evaluator approval, and pre-push validation.
+  - Workflow problems: planner spawn required one corrected retry because full-history fork cannot be combined with agent override in this environment.
+  - Improvements to adopt: keep the corrected spawn pattern in mind for future orchestrator runs; no repo doc or skill update is needed from this one-off retry.
+
+## Archive conditions
+
+- Archive this package under `tasks/archive/issue-164-ui-state-matrix/` after the exit criteria are met, dedicated pre-push validation passes, completion retrospective is recorded, and issue execution notes are updated.


### PR DESCRIPTION
## Summary
- add a typed browser-critical v0.9 state matrix for frontend-bff
- expose the browser notification event shape and type `mapNotificationEvent` as refresh-trigger-only
- add focused matrix tests and archive the completed #164 task package

## Validation
- `node ./node_modules/vitest/vitest.mjs run tests/browser-state-matrix.test.ts tests/routes.test.ts tests/chat-page-client.test.tsx`
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test`
- `npm run build`

Refs #164