### PR TITLE
feat(frontend-bff): recompose thread-first shell

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -260,15 +260,37 @@ input {
 }
 
 .chat-shell {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 12px;
+}
+
+.chat-topbar {
   display: flex;
-  justify-content: center;
-  padding: 20px 12px 40px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.chat-topbar h1 {
+  margin: 0;
+  font-size: 1.45rem;
+  line-height: 1.1;
+}
+
+.chat-topbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 .chat-layout {
-  width: min(100%, 720px);
   display: grid;
-  gap: 16px;
+  gap: 12px;
+  min-width: 0;
 }
 
 .chat-feedback-stack {
@@ -279,6 +301,32 @@ input {
 .chat-panel {
   display: grid;
   gap: 14px;
+  min-width: 0;
+}
+
+.thread-navigation {
+  display: none;
+}
+
+.thread-navigation.open {
+  display: grid;
+}
+
+.thread-view-card {
+  align-content: start;
+  min-height: calc(100vh - 104px);
+}
+
+.thread-context-metrics {
+  gap: 8px;
+}
+
+.compact-link,
+.compact-button,
+.inline-detail-button {
+  padding: 8px 10px;
+  border-radius: 12px;
+  font-size: 0.9rem;
 }
 
 .thread-list,
@@ -304,6 +352,7 @@ input {
   padding: 14px;
   text-align: left;
   cursor: pointer;
+  overflow-wrap: anywhere;
 }
 
 .thread-summary-card.active {
@@ -318,6 +367,26 @@ input {
   border-radius: 20px;
   background: rgba(255, 255, 255, 0.7);
   padding: 14px;
+}
+
+.pending-request-card {
+  overflow-wrap: anywhere;
+}
+
+.timeline-section {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.timeline-section header {
+  display: grid;
+  gap: 6px;
+}
+
+.timeline-section h2 {
+  margin: 0;
+  font-size: 1.1rem;
 }
 
 .chat-composer {
@@ -347,6 +416,8 @@ input {
   border-radius: 20px;
   padding: 14px;
   background: rgba(255, 255, 255, 0.66);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .chat-message.user {
@@ -372,18 +443,34 @@ input {
   font-weight: 600;
 }
 
-@media (min-width: 720px) {
-  .chat-layout {
-    grid-template-columns: 1fr 1fr;
-  }
+.thread-detail-surface {
+  align-content: start;
+}
 
-  .chat-layout > :first-child {
-    grid-column: 1 / -1;
-  }
+.detail-stack {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 
-  .chat-feedback-stack {
-    grid-column: 1 / -1;
-  }
+.detail-stack p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.detail-json {
+  max-width: 100%;
+  overflow: auto;
+  border: 1px solid rgba(35, 24, 15, 0.08);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  padding: 10px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .field-hint,
@@ -424,5 +511,80 @@ input {
 
   .hero-body {
     padding: 28px;
+  }
+}
+
+@media (max-width: 719px) {
+  .chat-topbar {
+    align-items: flex-start;
+  }
+
+  .chat-topbar-actions {
+    max-width: 50%;
+  }
+
+  .thread-navigation.open,
+  .thread-detail-surface {
+    position: fixed;
+    inset: 68px 12px 12px;
+    z-index: 20;
+    overflow: auto;
+  }
+
+  .thread-view-card {
+    min-height: auto;
+  }
+
+  .primary-link,
+  .secondary-link,
+  .submit-button {
+    max-width: 100%;
+    white-space: normal;
+  }
+}
+
+@media (min-width: 720px) {
+  .chat-shell {
+    padding: 20px;
+  }
+
+  .chat-topbar,
+  .chat-layout {
+    width: min(100%, 1280px);
+    justify-self: center;
+  }
+
+  .navigation-toggle {
+    display: none;
+  }
+
+  .chat-layout {
+    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .chat-layout:has(.thread-detail-surface) {
+    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr) minmax(260px, 340px);
+  }
+
+  .thread-navigation,
+  .thread-navigation.open {
+    display: grid;
+    position: sticky;
+    top: 20px;
+    max-height: calc(100vh - 40px);
+    overflow: auto;
+  }
+
+  .chat-feedback-stack,
+  .placeholder-card {
+    grid-column: 1 / -1;
+  }
+
+  .thread-detail-surface {
+    position: sticky;
+    top: 20px;
+    max-height: calc(100vh - 40px);
+    overflow: auto;
   }
 }

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -1,10 +1,12 @@
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 import type {
   PublicRequestDetail,
   PublicThreadListItem,
   PublicThreadStreamEvent,
   PublicThreadView,
+  PublicTimelineItem,
 } from "./thread-types";
 
 export interface ChatViewProps {
@@ -79,6 +81,14 @@ function requestBadgeClass(request: PublicRequestDetail | null) {
   return request.status === "pending" ? "status-badge warning" : "status-badge success";
 }
 
+type ThreadDetailSelection =
+  | { kind: "request_detail" }
+  | { kind: "timeline_item_detail"; timelineItemId: string };
+
+function timelineItemLabel(item: PublicTimelineItem) {
+  return String(item.payload.content ?? item.payload.summary ?? item.kind);
+}
+
 export function ChatView({
   workspaceId,
   threads,
@@ -108,46 +118,46 @@ export function ChatView({
   onDenyRequest,
 }: ChatViewProps) {
   const draftEntries = Object.entries(draftAssistantMessages);
+  const [isNavigationOpen, setIsNavigationOpen] = useState(false);
+  const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
+  const selectedTimelineItem =
+    detailSelection?.kind === "timeline_item_detail"
+      ? (selectedThreadView?.timeline.items.find(
+          (item) => item.timeline_item_id === detailSelection.timelineItemId,
+        ) ?? null)
+      : null;
+
+  useEffect(() => {
+    setIsNavigationOpen(false);
+    setDetailSelection(null);
+  }, [selectedThreadId]);
+
+  function selectThread(threadId: string) {
+    onSelectThread(threadId);
+    setIsNavigationOpen(false);
+  }
 
   return (
     <main className="chat-shell">
+      <header className="chat-topbar">
+        <div>
+          <p className="eyebrow">thread_view</p>
+          <h1>Chat</h1>
+        </div>
+        <div className="chat-topbar-actions">
+          <button
+            className="secondary-link action-button navigation-toggle"
+            onClick={() => setIsNavigationOpen((currentValue) => !currentValue)}
+            type="button"
+          >
+            {isNavigationOpen ? "Close threads" : "Threads"}
+          </button>
+          <Link className="secondary-link" href="/">
+            Home
+          </Link>
+        </div>
+      </header>
       <div className="chat-layout">
-        <section className="hero-card">
-          <div className="hero-body">
-            <p className="eyebrow">codex-webui</p>
-            <h1>Chat</h1>
-            <p className="hero-copy">
-              Use the v0.9 thread surface directly: start from first input, respond to pending
-              requests in thread context, and recover state from thread helpers.
-            </p>
-            <div className="hero-metrics">
-              <span className="metric-chip">Workspace: {workspaceId ?? "Choose from Home"}</span>
-              <span className="metric-chip">
-                Stream:{" "}
-                {connectionState === "live"
-                  ? "live"
-                  : connectionState === "reconnecting"
-                    ? "reacquiring"
-                    : "idle"}
-              </span>
-              <span className="metric-chip">Threads: {threads.length}</span>
-            </div>
-            <div className="hero-actions">
-              <Link className="secondary-link" href="/">
-                Back to Home
-              </Link>
-              {workspaceId ? (
-                <Link
-                  className="primary-link"
-                  href={threadChatHref(workspaceId, selectedThreadId ?? undefined)}
-                >
-                  Refresh thread shell
-                </Link>
-              ) : null}
-            </div>
-          </div>
-        </section>
-
         {!workspaceId ? (
           <section className="placeholder-card">
             <p className="eyebrow">Missing workspace</p>
@@ -173,7 +183,13 @@ export function ChatView({
 
         {workspaceId ? (
           <>
-            <section className="chat-panel create-card">
+            <section
+              className={
+                isNavigationOpen
+                  ? "chat-panel create-card thread-navigation open"
+                  : "chat-panel create-card thread-navigation"
+              }
+            >
               <header>
                 <p className="eyebrow">Threads</p>
                 <h2>Start or resume a thread</h2>
@@ -223,7 +239,7 @@ export function ChatView({
                         : "thread-summary-card"
                     }
                     key={thread.thread_id}
-                    onClick={() => onSelectThread(thread.thread_id)}
+                    onClick={() => selectThread(thread.thread_id)}
                     type="button"
                   >
                     <div className="workspace-meta-row">
@@ -241,7 +257,7 @@ export function ChatView({
               </div>
             </section>
 
-            <section className="chat-panel workspace-card">
+            <section className="chat-panel workspace-card thread-view-card">
               <header>
                 <div className="workspace-meta-row">
                   <p className="eyebrow">Current thread</p>
@@ -257,10 +273,28 @@ export function ChatView({
                     ? `Updated ${formatTimestamp(selectedThreadView.thread.updated_at)}`
                     : "Pick a thread from the list to load current activity and requests."}
                 </p>
+                <div className="hero-metrics thread-context-metrics">
+                  <span className="metric-chip">Workspace: {workspaceId}</span>
+                  <span className="metric-chip">
+                    Stream:{" "}
+                    {connectionState === "live"
+                      ? "live"
+                      : connectionState === "reconnecting"
+                        ? "reacquiring"
+                        : "idle"}
+                  </span>
+                  <span className="metric-chip">Threads: {threads.length}</span>
+                  <Link
+                    className="secondary-link compact-link"
+                    href={threadChatHref(workspaceId, selectedThreadId ?? undefined)}
+                  >
+                    Refresh
+                  </Link>
+                </div>
               </header>
 
               {selectedThreadView?.pending_request ? (
-                <div className="request-detail-card">
+                <div className="request-detail-card pending-request-card">
                   <div className="workspace-meta-row">
                     <strong>Pending request</strong>
                     <span className={requestBadgeClass(selectedRequestDetail)}>
@@ -269,15 +303,11 @@ export function ChatView({
                   </div>
                   <p>{selectedThreadView.pending_request.summary}</p>
                   {selectedRequestDetail ? (
-                    <>
-                      <p className="workspace-meta">{selectedRequestDetail.reason}</p>
-                      {selectedRequestDetail.operation_summary ? (
-                        <p className="workspace-meta">
-                          Operation: {selectedRequestDetail.operation_summary}
-                        </p>
-                      ) : null}
-                    </>
+                    <p className="workspace-meta">{selectedRequestDetail.reason}</p>
                   ) : null}
+                  <p className="workspace-meta">
+                    Requested {formatTimestamp(selectedThreadView.pending_request.requested_at)}
+                  </p>
                   <div className="workspace-actions">
                     <button
                       className="primary-link action-button"
@@ -299,6 +329,15 @@ export function ChatView({
                     >
                       Deny request
                     </button>
+                    {selectedRequestDetail ? (
+                      <button
+                        className="secondary-link action-button"
+                        onClick={() => setDetailSelection({ kind: "request_detail" })}
+                        type="button"
+                      >
+                        Request detail
+                      </button>
+                    ) : null}
                   </div>
                 </div>
               ) : selectedThreadView?.latest_resolved_request ? (
@@ -319,6 +358,77 @@ export function ChatView({
                   {isInterruptingThread ? "Interrupting..." : "Interrupt thread"}
                 </button>
               </div>
+
+              <section className="timeline-section" aria-label="Timeline">
+                <header>
+                  <p className="eyebrow">Timeline</p>
+                  <h2>Thread context</h2>
+                </header>
+
+                {isLoadingThread ? (
+                  <p className="workspace-status">Refreshing thread detail...</p>
+                ) : null}
+
+                <div className="chat-message-list">
+                  {!isLoadingThread &&
+                  selectedThreadView &&
+                  selectedThreadView.timeline.items.length === 0 &&
+                  draftEntries.length === 0 ? (
+                    <p className="empty-state">
+                      No timeline items yet. Start the thread or send follow-up input to continue.
+                    </p>
+                  ) : null}
+
+                  {selectedThreadView?.timeline.items.map((item) => (
+                    <article className="chat-message assistant" key={item.timeline_item_id}>
+                      <div className="workspace-meta-row">
+                        <strong>{item.kind}</strong>
+                        <span className="workspace-meta">{formatTimestamp(item.occurred_at)}</span>
+                      </div>
+                      <p>{timelineItemLabel(item)}</p>
+                      <button
+                        className="secondary-link action-button inline-detail-button"
+                        onClick={() =>
+                          setDetailSelection({
+                            kind: "timeline_item_detail",
+                            timelineItemId: item.timeline_item_id,
+                          })
+                        }
+                        type="button"
+                      >
+                        Timeline item detail
+                      </button>
+                    </article>
+                  ))}
+
+                  {draftEntries.map(([messageId, content]) => (
+                    <article className="chat-message assistant" key={messageId}>
+                      <div className="workspace-meta-row">
+                        <strong>assistant streaming</strong>
+                        <span className="workspace-meta">Live</span>
+                      </div>
+                      <p>{content}…</p>
+                    </article>
+                  ))}
+
+                  {streamEvents.map((event) => (
+                    <article className="chat-message user" key={event.event_id}>
+                      <div className="workspace-meta-row">
+                        <strong>{event.event_type}</strong>
+                        <span className="workspace-meta">{formatTimestamp(event.occurred_at)}</span>
+                      </div>
+                      <p>
+                        {String(
+                          event.payload.content ??
+                            event.payload.summary ??
+                            event.payload.message ??
+                            event.event_type,
+                        )}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </section>
 
               <div className="chat-composer">
                 <label className="form-label" htmlFor="message-input">
@@ -348,68 +458,55 @@ export function ChatView({
               </div>
             </section>
 
-            <section className="chat-panel workspace-card">
-              <header>
-                <p className="eyebrow">Activity</p>
-                <h2>Timeline</h2>
-                <p className="field-hint">
-                  Browser refresh and reconnect rely on `thread_view`, `timeline`, and the thread
-                  stream rather than legacy message/event endpoints.
-                </p>
-              </header>
+            {detailSelection ? (
+              <aside className="chat-panel workspace-card thread-detail-surface">
+                <header>
+                  <div className="workspace-meta-row">
+                    <p className="eyebrow">Detail</p>
+                    <button
+                      className="secondary-link action-button compact-button"
+                      onClick={() => setDetailSelection(null)}
+                      type="button"
+                    >
+                      Close
+                    </button>
+                  </div>
+                  <h2>
+                    {detailSelection.kind === "request_detail"
+                      ? "Request detail"
+                      : "Timeline item detail"}
+                  </h2>
+                </header>
 
-              {isLoadingThread ? (
-                <p className="workspace-status">Refreshing thread detail...</p>
-              ) : null}
-
-              <div className="chat-message-list">
-                {!isLoadingThread &&
-                selectedThreadView &&
-                selectedThreadView.timeline.items.length === 0 &&
-                draftEntries.length === 0 ? (
-                  <p className="empty-state">
-                    No timeline items yet. Start the thread or send follow-up input to continue.
-                  </p>
+                {detailSelection.kind === "request_detail" && selectedRequestDetail ? (
+                  <div className="detail-stack">
+                    <p>{selectedRequestDetail.summary}</p>
+                    <p className="workspace-meta">{selectedRequestDetail.reason}</p>
+                    {selectedRequestDetail.operation_summary ? (
+                      <p className="workspace-meta">
+                        Operation: {selectedRequestDetail.operation_summary}
+                      </p>
+                    ) : null}
+                    <span className={requestBadgeClass(selectedRequestDetail)}>
+                      {selectedRequestDetail.status}
+                    </span>
+                  </div>
                 ) : null}
 
-                {selectedThreadView?.timeline.items.map((item) => (
-                  <article className="chat-message assistant" key={item.timeline_item_id}>
-                    <div className="workspace-meta-row">
-                      <strong>{item.kind}</strong>
-                      <span className="workspace-meta">{formatTimestamp(item.occurred_at)}</span>
-                    </div>
-                    <p>{String(item.payload.content ?? item.payload.summary ?? item.kind)}</p>
-                  </article>
-                ))}
-
-                {draftEntries.map(([messageId, content]) => (
-                  <article className="chat-message assistant" key={messageId}>
-                    <div className="workspace-meta-row">
-                      <strong>assistant streaming</strong>
-                      <span className="workspace-meta">Live</span>
-                    </div>
-                    <p>{content}…</p>
-                  </article>
-                ))}
-
-                {streamEvents.map((event) => (
-                  <article className="chat-message user" key={event.event_id}>
-                    <div className="workspace-meta-row">
-                      <strong>{event.event_type}</strong>
-                      <span className="workspace-meta">{formatTimestamp(event.occurred_at)}</span>
-                    </div>
-                    <p>
-                      {String(
-                        event.payload.content ??
-                          event.payload.summary ??
-                          event.payload.message ??
-                          event.event_type,
-                      )}
+                {detailSelection.kind === "timeline_item_detail" && selectedTimelineItem ? (
+                  <div className="detail-stack">
+                    <p className="workspace-meta">
+                      {selectedTimelineItem.kind} at{" "}
+                      {formatTimestamp(selectedTimelineItem.occurred_at)}
                     </p>
-                  </article>
-                ))}
-              </div>
-            </section>
+                    <p>{timelineItemLabel(selectedTimelineItem)}</p>
+                    <pre className="detail-json">
+                      {JSON.stringify(selectedTimelineItem.payload, null, 2)}
+                    </pre>
+                  </div>
+                ) : null}
+              </aside>
+            ) : null}
           </>
         ) : null}
       </div>

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -747,6 +747,19 @@ describe("ChatPageClient", () => {
 
     expect(container.textContent).toContain("Run git push");
     expect(container.textContent).toContain("Codex requests permission to push changes to remote.");
+    expect(container.textContent).not.toContain("Operation: git push origin main");
+
+    const requestDetailButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Request detail",
+    );
+    expect(requestDetailButton).not.toBeUndefined();
+
+    await act(async () => {
+      requestDetailButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("Operation: git push origin main");
 
     const approveButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Approve request",

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-165-thread-first-shell](./archive/issue-165-thread-first-shell/README.md)
 - [issue-164-ui-state-matrix](./archive/issue-164-ui-state-matrix/README.md)
 - [issue-150-ngrok-sse-validation](./archive/issue-150-ngrok-sse-validation/README.md)
 - [issue-158-post-start-sendability](./archive/issue-158-post-start-sendability/README.md)

--- a/tasks/archive/issue-165-thread-first-shell/README.md
+++ b/tasks/archive/issue-165-thread-first-shell/README.md
@@ -1,0 +1,78 @@
+# Issue 165 Thread-First Shell
+
+## Purpose
+
+- Recompose the main browser shell around the v0.9 thread-first layout model for Issue #165.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/165
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`, section 5.3
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Implement desktop `[Navigation] [Thread View]` as the base composition.
+- Implement desktop `[Navigation] [Thread View] [Detail Surface]` only when secondary detail is open.
+- Implement mobile single-column `thread_view` behavior.
+- Provide mobile navigation drawer or sheet foundations.
+- Provide request, error, or item detail sheet/full-screen foundations on mobile.
+- Make `timeline` the dominant body of `thread_view`.
+- Keep current activity as a pinned summary rather than a competing primary panel.
+- Keep one dominant action path visible on mobile.
+
+## Exit criteria
+
+- Desktop follows the Navigation / Thread View / Detail Surface model from the v0.9 UI layout spec.
+- Mobile works at 360 CSS px without horizontal scrolling.
+- `thread_view` remains the primary context when detail opens.
+- Detail opening is selection-driven and does not replace lightweight notification signals.
+- Focused component tests cover desktop composition and mobile drawer/sheet behavior.
+
+## Work plan
+
+- Inspect the existing chat shell, thread view, and global CSS implementation in `apps/frontend-bff`.
+- Add or adjust focused component tests for desktop composition and mobile drawer/sheet behavior before implementation where practical.
+- Recompose the browser shell so navigation, thread view, and secondary detail surfaces match the v0.9 layout rules.
+- Update CSS to support the responsive desktop/mobile layout without horizontal scrolling at 360 CSS px.
+- Run targeted component tests, then the frontend validation sequence required by `apps/frontend-bff/README.md`.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-21T06-06-34Z-issue-165-close/events.ndjson`
+- Sprint evaluator verdict: `approved`
+- Pre-push validation gate: `passed`
+- Validation evidence:
+  - `git diff --check`
+  - `npm test -- tests/chat-view.test.tsx tests/chat-page-client.test.tsx`
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `npm test`
+  - `npm run build`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-165-thread-first-shell`
+- Active worktree: `.worktrees/issue-165-thread-first-shell`
+- Active PR: `None`
+- Notes: Reworked the Chat UI into a v0.9 thread-first shell with desktop navigation/thread/detail composition, selection-driven request/timeline detail, mobile overlay foundations, and timeline as the dominant thread body. Pre-push validation passed; remaining completion work is PR publish, merge to `main`, parent sync, worktree cleanup, Issue close, and Project `Done`.
+
+### Completion retrospective
+
+- Completion boundary: package archive after evaluator approval and pre-push validation.
+- Contract check: package exit criteria satisfied by `apps/frontend-bff/src/chat-view.tsx`, `apps/frontend-bff/app/globals.css`, and focused client coverage in `apps/frontend-bff/tests/chat-page-client.test.tsx`; Issue close remains blocked until the branch is merged to `main` and cleanup is complete.
+- What worked: planner/worker/evaluator separation kept the UI composition slice bounded, and validator caught the previously missing build gate before publish.
+- Workflow problems: worktree-local `node_modules` symlink needed correction from the initially created relative target before npm commands could run.
+- Improvements to adopt: use the documented `../../../../apps/frontend-bff/node_modules` target when creating app-local `node_modules` symlinks from `.worktrees/<branch>/apps/frontend-bff`.
+- Skill candidates or skill updates: consider tightening `codex-webui-work-packages` symlink examples for app-local paths under `.worktrees/`.
+- Follow-up updates: none required before archiving; final tracking belongs to GitHub/PR completion after merge.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective notes are captured, and the handoff notes are updated.


### PR DESCRIPTION
## Summary

- recompose Chat into a v0.9 thread-first shell with Navigation / Thread View / optional Detail Surface
- make request and timeline details selection-driven instead of auto-opened
- add mobile overlay foundations and 360px-safe wrapping for thread/request/detail content
- archive the completed #165 task package with validation evidence

## Validation

- `git diff --check`
- `npm test -- tests/chat-view.test.tsx tests/chat-page-client.test.tsx`
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test`
- `npm run build`

Closes #165
