### PR TITLE
feat: rework Home workspace resume shell

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -37,7 +37,8 @@ a {
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 
@@ -76,6 +77,88 @@ input {
   display: grid;
   gap: 18px;
   padding: 20px;
+}
+
+.home-app-shell {
+  display: grid;
+  gap: 18px;
+  padding: 18px;
+}
+
+.home-topbar,
+.workspace-context,
+.home-primary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.home-topbar {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.workspace-context {
+  align-items: end;
+  justify-content: space-between;
+  border: 1px solid rgba(35, 24, 15, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.58);
+  padding: 14px;
+}
+
+.workspace-context-main {
+  display: grid;
+  gap: 6px;
+  min-width: min(100%, 18rem);
+}
+
+.workspace-context-main h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
+.workspace-switcher {
+  display: grid;
+  gap: 8px;
+  min-width: min(100%, 15rem);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.workspace-switcher summary {
+  cursor: pointer;
+  border-radius: 14px;
+  background: rgba(35, 24, 15, 0.06);
+  color: var(--text-main);
+  padding: 10px 12px;
+}
+
+.workspace-switcher-control {
+  display: grid;
+  gap: 8px;
+  padding-top: 8px;
+}
+
+.workspace-switcher select {
+  width: 100%;
+  border: 1px solid rgba(35, 24, 15, 0.14);
+  border-radius: 14px;
+  background: #fffdf8;
+  color: var(--text-main);
+  padding: 10px 12px;
+}
+
+.workspace-switcher select:focus {
+  outline: 2px solid rgba(184, 77, 36, 0.22);
+  outline-offset: 1px;
+}
+
+.home-primary-actions {
+  align-items: center;
 }
 
 .eyebrow {
@@ -153,7 +236,11 @@ input {
 
 .primary-link,
 .secondary-link,
-.submit-button {
+.submit-button,
+.disabled-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 16px;
   padding: 12px 16px;
   font-weight: 700;
@@ -169,9 +256,16 @@ input {
   color: #fffaf6;
 }
 
-.secondary-link {
+.secondary-link,
+.disabled-link {
   background: rgba(35, 24, 15, 0.06);
   color: var(--text-main);
+}
+
+.disabled-link {
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.68;
 }
 
 .primary-link:hover,

--- a/apps/frontend-bff/e2e/chat-flow.runtime.spec.ts
+++ b/apps/frontend-bff/e2e/chat-flow.runtime.spec.ts
@@ -19,8 +19,59 @@ async function dismissNgrokInterstitial(page: Page) {
   }
 }
 
+async function openMobileThreadNavigation(page: Page, isDesktop: boolean) {
+  if (isDesktop) {
+    return;
+  }
+
+  await page.getByRole("button", { name: "Threads", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "Start or resume a thread", exact: true }),
+  ).toBeVisible();
+}
+
+async function expectThreadWaitingForInput(page: Page, threadId: string, isDesktop: boolean) {
+  if (isDesktop) {
+    await expect(
+      page
+        .locator(".thread-summary-card")
+        .filter({ hasText: threadId })
+        .getByText("Waiting for your input", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+  }
+
+  await expect(
+    page
+      .locator("section.chat-panel.workspace-card")
+      .filter({ has: page.getByText("Current thread", { exact: true }) })
+      .getByText("Waiting for your input", { exact: true }),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+async function startThreadFromFirstInput(page: Page, isDesktop: boolean, firstInput: string) {
+  const inputScope = isDesktop ? page : page.locator(".thread-navigation.open");
+  const firstInputField = inputScope.getByLabel("First input");
+  const startThreadButton = inputScope.getByRole("button", { name: "Start new thread" });
+
+  await firstInputField.fill(firstInput);
+  await expect(startThreadButton).toBeVisible();
+  await expect(startThreadButton).toBeEnabled();
+
+  if (isDesktop) {
+    await startThreadButton.click();
+    await expect(page.getByText("Started thread")).toBeVisible({ timeout: 15_000 });
+    return;
+  }
+
+  await Promise.all([
+    page.getByText("Started thread").waitFor({ timeout: 15_000 }),
+    startThreadButton.click({ force: true }),
+  ]);
+}
+
 test("runs the main thread flow against the live runtime stack", async ({ page }, testInfo) => {
   test.setTimeout(90_000);
+  const isDesktop = testInfo.project.name === "desktop-chromium";
   const workspaceName = `pw-${Date.now()}`;
   const firstInput = "Runtime-backed thread flow";
   const followUpInput = "Please explain the diff.";
@@ -40,20 +91,14 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
     await createWorkspaceButton.click();
     await expect(page.getByText(`Workspace "${workspaceName}" created.`)).toBeVisible();
 
-    await page
-      .locator("article.workspace-card")
-      .filter({ has: page.getByRole("heading", { name: workspaceName, exact: true }) })
-      .getByRole("link", { name: "Open thread" })
-      .click();
+    await page.locator(".home-primary-actions").getByRole("link", { name: "Ask Codex" }).click();
     await expect(page).toHaveURL(/\/chat\?workspaceId=/);
     const workspaceId = new URL(page.url()).searchParams.get("workspaceId") ?? "";
     expect(workspaceId).not.toBe("");
     await expect(page.getByRole("heading", { name: "Chat", exact: true })).toBeVisible();
 
-    await page.getByLabel("First input").fill(firstInput);
-    await expect(page.getByRole("button", { name: "Start new thread" })).toBeEnabled();
-    await page.getByRole("button", { name: "Start new thread" }).click();
-    await expect(page.getByText("Started thread")).toBeVisible({ timeout: 15_000 });
+    await openMobileThreadNavigation(page, isDesktop);
+    await startThreadFromFirstInput(page, isDesktop, firstInput);
 
     const currentThreadHeading = page
       .locator("section.chat-panel.workspace-card")
@@ -73,18 +118,7 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
 
     const sendReplyButton = page.getByRole("button", { name: "Send reply" });
     await expect(sendReplyButton).toBeDisabled();
-    await expect(
-      page
-        .locator(".thread-summary-card")
-        .filter({ hasText: threadId })
-        .getByText("Waiting for your input", { exact: true }),
-    ).toBeVisible({ timeout: 15_000 });
-    await expect(
-      page
-        .locator("section.chat-panel.workspace-card")
-        .filter({ has: page.getByText("Current thread", { exact: true }) })
-        .getByText("Waiting for your input", { exact: true }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expectThreadWaitingForInput(page, threadId, isDesktop);
 
     const threadViewPath = `/api/v1/threads/${threadId}/view`;
     const threadStreamPath = `/api/v1/threads/${threadId}/stream`;
@@ -108,18 +142,7 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
       })
       .toBeGreaterThan(threadStreamRequestCountBeforeReload);
 
-    await expect(
-      page
-        .locator(".thread-summary-card")
-        .filter({ hasText: threadId })
-        .getByText("Waiting for your input", { exact: true }),
-    ).toBeVisible({ timeout: 15_000 });
-    await expect(
-      page
-        .locator("section.chat-panel.workspace-card")
-        .filter({ has: page.getByText("Current thread", { exact: true }) })
-        .getByText("Waiting for your input", { exact: true }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expectThreadWaitingForInput(page, threadId, isDesktop);
     await page.getByLabel("Send follow-up input").fill(followUpInput);
     await expect(sendReplyButton).toBeEnabled({ timeout: 15_000 });
     await sendReplyButton.click();
@@ -135,18 +158,7 @@ test("runs the main thread flow against the live runtime stack", async ({ page }
         })
         .first(),
     ).toBeVisible({ timeout: 15_000 });
-    await expect(
-      page
-        .locator(".thread-summary-card")
-        .filter({ hasText: threadId })
-        .getByText("Waiting for your input", { exact: true }),
-    ).toBeVisible({ timeout: 15_000 });
-    await expect(
-      page
-        .locator("section.chat-panel.workspace-card")
-        .filter({ has: page.getByText("Current thread", { exact: true }) })
-        .getByText("Waiting for your input", { exact: true }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expectThreadWaitingForInput(page, threadId, isDesktop);
 
     const interruptThreadButton = page.getByRole("button", { name: "Interrupt thread" });
     if (await interruptThreadButton.isEnabled()) {

--- a/apps/frontend-bff/e2e/chat-flow.spec.ts
+++ b/apps/frontend-bff/e2e/chat-flow.spec.ts
@@ -13,22 +13,40 @@ async function sectionByHeading(page: Page, heading: string) {
     .first();
 }
 
-async function sectionBox(page: Page, heading: string) {
-  const section = await sectionByHeading(page, heading);
-  await expect(section).toBeVisible();
+async function locatorBox(locator: ReturnType<Page["locator"]>) {
+  await expect(locator).toBeVisible();
 
-  const box = await section.boundingBox();
+  const box = await locator.boundingBox();
   expect(box).not.toBeNull();
 
   return box!;
+}
+
+async function sectionBox(page: Page, heading: string) {
+  return locatorBox(await sectionByHeading(page, heading));
+}
+
+async function timelineBox(page: Page) {
+  return locatorBox(page.getByRole("region", { name: "Timeline", exact: true }));
 }
 
 async function threadCards(page: Page, currentThreadHeading: string) {
   return {
     startCard: await sectionBox(page, "Start or resume a thread"),
     currentCard: await sectionBox(page, currentThreadHeading),
-    timelineCard: await sectionBox(page, "Timeline"),
+    timelineCard: await timelineBox(page),
   };
+}
+
+async function openMobileThreadNavigation(page: Page, isDesktop: boolean) {
+  if (isDesktop) {
+    return;
+  }
+
+  await page.getByRole("button", { name: "Threads", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "Start or resume a thread", exact: true }),
+  ).toBeVisible();
 }
 
 function expectDesktopThreadLayoutStable(
@@ -39,9 +57,28 @@ function expectDesktopThreadLayoutStable(
   expect(current.currentCard.x).toBeCloseTo(baseline.currentCard.x, 0);
   expect(current.timelineCard.x).toBeCloseTo(baseline.timelineCard.x, 0);
   expect(current.currentCard.x).toBeGreaterThan(current.startCard.x + 20);
-  expect(current.timelineCard.x).toBeCloseTo(current.startCard.x, 0);
-  expect(current.startCard.y).toBeCloseTo(current.currentCard.y, 0);
+  expect(current.timelineCard.x).toBeGreaterThan(current.currentCard.x);
+  expect(current.timelineCard.x).toBeLessThan(current.currentCard.x + current.currentCard.width);
   expect(current.timelineCard.y).toBeGreaterThan(current.currentCard.y + 20);
+}
+
+async function expectThreadRunning(page: Page, isDesktop: boolean) {
+  if (isDesktop) {
+    await expect(
+      page
+        .locator(".thread-summary-card")
+        .filter({ hasText: "thread_001" })
+        .getByText("Running", { exact: true }),
+    ).toBeVisible();
+    return;
+  }
+
+  await expect(
+    page
+      .locator("section.chat-panel.workspace-card")
+      .filter({ has: page.getByText("Current thread", { exact: true }) })
+      .getByText("Running", { exact: true }),
+  ).toBeVisible();
 }
 
 test("runs the main thread flow from Home through interrupt on desktop and mobile", async ({
@@ -63,11 +100,7 @@ test("runs the main thread flow from Home through interrupt on desktop and mobil
     await page.getByRole("button", { name: "Create workspace" }).click();
     await expect(page.getByText('Workspace "alpha" created.')).toBeVisible();
 
-    await page
-      .locator("article.workspace-card")
-      .filter({ has: page.getByRole("heading", { name: "alpha", exact: true }) })
-      .getByRole("link", { name: "Open thread" })
-      .click();
+    await page.locator(".home-primary-actions").getByRole("link", { name: "Ask Codex" }).click();
     await expect(page).toHaveURL(/\/chat\?workspaceId=ws_alpha/);
     await expect(page.getByRole("heading", { name: "Chat", exact: true })).toBeVisible();
     await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
@@ -76,13 +109,11 @@ test("runs the main thread flow from Home through interrupt on desktop and mobil
     if (isDesktop) {
       baselineLayout = await threadCards(page, "Select a thread");
     } else {
-      await expect(
-        page.getByRole("heading", { name: "Start or resume a thread", exact: true }),
-      ).toBeVisible();
+      await openMobileThreadNavigation(page, isDesktop);
       await expect(
         page.getByRole("heading", { name: "Select a thread", exact: true }),
       ).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Timeline", exact: true })).toBeVisible();
+      await expect(page.getByRole("region", { name: "Timeline", exact: true })).toBeVisible();
     }
 
     await page.getByLabel("First input").fill("Fix build error");
@@ -100,12 +131,7 @@ test("runs the main thread flow from Home through interrupt on desktop and mobil
     await expect(sendReplyButton).toBeEnabled();
     await sendReplyButton.click();
     await expect(page.getByText("Input accepted. Waiting for thread updates.")).toBeVisible();
-    await expect(
-      page
-        .locator(".thread-summary-card")
-        .filter({ hasText: "thread_001" })
-        .getByText("Running", { exact: true }),
-    ).toBeVisible();
+    await expectThreadRunning(page, isDesktop);
     await expect(page.getByRole("button", { name: "Interrupt thread" })).toBeEnabled();
     await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
     if (isDesktop) {
@@ -118,7 +144,6 @@ test("runs the main thread flow from Home through interrupt on desktop and mobil
     await page.getByLabel("Send follow-up input").fill("Resume after interrupt.");
     await expect(sendReplyButton).toBeEnabled();
     await sendReplyButton.click();
-    await expect(page.getByText("Input accepted. Waiting for thread updates.")).toBeVisible();
     await expect(
       page.locator(".chat-message-list").getByText("Here is the explanation.").first(),
     ).toBeVisible();

--- a/apps/frontend-bff/src/home-page-client.tsx
+++ b/apps/frontend-bff/src/home-page-client.tsx
@@ -7,11 +7,20 @@ import { HomeView } from "./home-view";
 import type { HomeResponse } from "./runtime-types";
 import type { PublicNotificationEvent } from "./thread-types";
 
+function chooseDefaultWorkspaceId(home: HomeResponse | null) {
+  const newestWorkspace = home?.workspaces.toSorted(
+    (left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at),
+  )[0];
+
+  return home?.resume_candidates[0]?.workspace_id ?? newestWorkspace?.workspace_id ?? "";
+}
+
 export function HomePageClient() {
   const [home, setHome] = useState<HomeResponse | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState("");
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [workspaceName, setWorkspaceName] = useState("");
 
@@ -20,7 +29,17 @@ export function HomePageClient() {
     setErrorMessage(null);
 
     try {
-      setHome(await fetchHomeData());
+      const nextHome = await fetchHomeData();
+      setHome(nextHome);
+      setSelectedWorkspaceId((currentWorkspaceId) => {
+        if (
+          nextHome.workspaces.some((workspace) => workspace.workspace_id === currentWorkspaceId)
+        ) {
+          return currentWorkspaceId;
+        }
+
+        return chooseDefaultWorkspaceId(nextHome);
+      });
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Failed to load Home data.");
     } finally {
@@ -68,7 +87,12 @@ export function HomePageClient() {
       await createWorkspaceFromHome(trimmedName);
       setWorkspaceName("");
       setStatusMessage(`Workspace "${trimmedName}" created.`);
-      await loadHome();
+      const nextHome = await fetchHomeData();
+      setHome(nextHome);
+      setSelectedWorkspaceId(
+        nextHome.workspaces.find((workspace) => workspace.workspace_name === trimmedName)
+          ?.workspace_id ?? chooseDefaultWorkspaceId(nextHome),
+      );
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Failed to create workspace.");
     } finally {
@@ -83,7 +107,9 @@ export function HomePageClient() {
       isLoading={isLoading}
       isSubmitting={isSubmitting}
       onCreateWorkspace={handleCreateWorkspace}
+      onSelectedWorkspaceIdChange={setSelectedWorkspaceId}
       onWorkspaceNameChange={setWorkspaceName}
+      selectedWorkspaceId={selectedWorkspaceId}
       statusMessage={statusMessage}
       workspaceName={workspaceName}
     />

--- a/apps/frontend-bff/src/home-view.tsx
+++ b/apps/frontend-bff/src/home-view.tsx
@@ -1,17 +1,22 @@
 import Link from "next/link";
 
 import type { HomeResponse } from "./runtime-types";
+import type { PublicThreadListItem } from "./thread-types";
 
 export interface HomeViewProps {
   home: HomeResponse | null;
   errorMessage: string | null;
   isLoading: boolean;
   isSubmitting: boolean;
+  selectedWorkspaceId: string;
   statusMessage: string | null;
   workspaceName: string;
+  onSelectedWorkspaceIdChange: (workspaceId: string) => void;
   onWorkspaceNameChange: (value: string) => void;
   onCreateWorkspace: () => void;
 }
+
+type HomeWorkspace = HomeResponse["workspaces"][number];
 
 function formatThreadStatus(status: string) {
   return status.replaceAll("_", " ");
@@ -44,44 +49,138 @@ function formatResumeLabel(label: string) {
   return label.replaceAll("_", " ");
 }
 
+function findWorkspaceResumeCandidate(
+  workspaceId: string,
+  resumeCandidates: PublicThreadListItem[],
+) {
+  return resumeCandidates.find((thread) => thread.workspace_id === workspaceId) ?? null;
+}
+
+function workspaceOptionCue(
+  workspace: HomeWorkspace,
+  workspaceResumeCandidate: PublicThreadListItem | null,
+) {
+  if (workspace.pending_approval_count > 0) {
+    return `${workspace.pending_approval_count} approval${
+      workspace.pending_approval_count === 1 ? "" : "s"
+    }`;
+  }
+
+  return (
+    workspaceResumeCandidate?.resume_cue?.label ??
+    workspaceResumeCandidate?.blocked_cue?.label ??
+    null
+  );
+}
+
 export function HomeView({
   home,
   errorMessage,
   isLoading,
   isSubmitting,
+  selectedWorkspaceId,
   statusMessage,
   workspaceName,
+  onSelectedWorkspaceIdChange,
   onWorkspaceNameChange,
   onCreateWorkspace,
 }: HomeViewProps) {
+  const workspaces = home?.workspaces ?? [];
+  const resumeCandidates = home?.resume_candidates ?? [];
+  const selectedWorkspace =
+    workspaces.find((workspace) => workspace.workspace_id === selectedWorkspaceId) ??
+    workspaces[0] ??
+    null;
+  const topResumeCandidate = resumeCandidates[0] ?? null;
+  const selectedWorkspaceResumeCandidate = selectedWorkspace
+    ? findWorkspaceResumeCandidate(selectedWorkspace.workspace_id, resumeCandidates)
+    : null;
+  const selectedWorkspaceCue = selectedWorkspace
+    ? workspaceOptionCue(selectedWorkspace, selectedWorkspaceResumeCandidate)
+    : null;
+  const selectedThread = selectedWorkspace?.active_session_summary ?? null;
+
   return (
     <main className="home-shell">
       <div className="home-layout">
-        <section className="hero-card">
-          <div className="hero-body">
-            <p className="eyebrow">codex-webui</p>
-            <h1>Home</h1>
-            <p className="hero-copy">
-              Manage workspaces, see active threads, and resume the threads that need attention from
-              a smartphone-first shell.
-            </p>
-            <div className="hero-metrics">
-              <span className="metric-chip">
-                Resume candidates: {home?.resume_candidates.length ?? 0}
-              </span>
-              <span className="metric-chip">Workspaces: {home?.workspaces.length ?? 0}</span>
-              <span className="metric-chip">
-                Updated: {home ? formatTimestamp(home.updated_at) : "Waiting"}
-              </span>
+        <section className="home-app-shell hero-card">
+          <div className="home-topbar">
+            <div>
+              <p className="eyebrow">codex-webui</p>
+              <h1>Home</h1>
             </div>
-            <div className="hero-actions">
-              <Link className="primary-link" href="/chat">
-                Open thread shell
-              </Link>
-              <Link className="secondary-link" href="/">
-                Refresh Home
-              </Link>
+            <span className="metric-chip">
+              Updated: {home ? formatTimestamp(home.updated_at) : "Waiting"}
+            </span>
+          </div>
+
+          <div className="workspace-context">
+            <div className="workspace-context-main">
+              <p className="eyebrow">Current workspace</p>
+              <h2>{selectedWorkspace?.workspace_name ?? "No workspace selected"}</h2>
+              <p className="workspace-meta">
+                {selectedWorkspace
+                  ? (selectedWorkspaceCue ??
+                    `Updated ${formatTimestamp(selectedWorkspace.updated_at)}`)
+                  : isLoading
+                    ? "Loading workspace context..."
+                    : "Create a workspace to start a chat from Home."}
+              </p>
             </div>
+
+            {workspaces.length > 0 ? (
+              <details className="workspace-switcher">
+                <summary>Switch workspace</summary>
+                <label className="workspace-switcher-control" htmlFor="workspace-switcher">
+                  Workspace
+                  <select
+                    id="workspace-switcher"
+                    onChange={(event) => onSelectedWorkspaceIdChange(event.target.value)}
+                    value={selectedWorkspace?.workspace_id ?? ""}
+                  >
+                    {workspaces.map((workspace) => {
+                      const cue = workspaceOptionCue(
+                        workspace,
+                        findWorkspaceResumeCandidate(workspace.workspace_id, resumeCandidates),
+                      );
+
+                      return (
+                        <option key={workspace.workspace_id} value={workspace.workspace_id}>
+                          {workspace.workspace_name}
+                          {cue ? ` - ${cue}` : ""}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              </details>
+            ) : null}
+          </div>
+
+          <div className="home-primary-actions">
+            {selectedWorkspace ? (
+              <Link
+                className="primary-link"
+                href={workspaceChatHref(selectedWorkspace.workspace_id)}
+              >
+                Ask Codex
+              </Link>
+            ) : (
+              <span className="disabled-link">Ask Codex</span>
+            )}
+            <Link className="secondary-link" href="/">
+              Refresh Home
+            </Link>
+          </div>
+
+          <div className="hero-metrics">
+            <span className="metric-chip">Workspaces: {workspaces.length}</span>
+            <span className="metric-chip">Resume candidates: {resumeCandidates.length}</span>
+            {selectedThread ? (
+              <span className="metric-chip">
+                Active: {formatThreadStatus(selectedThread.status)}
+              </span>
+            ) : null}
           </div>
         </section>
 
@@ -120,115 +219,121 @@ export function HomeView({
         {errorMessage ? <p className="error-banner">{errorMessage}</p> : null}
 
         <section className="workspace-grid">
-          {home?.resume_candidates.map((thread) => (
-            <article className="workspace-card" key={thread.thread_id}>
+          {topResumeCandidate ? (
+            <article className="workspace-card top-resume-card">
               <header>
                 <div className="workspace-meta-row">
-                  <p className="eyebrow">Resume candidate</p>
+                  <p className="eyebrow">Resume next</p>
                   <span className="status-badge warning">
-                    {formatResumeLabel(thread.current_activity.label)}
+                    {topResumeCandidate.resume_cue?.label ?? "Resume"}
                   </span>
                 </div>
-                <h2>{thread.thread_id}</h2>
-                <p className="workspace-meta">Updated {formatTimestamp(thread.updated_at)}</p>
+                <h2>{topResumeCandidate.thread_id}</h2>
+                <p className="workspace-meta">
+                  Workspace {topResumeCandidate.workspace_id} - Updated{" "}
+                  {formatTimestamp(topResumeCandidate.updated_at)}
+                </p>
               </header>
 
               <p className="workspace-status">
-                {thread.blocked_cue?.label ?? thread.current_activity.label}
-                {thread.resume_cue ? ` ${thread.resume_cue.label}.` : null}
+                {topResumeCandidate.blocked_cue?.label ?? topResumeCandidate.current_activity.label}
+                {topResumeCandidate.resume_cue ? ` ${topResumeCandidate.resume_cue.label}.` : null}
               </p>
 
               <div className="hero-metrics">
-                <span className="metric-chip">Workspace: {thread.workspace_id}</span>
                 <span className="metric-chip">
-                  Priority: {thread.resume_cue?.priority_band ?? "none"}
+                  Activity: {formatResumeLabel(topResumeCandidate.current_activity.label)}
+                </span>
+                <span className="metric-chip">
+                  Priority: {topResumeCandidate.resume_cue?.priority_band ?? "none"}
                 </span>
               </div>
 
               <div className="workspace-actions">
                 <Link
                   className="primary-link"
-                  href={workspaceChatHref(thread.workspace_id, thread.thread_id)}
+                  href={workspaceChatHref(
+                    topResumeCandidate.workspace_id,
+                    topResumeCandidate.thread_id,
+                  )}
                 >
                   Resume thread
                 </Link>
-                <Link className="secondary-link" href="/">
-                  Refresh Home
-                </Link>
               </div>
             </article>
-          ))}
+          ) : null}
 
-          {!isLoading && home && home.resume_candidates.length === 0 ? (
+          {!isLoading && home && resumeCandidates.length === 0 ? (
             <article className="workspace-card">
               <p className="empty-state">
-                No resume candidates right now. Pick a workspace below to start or continue work.
+                No resume candidates right now. Use the current workspace context to ask Codex.
               </p>
             </article>
           ) : null}
         </section>
 
-        <section className="workspace-grid">
+        <section className="workspace-grid workspace-context-details">
           {isLoading && !home ? (
             <article className="workspace-card">
               <p className="workspace-status">Loading Home data...</p>
             </article>
           ) : null}
 
-          {!isLoading && home && home.workspaces.length === 0 ? (
+          {!isLoading && home && workspaces.length === 0 ? (
             <article className="workspace-card">
               <p className="empty-state">
-                No workspaces yet. Create one above to start the UI flow.
+                No workspaces yet. Create one above to start the first-input chat flow.
               </p>
             </article>
           ) : null}
 
-          {home?.workspaces.map((workspace) => {
-            const activeThread = workspace.active_session_summary;
-            const statusClassName = activeThread ? "status-badge success" : "status-badge warning";
-
-            return (
-              <article className="workspace-card" key={workspace.workspace_id}>
-                <header>
-                  <div className="workspace-meta-row">
-                    <p className="eyebrow">Workspace</p>
-                    <span className={statusClassName}>
-                      {activeThread ? formatThreadStatus(activeThread.status) : "No active thread"}
-                    </span>
-                  </div>
-                  <h2>{workspace.workspace_name}</h2>
-                  <p className="workspace-meta">Updated {formatTimestamp(workspace.updated_at)}</p>
-                </header>
-
-                <p className="workspace-status">
-                  {activeThread
-                    ? `Active thread ${activeThread.session_id} last moved at ${formatTimestamp(
-                        activeThread.last_message_at,
-                      )}.`
-                    : "This workspace is ready for its first thread."}
-                </p>
-
-                <div className="hero-metrics">
-                  <span className="metric-chip">
-                    Request queue: {workspace.pending_approval_count}
-                  </span>
-                  <span className="metric-chip">ID: {workspace.workspace_id}</span>
-                </div>
-
-                <div className="workspace-actions">
-                  <Link
-                    className="primary-link"
-                    href={workspaceChatHref(workspace.workspace_id, activeThread?.session_id)}
+          {selectedWorkspace ? (
+            <article className="workspace-card">
+              <header>
+                <div className="workspace-meta-row">
+                  <p className="eyebrow">Selected context</p>
+                  <span
+                    className={selectedThread ? "status-badge success" : "status-badge warning"}
                   >
-                    Open thread
-                  </Link>
-                  <Link className="secondary-link" href="/">
-                    Stay on Home
-                  </Link>
+                    {selectedThread
+                      ? formatThreadStatus(selectedThread.status)
+                      : "Ready for first thread"}
+                  </span>
                 </div>
-              </article>
-            );
-          })}
+                <h2>{selectedWorkspace.workspace_name}</h2>
+                <p className="workspace-meta">
+                  Updated {formatTimestamp(selectedWorkspace.updated_at)}
+                </p>
+              </header>
+
+              <p className="workspace-status">
+                {selectedThread
+                  ? `Active thread ${selectedThread.session_id} last moved at ${formatTimestamp(
+                      selectedThread.last_message_at,
+                    )}.`
+                  : "This workspace is ready for its first thread."}
+              </p>
+
+              <div className="hero-metrics">
+                <span className="metric-chip">
+                  Request queue: {selectedWorkspace.pending_approval_count}
+                </span>
+                <span className="metric-chip">ID: {selectedWorkspace.workspace_id}</span>
+                {selectedWorkspaceCue ? (
+                  <span className="metric-chip">{selectedWorkspaceCue}</span>
+                ) : null}
+              </div>
+
+              <div className="workspace-actions">
+                <Link
+                  className="primary-link"
+                  href={workspaceChatHref(selectedWorkspace.workspace_id)}
+                >
+                  Ask Codex
+                </Link>
+              </div>
+            </article>
+          ) : null}
         </section>
       </div>
     </main>

--- a/apps/frontend-bff/tests/home-page-client.test.tsx
+++ b/apps/frontend-bff/tests/home-page-client.test.tsx
@@ -160,4 +160,132 @@ describe("HomePageClient", () => {
     expect(container.textContent).toContain("Resume here first");
     expect(container.textContent).toContain("Needs your response");
   });
+
+  it("switches compact workspace context locally and scopes Ask Codex to the selected workspace", async () => {
+    homeDataMocks.fetchHomeData.mockResolvedValueOnce(
+      buildHome({
+        workspaces: [
+          {
+            workspace_id: "ws_alpha",
+            workspace_name: "alpha",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            active_session_summary: null,
+            pending_approval_count: 1,
+          },
+          {
+            workspace_id: "ws_beta",
+            workspace_name: "beta",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:24:00Z",
+            active_session_summary: null,
+            pending_approval_count: 0,
+          },
+        ],
+        resume_candidates: [
+          {
+            thread_id: "thread_beta",
+            workspace_id: "ws_beta",
+            native_status: {
+              thread_status: "idle",
+              active_flags: [],
+              latest_turn_status: "failed",
+            },
+            updated_at: "2026-03-27T05:24:00Z",
+            current_activity: {
+              kind: "latest_turn_failed",
+              label: "Latest turn failed",
+            },
+            badge: {
+              kind: "latest_turn_failed",
+              label: "Failed",
+            },
+            blocked_cue: {
+              kind: "latest_turn_failed",
+              label: "Needs attention",
+            },
+            resume_cue: {
+              reason_kind: "latest_turn_failed",
+              priority_band: "high",
+              label: "Resume soon",
+            },
+          },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      root.render(<HomePageClient />);
+    });
+    await flushUi();
+
+    const switcher = container.querySelector<HTMLSelectElement>("#workspace-switcher");
+    expect(switcher).not.toBeNull();
+    expect(switcher?.value).toBe("ws_beta");
+    expect(container.textContent).toContain("beta");
+    expect(
+      container.querySelector<HTMLAnchorElement>(".home-primary-actions .primary-link")?.href,
+    ).toContain("/chat?workspaceId=ws_beta");
+    expect(
+      container.querySelector<HTMLAnchorElement>(".home-primary-actions .primary-link")?.href,
+    ).not.toContain("threadId");
+
+    await act(async () => {
+      switcher!.value = "ws_alpha";
+      switcher!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("alpha");
+    expect(
+      container.querySelector<HTMLAnchorElement>(".home-primary-actions .primary-link")?.href,
+    ).toContain("/chat?workspaceId=ws_alpha");
+    expect(homeDataMocks.fetchHomeData).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects the newest workspace when there is no resume candidate", async () => {
+    homeDataMocks.fetchHomeData.mockResolvedValueOnce(
+      buildHome({
+        workspaces: [
+          {
+            workspace_id: "ws_older",
+            workspace_name: "older",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            active_session_summary: null,
+            pending_approval_count: 0,
+          },
+          {
+            workspace_id: "ws_newest",
+            workspace_name: "newest",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:26:00Z",
+            active_session_summary: null,
+            pending_approval_count: 0,
+          },
+          {
+            workspace_id: "ws_middle",
+            workspace_name: "middle",
+            created_at: "2026-03-27T05:12:34Z",
+            updated_at: "2026-03-27T05:24:00Z",
+            active_session_summary: null,
+            pending_approval_count: 0,
+          },
+        ],
+        resume_candidates: [],
+      }),
+    );
+
+    await act(async () => {
+      root.render(<HomePageClient />);
+    });
+    await flushUi();
+
+    expect(container.querySelector<HTMLSelectElement>("#workspace-switcher")?.value).toBe(
+      "ws_newest",
+    );
+    expect(
+      container.querySelector<HTMLAnchorElement>(".home-primary-actions .primary-link")?.href,
+    ).toContain("/chat?workspaceId=ws_newest");
+    expect(container.textContent).toContain("newest");
+  });
 });

--- a/apps/frontend-bff/tests/home-view.test.tsx
+++ b/apps/frontend-bff/tests/home-view.test.tsx
@@ -21,7 +21,7 @@ vi.mock("next/link", () => ({
 }));
 
 describe("HomeView", () => {
-  it("renders workspace summaries and navigation entry points", () => {
+  it("renders compact workspace context, switcher cues, and scoped navigation entry points", () => {
     const markup = renderToStaticMarkup(
       <HomeView
         errorMessage={null}
@@ -38,6 +38,14 @@ describe("HomeView", () => {
                 last_message_at: "2026-03-27T05:21:40Z",
               },
               pending_approval_count: 2,
+            },
+            {
+              workspace_id: "ws_beta",
+              workspace_name: "beta",
+              created_at: "2026-03-27T05:12:34Z",
+              updated_at: "2026-03-27T05:24:00Z",
+              active_session_summary: null,
+              pending_approval_count: 0,
             },
           ],
           resume_candidates: [
@@ -68,25 +76,89 @@ describe("HomeView", () => {
                 label: "Resume here first",
               },
             },
+            {
+              thread_id: "thread_failed",
+              workspace_id: "ws_beta",
+              native_status: {
+                thread_status: "idle",
+                active_flags: [],
+                latest_turn_status: "failed",
+              },
+              updated_at: "2026-03-27T05:24:00Z",
+              current_activity: {
+                kind: "latest_turn_failed",
+                label: "Latest turn failed",
+              },
+              badge: {
+                kind: "latest_turn_failed",
+                label: "Failed",
+              },
+              blocked_cue: {
+                kind: "latest_turn_failed",
+                label: "Needs attention",
+              },
+              resume_cue: {
+                reason_kind: "latest_turn_failed",
+                priority_band: "high",
+                label: "Resume soon",
+              },
+            },
           ],
           updated_at: "2026-03-27T05:22:00Z",
         }}
         isLoading={false}
         isSubmitting={false}
         onCreateWorkspace={() => {}}
+        onSelectedWorkspaceIdChange={() => {}}
         onWorkspaceNameChange={() => {}}
+        selectedWorkspaceId="ws_alpha"
         statusMessage={null}
         workspaceName=""
       />,
     );
 
-    expect(markup).toContain("Resume candidates: 1");
+    expect(markup).toContain("Current workspace");
+    expect(markup).toContain("Switch workspace");
+    expect(markup).toContain('<details class="workspace-switcher">');
+    expect(markup).toContain("<summary>Switch workspace</summary>");
+    expect(markup).not.toContain('<details class="workspace-switcher" open="">');
+    expect(markup).toContain('<select id="workspace-switcher"');
+    expect(markup).toContain("alpha - 2 approvals");
+    expect(markup).toContain("beta - Resume soon");
+    expect(markup).toContain("Resume candidates: 2");
     expect(markup).toContain("Resume thread");
+    expect(markup).toContain("/chat?workspaceId=ws_alpha&amp;threadId=thread_approval");
+    expect(markup).toContain("/chat?workspaceId=ws_alpha");
     expect(markup).toContain("Needs your response");
     expect(markup).toContain("alpha");
-    expect(markup).toContain("Open thread");
-    expect(markup).toContain("Open thread shell");
+    expect(markup).toContain("Ask Codex");
     expect(markup).toContain("Request queue: 2");
     expect(markup).toContain("Create workspace");
+  });
+
+  it("does not expose workspace-scoped chat links when no workspace exists", () => {
+    const markup = renderToStaticMarkup(
+      <HomeView
+        errorMessage={null}
+        home={{
+          workspaces: [],
+          resume_candidates: [],
+          updated_at: "2026-03-27T05:22:00Z",
+        }}
+        isLoading={false}
+        isSubmitting={false}
+        onCreateWorkspace={() => {}}
+        onSelectedWorkspaceIdChange={() => {}}
+        onWorkspaceNameChange={() => {}}
+        selectedWorkspaceId=""
+        statusMessage={null}
+        workspaceName=""
+      />,
+    );
+
+    expect(markup).toContain("No workspace selected");
+    expect(markup).toContain("Create a workspace to start a chat from Home.");
+    expect(markup).toContain("No workspaces yet");
+    expect(markup).not.toContain('href="/chat?workspaceId=');
   });
 });

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-167-home-shell-resume](./archive/issue-167-home-shell-resume/README.md)
 - [issue-166-request-detail-recovery](./archive/issue-166-request-detail-recovery/README.md)
 - [issue-165-thread-first-shell](./archive/issue-165-thread-first-shell/README.md)
 - [issue-164-ui-state-matrix](./archive/issue-164-ui-state-matrix/README.md)

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-167-home-shell-resume](./issue-167-home-shell-resume/README.md)
 - [issue-150-ngrok-sse-validation](./issue-150-ngrok-sse-validation/README.md)
 - [issue-158-post-start-sendability](./issue-158-post-start-sendability/README.md)
 - [app_server_behavior_validation](./app_server_behavior_validation/README.md)

--- a/tasks/archive/issue-167-home-shell-resume/README.md
+++ b/tasks/archive/issue-167-home-shell-resume/README.md
@@ -1,0 +1,70 @@
+# Issue 167: Home Shell Resume
+
+## Purpose
+
+Rework Home and workspace selection so the app shell exposes current workspace context, compact workspace switching, high-priority resume entrypoints, and first-input thread start without returning to a card-heavy workspace destination.
+
+## Primary issue
+
+- Issue: [#167 Phase 4B follow-up 4: Rework Home and workspace switcher as app-shell resume entrypoints](https://github.com/tsukushibito/codex-webui/issues/167)
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`, section 5.3
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`, sections 18.2, 18.3, 18.5, and 18.6
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`, sections 4.3, 4.4, and 7
+- `docs/specs/codex_webui_public_api_v0_9.md`, sections 6.8, 7.8, 8.1, and 9.3
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Make Home prioritize resume candidates and high-priority thread/workspace signals.
+- Present the current workspace as compact app-shell context rather than a permanently expanded workspace tree.
+- Provide a compact workspace switcher path from Home.
+- Keep `Ask Codex` tied to the selected workspace and the first-input start route.
+- Add focused route, data, and component tests for resume ordering, workspace switching, and high-priority workspace/thread cues.
+
+## Exit criteria
+
+- Home leads directly to workspace selection, first-input thread start, or high-priority thread resume.
+- Current workspace context is visible without dominating Home as a workspace-card grid.
+- Mobile users can reach the most relevant resume target without first navigating through a card-heavy workspace destination.
+- Focused tests cover resume candidates, compact workspace selection, and high-priority workspace/thread signals.
+- Local validation for the touched `frontend-bff` surface passes before pre-push validation.
+
+## Work plan
+
+- Inspect current Home data shape, Home client state, and Home view composition.
+- Adjust Home data/view-model handling only where the existing public v0.9 Home aggregate supports the UI.
+- Recompose `HomeView` and `HomePageClient` around selected workspace context, resume entrypoints, and compact switching.
+- Update focused tests before broad validation.
+- Run targeted `frontend-bff` checks, then hand off to dedicated pre-push validation.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-21T12-10-24Z-issue-167-close/events.ndjson`
+- Sprint evaluator verdict: `approved`
+- Dedicated pre-push validation gate: `passed`
+- Validation evidence:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `npm test`
+  - `npm run build`
+  - `npm run test:e2e -- e2e/chat-flow.spec.ts`
+  - `npm run test:e2e -- e2e/chat-flow.runtime.spec.ts`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-167-home-shell-resume`
+- Active worktree: `.worktrees/issue-167-home-shell-resume`
+- Active PR: `None`
+- Notes:
+  - Home now presents a compact current-workspace app-shell context, closed-by-default workspace switcher, top resume entrypoint, and workspace-scoped `Ask Codex` first-input path.
+  - Focused unit/component and desktop/mobile Playwright coverage passed for the Home-to-chat first-input flow.
+  - Completion retrospective: package exit criteria are satisfied locally; Issue close remains blocked until the branch is committed, pushed, reviewed/merged to `main`, parent checkout is synced, and the worktree is removed.
+  - Workflow note: the worktree needed a local ignored `apps/codex-runtime/node_modules` symlink before Playwright could start the runtime webServer.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, dedicated pre-push validation has passed, completion retrospective has run, and handoff notes include validation evidence.


### PR DESCRIPTION
## Summary
- Rework Home into compact current-workspace context with a closed-by-default workspace switcher.
- Add top resume entrypoint and workspace-scoped `Ask Codex` first-input navigation.
- Update Home unit/component tests and desktop/mobile Playwright flows.
- Archive the completed Issue #167 task package.

Closes #167

## Validation
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test`
- `npm run build`
- `npm run test:e2e -- e2e/chat-flow.spec.ts`
- `npm run test:e2e -- e2e/chat-flow.runtime.spec.ts`
