### PR TITLE
feat(frontend-bff): connect request detail recovery signals

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -369,7 +369,8 @@ input {
   padding: 14px;
 }
 
-.pending-request-card {
+.pending-request-card,
+.resolved-request-card {
   overflow-wrap: anywhere;
 }
 
@@ -459,6 +460,41 @@ input {
   line-height: 1.5;
 }
 
+.request-detail-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.request-detail-list div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.request-detail-list dt {
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.request-detail-list dd {
+  margin: 0;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.request-operation-summary {
+  border-radius: 14px;
+  background: rgba(35, 24, 15, 0.06);
+  padding: 10px 12px;
+}
+
+.request-detail-actions {
+  margin-top: 2px;
+}
+
 .detail-json {
   max-width: 100%;
   overflow: auto;
@@ -529,6 +565,7 @@ input {
     inset: 68px 12px 12px;
     z-index: 20;
     overflow: auto;
+    max-width: calc(100vw - 24px);
   }
 
   .thread-view-card {

--- a/apps/frontend-bff/src/chat-data.ts
+++ b/apps/frontend-bff/src/chat-data.ts
@@ -136,12 +136,16 @@ export async function respondToPendingRequest(
 
 export async function loadChatThreadBundle(threadId: string, fetchImpl: FetchLike = fetch) {
   const view = await getThreadView(threadId, fetchImpl);
-  const pendingRequestDetail = view.pending_request
-    ? await getRequestDetail(view.pending_request.request_id, fetchImpl)
-    : null;
+  const [pendingRequestDetail, latestResolvedRequestDetail] = await Promise.all([
+    view.pending_request ? getRequestDetail(view.pending_request.request_id, fetchImpl) : null,
+    view.latest_resolved_request
+      ? getRequestDetail(view.latest_resolved_request.request_id, fetchImpl)
+      : null,
+  ]);
 
   return {
     view,
+    latestResolvedRequestDetail,
     pendingRequestDetail,
   };
 }

--- a/apps/frontend-bff/src/chat-page-client.tsx
+++ b/apps/frontend-bff/src/chat-page-client.tsx
@@ -14,6 +14,7 @@ import {
 import { ChatView } from "./chat-view";
 import { logLiveChatDebug } from "./debug";
 import type {
+  PublicNotificationEvent,
   PublicRequestDetail,
   PublicThreadListItem,
   PublicThreadStreamEvent,
@@ -45,6 +46,35 @@ const ACTIVE_THREAD_REFRESH_INTERVAL_MS = 1500;
 const POST_START_READY_REFRESH_INTERVAL_MS = 400;
 const POST_START_READY_REFRESH_ATTEMPTS = 8;
 
+function selectRequestDetail(bundle: {
+  latestResolvedRequestDetail?: PublicRequestDetail | null;
+  pendingRequestDetail: PublicRequestDetail | null;
+}) {
+  return bundle.pendingRequestDetail ?? bundle.latestResolvedRequestDetail ?? null;
+}
+
+function hasStreamSequenceInconsistency(
+  events: PublicThreadStreamEvent[],
+  nextEvent: PublicThreadStreamEvent,
+) {
+  const duplicateSequenceEvent = events.find(
+    (event) => event.sequence === nextEvent.sequence && event.event_id !== nextEvent.event_id,
+  );
+
+  if (duplicateSequenceEvent) {
+    return true;
+  }
+
+  const knownSequences = new Set(events.map((event) => event.sequence));
+  if (knownSequences.has(nextEvent.sequence)) {
+    return false;
+  }
+
+  const maxSequence = events.reduce((currentMax, event) => Math.max(currentMax, event.sequence), 0);
+
+  return maxSequence > 0 && nextEvent.sequence > maxSequence + 1;
+}
+
 export function ChatPageClient() {
   const searchParams = useSearchParams();
   const workspaceId = searchParams.get("workspaceId");
@@ -74,6 +104,7 @@ export function ChatPageClient() {
   const threadListRefreshIdRef = useRef(0);
   const selectedThreadRefreshIdRef = useRef(0);
   const selectedThreadIdRef = useRef<string | null>(initialThreadId);
+  const streamEventsRef = useRef<PublicThreadStreamEvent[]>([]);
 
   function updateSelectedThreadId(
     nextThreadId: string | null,
@@ -189,7 +220,7 @@ export function ChatPageClient() {
       }
 
       setSelectedThreadView(bundle.view);
-      setSelectedRequestDetail(bundle.pendingRequestDetail);
+      setSelectedRequestDetail(selectRequestDetail(bundle));
       return bundle;
     } catch (error) {
       if (selectedThreadRefreshIdRef.current === refreshId) {
@@ -233,6 +264,7 @@ export function ChatPageClient() {
       setSelectedThreadView(null);
       setSelectedRequestDetail(null);
       setStreamEvents([]);
+      streamEventsRef.current = [];
       setDraftAssistantMessages({});
       setConnectionState("idle");
       return;
@@ -243,6 +275,7 @@ export function ChatPageClient() {
       previous_thread_id: selectedThreadView?.thread.thread_id ?? null,
     });
     setStreamEvents([]);
+    streamEventsRef.current = [];
     setDraftAssistantMessages({});
     void refreshSelectedThread(selectedThreadId);
   }, [selectedThreadId]);
@@ -307,6 +340,7 @@ export function ChatPageClient() {
       logLiveChatDebug("chat-stream", "thread stream opened", {
         thread_id: selectedThreadId,
       });
+      void refreshSelectedThreadAndList(selectedThreadId);
     };
 
     stream.onmessage = (messageEvent) => {
@@ -316,7 +350,14 @@ export function ChatPageClient() {
         event_type: event.event_type,
         sequence: event.sequence,
       });
-      setStreamEvents((currentEvents) => upsertStreamEvent(currentEvents, event));
+      const sequenceInconsistent = hasStreamSequenceInconsistency(streamEventsRef.current, event);
+      const nextStreamEvents = upsertStreamEvent(streamEventsRef.current, event);
+      streamEventsRef.current = nextStreamEvents;
+      setStreamEvents(nextStreamEvents);
+
+      if (sequenceInconsistent) {
+        setStatusMessage("Thread stream changed unexpectedly. Reacquiring thread state.");
+      }
 
       if (event.event_type === "message.assistant.delta") {
         const messageId = event.payload.message_id;
@@ -343,11 +384,11 @@ export function ChatPageClient() {
         }
       }
 
-      if (event.event_type === "approval.requested") {
+      if (!sequenceInconsistent && event.event_type === "approval.requested") {
         setStatusMessage("Request pending. Respond from the current thread.");
       }
 
-      if (event.event_type === "approval.resolved") {
+      if (!sequenceInconsistent && event.event_type === "approval.resolved") {
         setStatusMessage("Request resolved. Thread state refreshed.");
       }
 
@@ -382,6 +423,43 @@ export function ChatPageClient() {
       }
     };
   }, [selectedThreadId, streamVersion]);
+
+  useEffect(() => {
+    const notifications = new EventSource("/api/v1/notifications/stream");
+
+    notifications.onmessage = (messageEvent) => {
+      const event = JSON.parse(messageEvent.data) as PublicNotificationEvent;
+      logLiveChatDebug("chat-notifications", "notification stream event received", {
+        event_type: event.event_type,
+        high_priority: event.high_priority,
+        selected_thread_id: selectedThreadIdRef.current,
+        thread_id: event.thread_id,
+      });
+
+      if (event.high_priority) {
+        setStatusMessage("High-priority background thread needs attention.");
+      } else {
+        setStatusMessage("Thread notification received. Refreshing current state.");
+      }
+
+      const currentThreadId = selectedThreadIdRef.current;
+      if (currentThreadId && event.thread_id === currentThreadId) {
+        void refreshSelectedThreadAndList(currentThreadId);
+        return;
+      }
+
+      void refreshThreads(currentThreadId);
+    };
+
+    notifications.onerror = () => {
+      logLiveChatDebug("chat-notifications", "notification stream errored");
+      notifications.close();
+    };
+
+    return () => {
+      notifications.close();
+    };
+  }, [workspaceId]);
 
   async function handleCreateThread() {
     if (!workspaceId) {

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -81,6 +81,10 @@ function requestBadgeClass(request: PublicRequestDetail | null) {
   return request.status === "pending" ? "status-badge warning" : "status-badge success";
 }
 
+function formatMachineLabel(value: string | null | undefined) {
+  return value ? value.replaceAll("_", " ") : "Not available";
+}
+
 type ThreadDetailSelection =
   | { kind: "request_detail" }
   | { kind: "timeline_item_detail"; timelineItemId: string };
@@ -252,6 +256,11 @@ export function ChatView({
                     <span className="workspace-meta">
                       Updated {formatTimestamp(thread.updated_at)}
                     </span>
+                    {thread.resume_cue ? (
+                      <span className="workspace-meta">
+                        {formatMachineLabel(thread.resume_cue.label)}
+                      </span>
+                    ) : null}
                   </button>
                 ))}
               </div>
@@ -298,7 +307,7 @@ export function ChatView({
                   <div className="workspace-meta-row">
                     <strong>Pending request</strong>
                     <span className={requestBadgeClass(selectedRequestDetail)}>
-                      {selectedThreadView.pending_request.risk_category.replaceAll("_", " ")}
+                      {formatMachineLabel(selectedThreadView.pending_request.risk_category)}
                     </span>
                   </div>
                   <p>{selectedThreadView.pending_request.summary}</p>
@@ -341,9 +350,28 @@ export function ChatView({
                   </div>
                 </div>
               ) : selectedThreadView?.latest_resolved_request ? (
-                <p className="request-signal">
-                  Latest request: {selectedThreadView.latest_resolved_request.decision}
-                </p>
+                <div className="request-detail-card resolved-request-card">
+                  <div className="workspace-meta-row">
+                    <strong>Latest resolved request</strong>
+                    <span className={requestBadgeClass(selectedRequestDetail)}>
+                      {selectedThreadView.latest_resolved_request.decision}
+                    </span>
+                  </div>
+                  <p>Decision: {selectedThreadView.latest_resolved_request.decision}</p>
+                  <p className="workspace-meta">
+                    Responded{" "}
+                    {formatTimestamp(selectedThreadView.latest_resolved_request.responded_at)}
+                  </p>
+                  {selectedRequestDetail ? (
+                    <button
+                      className="secondary-link action-button inline-detail-button"
+                      onClick={() => setDetailSelection({ kind: "request_detail" })}
+                      type="button"
+                    >
+                      Reopen request detail
+                    </button>
+                  ) : null}
+                </div>
               ) : null}
 
               <div className="workspace-actions">
@@ -480,16 +508,80 @@ export function ChatView({
 
                 {detailSelection.kind === "request_detail" && selectedRequestDetail ? (
                   <div className="detail-stack">
+                    <div className="workspace-meta-row">
+                      <span className={requestBadgeClass(selectedRequestDetail)}>
+                        {selectedRequestDetail.status}
+                      </span>
+                      <span className="status-badge">
+                        {formatMachineLabel(selectedRequestDetail.risk_category)}
+                      </span>
+                    </div>
                     <p>{selectedRequestDetail.summary}</p>
-                    <p className="workspace-meta">{selectedRequestDetail.reason}</p>
+                    <dl className="request-detail-list">
+                      <div>
+                        <dt>Reason</dt>
+                        <dd>{selectedRequestDetail.reason}</dd>
+                      </div>
+                      {selectedRequestDetail.operation_summary ? (
+                        <div>
+                          <dt>Operation</dt>
+                          <dd>{selectedRequestDetail.operation_summary}</dd>
+                        </div>
+                      ) : null}
+                      <div>
+                        <dt>Requested</dt>
+                        <dd>{formatTimestamp(selectedRequestDetail.requested_at)}</dd>
+                      </div>
+                      <div>
+                        <dt>Thread</dt>
+                        <dd>{selectedRequestDetail.thread_id}</dd>
+                      </div>
+                      <div>
+                        <dt>Turn</dt>
+                        <dd>{selectedRequestDetail.turn_id ?? "Not available"}</dd>
+                      </div>
+                      <div>
+                        <dt>Item</dt>
+                        <dd>{selectedRequestDetail.item_id}</dd>
+                      </div>
+                      {selectedRequestDetail.decision ? (
+                        <div>
+                          <dt>Decision</dt>
+                          <dd>{selectedRequestDetail.decision}</dd>
+                        </div>
+                      ) : null}
+                      {selectedRequestDetail.responded_at ? (
+                        <div>
+                          <dt>Responded</dt>
+                          <dd>{formatTimestamp(selectedRequestDetail.responded_at)}</dd>
+                        </div>
+                      ) : null}
+                    </dl>
                     {selectedRequestDetail.operation_summary ? (
-                      <p className="workspace-meta">
+                      <p className="request-operation-summary">
                         Operation: {selectedRequestDetail.operation_summary}
                       </p>
                     ) : null}
-                    <span className={requestBadgeClass(selectedRequestDetail)}>
-                      {selectedRequestDetail.status}
-                    </span>
+                    {selectedRequestDetail.status === "pending" ? (
+                      <div className="workspace-actions request-detail-actions">
+                        <button
+                          className="primary-link action-button"
+                          disabled={isRespondingToRequest}
+                          onClick={onApproveRequest}
+                          type="button"
+                        >
+                          {isRespondingToRequest ? "Submitting..." : "Approve request"}
+                        </button>
+                        <button
+                          className="secondary-link action-button"
+                          disabled={isRespondingToRequest}
+                          onClick={onDenyRequest}
+                          type="button"
+                        >
+                          Deny request
+                        </button>
+                      </div>
+                    ) : null}
                   </div>
                 ) : null}
 

--- a/apps/frontend-bff/src/home-page-client.tsx
+++ b/apps/frontend-bff/src/home-page-client.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { createWorkspaceFromHome, fetchHomeData } from "./home-data";
 import { HomeView } from "./home-view";
 import type { HomeResponse } from "./runtime-types";
+import type { PublicNotificationEvent } from "./thread-types";
 
 export function HomePageClient() {
   const [home, setHome] = useState<HomeResponse | null>(null);
@@ -29,6 +30,28 @@ export function HomePageClient() {
 
   useEffect(() => {
     void loadHome();
+  }, []);
+
+  useEffect(() => {
+    const notifications = new EventSource("/api/v1/notifications/stream");
+
+    notifications.onmessage = (messageEvent) => {
+      const event = JSON.parse(messageEvent.data) as PublicNotificationEvent;
+      setStatusMessage(
+        event.high_priority
+          ? "High-priority background thread needs attention."
+          : "Thread notification received. Refreshing Home.",
+      );
+      void loadHome();
+    };
+
+    notifications.onerror = () => {
+      notifications.close();
+    };
+
+    return () => {
+      notifications.close();
+    };
   }, []);
 
   async function handleCreateWorkspace() {

--- a/apps/frontend-bff/tests/chat-data.test.ts
+++ b/apps/frontend-bff/tests/chat-data.test.ts
@@ -123,7 +123,7 @@ describe("chat data access", () => {
     expect(reply.accepted.input_item_id).toBe("item_002");
   });
 
-  it("loads thread view and pending request detail for chat refresh", async () => {
+  it("loads thread view plus pending and latest resolved request detail for chat refresh", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(
@@ -153,7 +153,17 @@ describe("chat data access", () => {
             summary: "Run git push",
             requested_at: "2026-03-27T05:20:00Z",
           },
-          latest_resolved_request: null,
+          latest_resolved_request: {
+            request_id: "req_resolved_001",
+            thread_id: "thread_001",
+            turn_id: "turn_000",
+            item_id: "item_000",
+            request_kind: "approval",
+            status: "resolved",
+            decision: "approved",
+            requested_at: "2026-03-27T05:10:00Z",
+            responded_at: "2026-03-27T05:11:00Z",
+          },
           composer: {
             accepting_user_input: false,
             interrupt_available: true,
@@ -187,12 +197,37 @@ describe("chat data access", () => {
           },
           context: null,
         }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          request_id: "req_resolved_001",
+          thread_id: "thread_001",
+          turn_id: "turn_000",
+          item_id: "item_000",
+          request_kind: "approval",
+          status: "resolved",
+          risk_category: "external_side_effect",
+          summary: "Run git fetch",
+          reason: "Codex requested permission to fetch remote refs.",
+          operation_summary: "git fetch origin",
+          requested_at: "2026-03-27T05:10:00Z",
+          responded_at: "2026-03-27T05:11:00Z",
+          decision: "approved",
+          decision_options: {
+            policy_scope_supported: false,
+            default_policy_scope: "once",
+          },
+          context: null,
+        }),
       );
 
     const bundle = await loadChatThreadBundle("thread_001", fetchMock);
 
     expect(bundle.view.thread.thread_id).toBe("thread_001");
     expect(bundle.pendingRequestDetail?.request_id).toBe("req_001");
+    expect(bundle.latestResolvedRequestDetail?.request_id).toBe("req_resolved_001");
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/requests/req_001", expect.any(Object));
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/requests/req_resolved_001", expect.any(Object));
   });
 
   it("loads request detail, submits a request response, and interrupts a thread", async () => {

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -151,6 +151,17 @@ function buildPendingRequestDetail(
   };
 }
 
+function buildResolvedRequestDetail(
+  overrides: Partial<PublicRequestDetail> = {},
+): PublicRequestDetail {
+  return buildPendingRequestDetail({
+    status: "resolved",
+    decision: "approved",
+    responded_at: "2026-03-27T05:21:00Z",
+    ...overrides,
+  });
+}
+
 function buildAcceptedInputResponse(
   overrides: Partial<PublicThreadInputAcceptedResponse> = {},
 ): PublicThreadInputAcceptedResponse {
@@ -761,9 +772,9 @@ describe("ChatPageClient", () => {
 
     expect(container.textContent).toContain("Operation: git push origin main");
 
-    const approveButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === "Approve request",
-    );
+    const approveButton = Array.from(container.querySelectorAll("button"))
+      .reverse()
+      .find((button) => button.textContent === "Approve request");
     expect(approveButton).not.toBeUndefined();
 
     await act(async () => {
@@ -776,6 +787,58 @@ describe("ChatPageClient", () => {
       "approved",
       expect.stringMatching(/^response_/),
     );
+  });
+
+  it("reopens latest resolved request detail without response actions", async () => {
+    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
+      items: [buildThreadListItem()],
+      next_cursor: null,
+      has_more: false,
+    });
+    chatDataMocks.loadChatThreadBundle.mockResolvedValue({
+      view: buildThreadView({
+        latest_resolved_request: {
+          request_id: "req_001",
+          thread_id: "thread_001",
+          turn_id: "turn_001",
+          item_id: "item_001",
+          request_kind: "approval",
+          status: "resolved",
+          decision: "denied",
+          requested_at: "2026-03-27T05:20:00Z",
+          responded_at: "2026-03-27T05:21:00Z",
+        },
+      }),
+      latestResolvedRequestDetail: buildResolvedRequestDetail({
+        decision: "denied",
+        responded_at: "2026-03-27T05:21:00Z",
+      }),
+      pendingRequestDetail: null,
+    });
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("Latest resolved request");
+    expect(container.textContent).toContain("Decision: denied");
+
+    const detailButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Reopen request detail",
+    );
+    expect(detailButton).not.toBeUndefined();
+
+    await act(async () => {
+      detailButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("Request detail");
+    expect(container.textContent).toContain("Decision");
+    expect(container.textContent).toContain("Responded");
+    expect(container.textContent).not.toContain("Approve request");
+    expect(container.textContent).not.toContain("Deny request");
   });
 
   it("refreshes thread state after a thread stream event arrives", async () => {
@@ -816,6 +879,118 @@ describe("ChatPageClient", () => {
 
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
     expect(container.textContent).toContain("Request pending. Respond from the current thread.");
+  });
+
+  it("marks stream sequence gaps as inconsistent and reacquires selected thread state", async () => {
+    const firstEvent: PublicThreadStreamEvent = {
+      event_id: "evt_002",
+      thread_id: "thread_001",
+      event_type: "session.status_changed",
+      sequence: 2,
+      occurred_at: "2026-03-27T05:20:00Z",
+      payload: {
+        status: "running",
+      },
+    };
+    const gapEvent: PublicThreadStreamEvent = {
+      event_id: "evt_004",
+      thread_id: "thread_001",
+      event_type: "approval.requested",
+      sequence: 4,
+      occurred_at: "2026-03-27T05:21:00Z",
+      payload: {
+        summary: "Run git push",
+      },
+    };
+
+    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
+      items: [buildThreadListItem()],
+      next_cursor: null,
+      has_more: false,
+    });
+    chatDataMocks.loadChatThreadBundle.mockResolvedValue({
+      view: buildThreadView(),
+      pendingRequestDetail: null,
+    });
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    await act(async () => {
+      MockEventSource.instances[0]?.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify(firstEvent),
+        }),
+      );
+    });
+    await flushUi();
+
+    await act(async () => {
+      MockEventSource.instances[0]?.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify(gapEvent),
+        }),
+      );
+    });
+    await flushUi();
+
+    expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(3);
+    expect(container.textContent).toContain(
+      "Thread stream changed unexpectedly. Reacquiring thread state.",
+    );
+  });
+
+  it("uses global notification events as refresh triggers and high-priority signals", async () => {
+    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
+      items: [
+        buildThreadListItem(),
+        buildThreadListItem({
+          thread_id: "thread_background",
+          resume_cue: {
+            reason_kind: "waiting_on_approval",
+            priority_band: "highest",
+            label: "Resume here first",
+          },
+        }),
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+    chatDataMocks.loadChatThreadBundle.mockResolvedValue({
+      view: buildThreadView(),
+      pendingRequestDetail: null,
+    });
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    const notifications = MockEventSource.instances.find(
+      (instance) => instance.url === "/api/v1/notifications/stream",
+    );
+    expect(notifications).not.toBeUndefined();
+
+    await act(async () => {
+      notifications?.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            thread_id: "thread_background",
+            event_type: "approval.requested",
+            occurred_at: "2026-03-27T05:25:00Z",
+            high_priority: true,
+          }),
+        }),
+      );
+    });
+    await flushUi();
+
+    expect(chatDataMocks.listWorkspaceThreads).toHaveBeenCalledTimes(2);
+    expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("High-priority background thread needs attention.");
+    expect(container.textContent).toContain("Resume here first");
   });
 
   it("keeps the final assistant message visible after completion refresh", async () => {

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -209,4 +209,99 @@ describe("ChatView", () => {
       markup.indexOf("chat-panel create-card"),
     );
   });
+
+  it("renders latest resolved request recovery affordance without response controls", () => {
+    const markup = renderToStaticMarkup(
+      <ChatView
+        connectionState="idle"
+        draftAssistantMessages={{}}
+        errorMessage={null}
+        isCreatingThread={false}
+        isInterruptingThread={false}
+        isLoadingThread={false}
+        isLoadingThreads={false}
+        isRespondingToRequest={false}
+        isSendingMessage={false}
+        messageDraft=""
+        newThreadInput=""
+        onApproveRequest={() => {}}
+        onCreateThread={() => {}}
+        onDenyRequest={() => {}}
+        onInterruptThread={() => {}}
+        onMessageDraftChange={() => {}}
+        onNewThreadInputChange={() => {}}
+        onSelectThread={() => {}}
+        onSendMessage={() => {}}
+        selectedRequestDetail={{
+          request_id: "req_001",
+          thread_id: "thread_001",
+          turn_id: "turn_001",
+          item_id: "item_001",
+          request_kind: "approval",
+          status: "resolved",
+          risk_category: "external_side_effect",
+          summary: "Run git push",
+          reason: "Codex requested permission to push changes.",
+          operation_summary: "git push origin main",
+          requested_at: "2026-03-27T05:20:00Z",
+          responded_at: "2026-03-27T05:21:00Z",
+          decision: "approved",
+          decision_options: {
+            policy_scope_supported: false,
+            default_policy_scope: "once",
+          },
+          context: null,
+        }}
+        selectedThreadId="thread_001"
+        selectedThreadView={{
+          thread: {
+            thread_id: "thread_001",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "waiting_input",
+              active_flags: [],
+              latest_turn_status: null,
+            },
+            updated_at: "2026-03-27T05:22:00Z",
+          },
+          current_activity: {
+            kind: "waiting_on_user_input",
+            label: "Waiting for your input",
+          },
+          pending_request: null,
+          latest_resolved_request: {
+            request_id: "req_001",
+            thread_id: "thread_001",
+            turn_id: "turn_001",
+            item_id: "item_001",
+            request_kind: "approval",
+            status: "resolved",
+            decision: "approved",
+            requested_at: "2026-03-27T05:20:00Z",
+            responded_at: "2026-03-27T05:21:00Z",
+          },
+          composer: {
+            accepting_user_input: true,
+            interrupt_available: false,
+            blocked_by_request: false,
+          },
+          timeline: {
+            items: [],
+            next_cursor: null,
+            has_more: false,
+          },
+        }}
+        statusMessage={null}
+        streamEvents={[]}
+        threads={[]}
+        workspaceId="ws_alpha"
+      />,
+    );
+
+    expect(markup).toContain("Latest resolved request");
+    expect(markup).toContain("Decision: approved");
+    expect(markup).toContain("Reopen request detail");
+    expect(markup).not.toContain("Approve request");
+    expect(markup).not.toContain("Deny request");
+  });
 });

--- a/apps/frontend-bff/tests/home-page-client.test.tsx
+++ b/apps/frontend-bff/tests/home-page-client.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+import type React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HomeResponse } from "../src/runtime-types";
+
+const homeDataMocks = vi.hoisted(() => ({
+  createWorkspaceFromHome: vi.fn(),
+  fetchHomeData: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../src/home-data", () => ({
+  createWorkspaceFromHome: homeDataMocks.createWorkspaceFromHome,
+  fetchHomeData: homeDataMocks.fetchHomeData,
+}));
+
+import { HomePageClient } from "../src/home-page-client";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  readonly close = vi.fn();
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+function buildHome(overrides: Partial<HomeResponse> = {}): HomeResponse {
+  return {
+    workspaces: [
+      {
+        workspace_id: "ws_alpha",
+        workspace_name: "alpha",
+        created_at: "2026-03-27T05:12:34Z",
+        updated_at: "2026-03-27T05:22:00Z",
+        active_session_summary: null,
+        pending_approval_count: 0,
+      },
+    ],
+    resume_candidates: [],
+    updated_at: "2026-03-27T05:22:00Z",
+    ...overrides,
+  };
+}
+
+async function flushUi() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("HomePageClient", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    MockEventSource.instances = [];
+    homeDataMocks.createWorkspaceFromHome.mockReset();
+    homeDataMocks.fetchHomeData.mockReset();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+    delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+      .IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("uses notification events to refresh Home and surface high-priority background work", async () => {
+    homeDataMocks.fetchHomeData.mockResolvedValueOnce(buildHome()).mockResolvedValueOnce(
+      buildHome({
+        resume_candidates: [
+          {
+            thread_id: "thread_approval",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "running",
+              active_flags: ["waiting_on_request"],
+              latest_turn_status: "running",
+            },
+            updated_at: "2026-03-27T05:23:00Z",
+            current_activity: {
+              kind: "waiting_on_approval",
+              label: "Approval required",
+            },
+            badge: {
+              kind: "approval_required",
+              label: "Approval required",
+            },
+            blocked_cue: {
+              kind: "approval_required",
+              label: "Needs your response",
+            },
+            resume_cue: {
+              reason_kind: "waiting_on_approval",
+              priority_band: "highest",
+              label: "Resume here first",
+            },
+          },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      root.render(<HomePageClient />);
+    });
+    await flushUi();
+
+    expect(MockEventSource.instances[0]?.url).toBe("/api/v1/notifications/stream");
+
+    await act(async () => {
+      MockEventSource.instances[0]?.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            thread_id: "thread_approval",
+            event_type: "approval.requested",
+            occurred_at: "2026-03-27T05:23:00Z",
+            high_priority: true,
+          }),
+        }),
+      );
+    });
+    await flushUi();
+
+    expect(homeDataMocks.fetchHomeData).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("High-priority background thread needs attention.");
+    expect(container.textContent).toContain("Resume here first");
+    expect(container.textContent).toContain("Needs your response");
+  });
+});

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-166-request-detail-recovery](./archive/issue-166-request-detail-recovery/README.md)
 - [issue-165-thread-first-shell](./archive/issue-165-thread-first-shell/README.md)
 - [issue-164-ui-state-matrix](./archive/issue-164-ui-state-matrix/README.md)
 - [issue-150-ngrok-sse-validation](./archive/issue-150-ngrok-sse-validation/README.md)

--- a/tasks/archive/issue-166-request-detail-recovery/README.md
+++ b/tasks/archive/issue-166-request-detail-recovery/README.md
@@ -1,0 +1,79 @@
+# Issue 166 Request Detail Recovery
+
+## Purpose
+
+- Execute Issue #166: connect request detail, just-resolved recovery visibility, and background priority promotion from thread context in the v0.9 thread-first UI.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/166
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`, section 5.3
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Open pending request detail from the thread-context detail path on desktop and mobile.
+- Support request response actions from the thread-context detail path while keeping minimum confirmation information visible.
+- Surface `latest_resolved_request` enough to support recovery-oriented reopening during the retained visibility window.
+- Reacquire `thread_view`, `timeline`, and request helper state through REST after reconnect or sequence inconsistency.
+- Subscribe to the global notifications stream from the app shell where appropriate.
+- Treat notification events as lightweight refresh triggers and priority signals, not authoritative state.
+- Surface background `waitingOnApproval`, `systemError`, and latest-turn failure conditions without rebuilding a dedicated approval screen.
+
+## Exit criteria
+
+- Pending request response is reachable from thread context without a dedicated approval screen.
+- Mobile request response can be completed from an open relevant thread within the v0.9 usability target.
+- Just-resolved request visibility supports recovery rather than disappearing immediately from the user model.
+- High-priority background threads are noticeable through lightweight UI signals.
+- Notification handling refreshes authoritative REST state instead of treating notification payloads as final state.
+- Focused `apps/frontend-bff` validation covers the changed thread/request UI behavior.
+
+## Work plan
+
+- Inspect the current thread-first shell, request helper data flow, and notifications route.
+- Plan one bounded sprint that connects request detail, recovery visibility, and notification promotion without expanding into the later Home/workspace-switcher slice.
+- Implement the approved sprint in `apps/frontend-bff`.
+- Run targeted frontend validation, including `npm run check` for touched frontend files.
+- Run the dedicated pre-push validation gate before any push, archive, merge, or close-oriented handoff.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-21T07-39-55Z-issue-166-close/events.ndjson`
+- Sprint validation evidence:
+  - `npm run check` passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - `npm test -- tests/chat-data.test.ts tests/chat-page-client.test.tsx tests/chat-view.test.tsx tests/home-page-client.test.tsx` passed with 19 tests.
+  - `npm test` passed with 58 tests.
+- Pre-push validation evidence:
+  - Dedicated validator gate passed the same command set.
+  - Validator observed `none_beyond_reads`.
+
+## Status / handoff notes
+
+- Status: `locally complete; archived after pre-push validation`
+- Active branch: `issue-166-request-detail-recovery`
+- Active worktree: `.worktrees/issue-166-request-detail-recovery`
+- Notes:
+  - Implemented request-detail loading for pending and latest-resolved request helpers.
+  - Added thread-context pending/resolved request detail affordances without introducing a dedicated approval screen.
+  - Added stream sequence inconsistency and notification-triggered REST refresh paths.
+  - Completion retrospective:
+    - Completion boundary: package archive after sprint approval and pre-push validation.
+    - Contract check: package exit criteria satisfied by frontend implementation and focused/full validation evidence.
+    - What worked: planner/worker/evaluator split kept implementation scoped to `apps/frontend-bff`.
+    - Workflow problems: initial worktree-local `node_modules` symlink was broken and was corrected as ignored local environment plumbing.
+    - Improvements to adopt: keep shared dependency symlink checks explicit when creating worktrees.
+    - Skill candidates or skill updates: none.
+    - Follow-up updates: PR merge, parent `main` sync, worktree cleanup, final Issue close, and Project `Done` remain pending.
+
+## Archive conditions
+
+- Archive this package after the issue scope is locally complete, sprint approval is recorded, the dedicated pre-push validation gate passes, and handoff notes are updated.
+- Do not close Issue #166 or mark Project status `Done` until the work is reachable on `main`, the parent checkout is synced, and the active worktree is removed.


### PR DESCRIPTION
## Summary

- load pending and latest-resolved request detail for the thread-first chat surface
- expose pending/resolved request detail actions from thread context without a dedicated approval screen
- use thread stream sequence issues and global notifications as REST refresh triggers for authoritative state
- archive the completed Issue #166 local task package

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- tests/chat-data.test.ts tests/chat-page-client.test.tsx tests/chat-view.test.tsx tests/home-page-client.test.tsx`
- `npm test`

Closes #166
