### PR TITLE
feat(frontend-bff): retire legacy public route surfaces

### DIFF
--- a/apps/frontend-bff/app/api/v1/approvals/[approvalId]/approve/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/[approvalId]/approve/route.ts
@@ -1,6 +1,5 @@
-import { approveApproval } from "../../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
 
-export async function POST(request: Request, context: { params: Promise<{ approvalId: string }> }) {
-  const { approvalId } = await context.params;
-  return approveApproval(request, approvalId);
+export function POST() {
+  return retiredLegacyRouteResponse("approvals");
 }

--- a/apps/frontend-bff/app/api/v1/approvals/[approvalId]/deny/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/[approvalId]/deny/route.ts
@@ -1,6 +1,5 @@
-import { denyApproval } from "../../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
 
-export async function POST(request: Request, context: { params: Promise<{ approvalId: string }> }) {
-  const { approvalId } = await context.params;
-  return denyApproval(request, approvalId);
+export function POST() {
+  return retiredLegacyRouteResponse("approvals");
 }

--- a/apps/frontend-bff/app/api/v1/approvals/[approvalId]/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/[approvalId]/route.ts
@@ -1,6 +1,5 @@
-import { getApproval } from "../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../src/retired-routes";
 
-export async function GET(request: Request, context: { params: Promise<{ approvalId: string }> }) {
-  const { approvalId } = await context.params;
-  return getApproval(request, approvalId);
+export function GET() {
+  return retiredLegacyRouteResponse("approvals");
 }

--- a/apps/frontend-bff/app/api/v1/approvals/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/route.ts
@@ -1,5 +1,5 @@
-import { listApprovals } from "../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../src/retired-routes";
 
-export async function GET(request: Request) {
-  return listApprovals(request);
+export function GET() {
+  return retiredLegacyRouteResponse("approvals");
 }

--- a/apps/frontend-bff/app/api/v1/approvals/stream/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/stream/route.ts
@@ -1,8 +1,8 @@
-import { getApprovalStream } from "../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../src/retired-routes";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(request: Request) {
-  return getApprovalStream(request);
+export function GET() {
+  return retiredLegacyRouteResponse("approvals");
 }

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/events/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/events/route.ts
@@ -1,6 +1,5 @@
-import { listEvents } from "../../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
 
-export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = await context.params;
-  return listEvents(request, sessionId);
+export function GET() {
+  return retiredLegacyRouteResponse("sessions");
 }

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/messages/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/messages/route.ts
@@ -1,11 +1,9 @@
-import { listMessages, postMessage } from "../../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
 
-export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = await context.params;
-  return listMessages(request, sessionId);
+export function GET() {
+  return retiredLegacyRouteResponse("sessions");
 }
 
-export async function POST(request: Request, context: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = await context.params;
-  return postMessage(request, sessionId);
+export function POST() {
+  return retiredLegacyRouteResponse("sessions");
 }

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/route.ts
@@ -1,6 +1,5 @@
-import { getSession } from "../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../src/retired-routes";
 
-export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = await context.params;
-  return getSession(request, sessionId);
+export function GET() {
+  return retiredLegacyRouteResponse("sessions");
 }

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/start/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/start/route.ts
@@ -1,6 +1,5 @@
-import { startSession } from "../../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
 
-export async function POST(request: Request, context: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = await context.params;
-  return startSession(request, sessionId);
+export function POST() {
+  return retiredLegacyRouteResponse("sessions");
 }

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stop/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stop/route.ts
@@ -1,6 +1,5 @@
-import { stopSession } from "../../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
 
-export async function POST(request: Request, context: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = await context.params;
-  return stopSession(request, sessionId);
+export function POST() {
+  return retiredLegacyRouteResponse("sessions");
 }

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stream/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stream/route.ts
@@ -1,9 +1,8 @@
-import { getSessionStream } from "../../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = await context.params;
-  return getSessionStream(request, sessionId);
+export function GET() {
+  return retiredLegacyRouteResponse("sessions");
 }

--- a/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/sessions/route.ts
+++ b/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/sessions/route.ts
@@ -1,14 +1,9 @@
-import { createSession, listSessions } from "../../../../../../src/handlers";
+import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
 
-export async function GET(request: Request, context: { params: Promise<{ workspaceId: string }> }) {
-  const { workspaceId } = await context.params;
-  return listSessions(request, workspaceId);
+export function GET() {
+  return retiredLegacyRouteResponse("sessions");
 }
 
-export async function POST(
-  request: Request,
-  context: { params: Promise<{ workspaceId: string }> },
-) {
-  const { workspaceId } = await context.params;
-  return createSession(request, workspaceId);
+export function POST() {
+  return retiredLegacyRouteResponse("sessions");
 }

--- a/apps/frontend-bff/e2e/helpers/browser-mocks.ts
+++ b/apps/frontend-bff/e2e/helpers/browser-mocks.ts
@@ -483,7 +483,7 @@ export async function mockApprovalFlow(page: Page) {
                 occurred_at: resolvedAt,
                 kind: "approval.resolved",
                 payload: {
-                  summary: `Approval ${resolution}.`,
+                  summary: `Latest request: ${resolution}`,
                 },
               },
             ]),
@@ -604,84 +604,6 @@ export async function mockApprovalFlow(page: Page) {
           change_ticket: "CHG-93",
         },
       });
-    }
-
-    if (pathname === "/api/v1/approvals" && request.method() === "GET") {
-      return json(route, {
-        items:
-          resolution === "pending"
-            ? [
-                {
-                  approval_id: "apr_001",
-                  session_id: "thread_001",
-                  workspace_id: "ws_alpha",
-                  status: "pending",
-                  resolution: null,
-                  approval_category: "external_side_effect",
-                  title: "Run deployment",
-                  description: "Apply the prepared deployment plan.",
-                  requested_at: requestedAt,
-                  resolved_at: null,
-                },
-              ]
-            : [],
-        next_cursor: null,
-        has_more: false,
-      });
-    }
-
-    if (pathname === "/api/v1/approvals/apr_001" && request.method() === "GET") {
-      return json(route, {
-        approval_id: "apr_001",
-        session_id: "thread_001",
-        workspace_id: "ws_alpha",
-        status: resolution === "pending" ? "pending" : resolution,
-        resolution: resolution === "pending" ? null : resolution,
-        approval_category: "external_side_effect",
-        title: "Run deployment",
-        description: "Apply the prepared deployment plan.",
-        requested_at: requestedAt,
-        resolved_at: resolution === "pending" ? null : resolvedAt,
-        operation_summary: "Deploy the latest checked-in build to staging.",
-        context: {
-          environment: "staging",
-          change_ticket: "CHG-93",
-        },
-      });
-    }
-
-    if (pathname === "/api/v1/approvals/apr_001/approve" && request.method() === "POST") {
-      resolution = "approved";
-      return json(
-        route,
-        {
-          request: {
-            request_id: "req_001",
-            status: "resolved",
-            decision: "approved",
-            responded_at: resolvedAt,
-          },
-          thread: currentThread(),
-        },
-        200,
-      );
-    }
-
-    if (pathname === "/api/v1/approvals/apr_001/deny" && request.method() === "POST") {
-      resolution = "denied";
-      return json(
-        route,
-        {
-          request: {
-            request_id: "req_001",
-            status: "resolved",
-            decision: "denied",
-            responded_at: resolvedAt,
-          },
-          thread: currentThread(),
-        },
-        200,
-      );
     }
 
     if (pathname === "/api/v1/requests/req_001/response" && request.method() === "POST") {

--- a/apps/frontend-bff/src/browser-state-matrix.ts
+++ b/apps/frontend-bff/src/browser-state-matrix.ts
@@ -34,7 +34,7 @@ export interface BrowserCriticalStateMatrixEntry {
 
 export interface BrowserAdjacentCompatibilityBehavior {
   route_family: string;
-  classification: "non_browser_critical_compatibility";
+  classification: "retired_non_browser_critical_compatibility";
   follow_up_issue: 168;
   reason: string;
 }
@@ -166,16 +166,16 @@ export const browserCriticalStateMatrix = [
 export const browserAdjacentCompatibilityBehaviors = [
   {
     route_family: "/api/v1/workspaces/{workspace_id}/sessions and /api/v1/sessions/{session_id}/*",
-    classification: "non_browser_critical_compatibility",
+    classification: "retired_non_browser_critical_compatibility",
     follow_up_issue: 168,
     reason:
-      "Legacy session route behavior remains available but is outside the browser-critical v0.9 matrix.",
+      "Legacy session route behavior is retired and quarantined outside the browser-critical v0.9 matrix.",
   },
   {
     route_family: "/api/v1/approvals*",
-    classification: "non_browser_critical_compatibility",
+    classification: "retired_non_browser_critical_compatibility",
     follow_up_issue: 168,
     reason:
-      "Standalone approval route behavior remains available but request helpers are the browser-critical v0.9 surface.",
+      "Standalone approval route behavior is retired and quarantined; request helpers are the browser-critical v0.9 surface.",
   },
 ] as const satisfies readonly BrowserAdjacentCompatibilityBehavior[];

--- a/apps/frontend-bff/src/retired-routes.ts
+++ b/apps/frontend-bff/src/retired-routes.ts
@@ -1,0 +1,25 @@
+import { errorResponse } from "./errors";
+
+type RetiredLegacyRouteFamily = "approvals" | "sessions";
+
+const replacementEndpoints = [
+  "/api/v1/workspaces/{workspace_id}/threads",
+  "/api/v1/threads/{thread_id}",
+  "/api/v1/threads/{thread_id}/view",
+  "/api/v1/threads/{thread_id}/pending_request",
+  "/api/v1/requests/{request_id}",
+  "/api/v1/requests/{request_id}/response",
+];
+
+export function retiredLegacyRouteResponse(routeFamily: RetiredLegacyRouteFamily) {
+  return errorResponse(410, {
+    error: {
+      code: "legacy_route_retired",
+      message: `Legacy ${routeFamily} routes are retired; use v0.9 thread and request endpoints instead.`,
+      details: {
+        route_family: routeFamily,
+        replacement_endpoints: replacementEndpoints,
+      },
+    },
+  });
+}

--- a/apps/frontend-bff/tests/browser-state-matrix.test.ts
+++ b/apps/frontend-bff/tests/browser-state-matrix.test.ts
@@ -158,11 +158,13 @@ describe("browser-critical state matrix", () => {
     expect(matrixEntry("request_response").request_kind_values).toContain("approval");
   });
 
-  it("marks legacy route families as compatibility behavior for follow-up 168", () => {
+  it("marks legacy route families as retired quarantined compatibility behavior for follow-up 168", () => {
     expect(
       browserAdjacentCompatibilityBehaviors.every(
         (behavior) =>
-          behavior.classification === "non_browser_critical_compatibility" &&
+          behavior.classification === "retired_non_browser_critical_compatibility" &&
+          behavior.reason.includes("retired") &&
+          behavior.reason.includes("quarantined") &&
           behavior.follow_up_issue === 168,
       ),
     ).toBe(true);

--- a/apps/frontend-bff/tests/routes.test.ts
+++ b/apps/frontend-bff/tests/routes.test.ts
@@ -1,27 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import * as approvalActionApproveRoute from "../app/api/v1/approvals/[approvalId]/approve/route";
+import * as approvalActionDenyRoute from "../app/api/v1/approvals/[approvalId]/deny/route";
+import * as approvalDetailRoute from "../app/api/v1/approvals/[approvalId]/route";
+import * as approvalListRoute from "../app/api/v1/approvals/route";
+import * as approvalStreamRoute from "../app/api/v1/approvals/stream/route";
+import * as sessionEventsRoute from "../app/api/v1/sessions/[sessionId]/events/route";
+import * as sessionMessagesRoute from "../app/api/v1/sessions/[sessionId]/messages/route";
+import * as sessionDetailRoute from "../app/api/v1/sessions/[sessionId]/route";
+import * as sessionStartRoute from "../app/api/v1/sessions/[sessionId]/start/route";
+import * as sessionStopRoute from "../app/api/v1/sessions/[sessionId]/stop/route";
+import * as sessionStreamRoute from "../app/api/v1/sessions/[sessionId]/stream/route";
+import * as workspaceSessionsRoute from "../app/api/v1/workspaces/[workspaceId]/sessions/route";
 import {
-  approveApproval,
-  createSession,
-  getApproval,
-  getApprovalStream,
   getHome,
   getNotificationsStream,
   getPendingRequest,
   getRequestDetail,
-  getSessionStream,
   getThread,
   getThreadStream,
   getThreadView,
   getTimeline,
-  listEvents,
   listThreads,
   listWorkspaces,
   postRequestResponse,
   postThreadInput,
   postThreadInterrupt,
   postWorkspaceInput,
-  stopSession,
 } from "../src/handlers";
 
 function jsonResponse(body: unknown, status = 200) {
@@ -1087,442 +1092,78 @@ describe("frontend-bff route handlers", () => {
     });
   });
 
-  it("derives can_start from the workspace active session after session creation", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse(
-          {
-            session_id: "thread_002",
-            workspace_id: "ws_alpha",
-            title: "Fix build error",
-            status: "created",
-            created_at: "2026-03-27T05:12:34Z",
-            updated_at: "2026-03-27T05:12:34Z",
-            started_at: null,
-            last_message_at: null,
-            active_approval_id: null,
-            current_turn_id: null,
-            app_session_overlay_state: "open",
-          },
-          201,
-        ),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          workspace_id: "ws_alpha",
-          workspace_name: "alpha",
-          directory_name: "alpha",
-          created_at: "2026-03-27T05:12:34Z",
-          updated_at: "2026-03-27T05:22:00Z",
-          active_session_id: "thread_001",
-          active_session_summary: {
-            session_id: "thread_001",
-            status: "running",
-            last_message_at: "2026-03-27T05:21:40Z",
-          },
-          pending_approval_count: 0,
-        }),
-      );
+  it("returns retired quarantine envelopes for legacy session route modules", async () => {
+    const routes = [
+      workspaceSessionsRoute.GET,
+      workspaceSessionsRoute.POST,
+      sessionDetailRoute.GET,
+      sessionStartRoute.POST,
+      sessionStopRoute.POST,
+      sessionEventsRoute.GET,
+      sessionMessagesRoute.GET,
+      sessionMessagesRoute.POST,
+      sessionStreamRoute.GET,
+    ];
 
-    const response = await createSession(
-      new Request("http://localhost/api/v1/workspaces/ws_alpha/sessions", {
-        method: "POST",
-        body: JSON.stringify({
-          title: "Fix build error",
-        }),
-      }),
-      "ws_alpha",
-    );
+    for (const route of routes) {
+      const response = route();
 
-    expect(response.status).toBe(201);
-    expect(await response.json()).toMatchObject({
-      session_id: "thread_002",
-      status: "created",
-      can_send_message: false,
-      can_start: false,
-      can_stop: false,
-    });
+      expect(response.status).toBe(410);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "legacy_route_retired",
+          message:
+            "Legacy sessions routes are retired; use v0.9 thread and request endpoints instead.",
+          details: {
+            route_family: "sessions",
+            replacement_endpoints: [
+              "/api/v1/workspaces/{workspace_id}/threads",
+              "/api/v1/threads/{thread_id}",
+              "/api/v1/threads/{thread_id}/view",
+              "/api/v1/threads/{thread_id}/pending_request",
+              "/api/v1/requests/{request_id}",
+              "/api/v1/requests/{request_id}/response",
+            ],
+          },
+        },
+      });
+    }
+    expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("maps stop results and canceled approvals to the public shape", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse({
-          session: {
-            session_id: "thread_001",
-            workspace_id: "ws_alpha",
-            title: "Fix build error",
-            status: "stopped",
-            created_at: "2026-03-27T05:12:34Z",
-            updated_at: "2026-03-27T05:24:00Z",
-            started_at: "2026-03-27T05:13:00Z",
-            last_message_at: "2026-03-27T05:23:00Z",
-            active_approval_id: null,
-            current_turn_id: "turn_009",
-            app_session_overlay_state: "closed",
-          },
-          canceled_approval: {
-            approval_id: "apr_001",
-            session_id: "thread_001",
-            workspace_id: "ws_alpha",
-            status: "canceled",
-            resolution: "canceled",
-            approval_category: "external_side_effect",
-            summary: "Run git push",
-            reason: "Codex requests permission to push changes to remote.",
-            operation_summary: "git push origin main",
-            context: null,
-            created_at: "2026-03-27T05:18:00Z",
-            resolved_at: "2026-03-27T05:24:00Z",
-            native_request_kind: "approval_request",
-          },
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          workspace_id: "ws_alpha",
-          workspace_name: "alpha",
-          directory_name: "alpha",
-          created_at: "2026-03-27T05:12:34Z",
-          updated_at: "2026-03-27T05:24:00Z",
-          active_session_id: null,
-          active_session_summary: null,
-          pending_approval_count: 0,
-        }),
-      );
+  it("returns retired quarantine envelopes for standalone approval route modules", async () => {
+    const routes = [
+      approvalListRoute.GET,
+      approvalDetailRoute.GET,
+      approvalActionApproveRoute.POST,
+      approvalActionDenyRoute.POST,
+      approvalStreamRoute.GET,
+    ];
 
-    const response = await stopSession(
-      new Request("http://localhost/api/v1/sessions/thread_001/stop", {
-        method: "POST",
-      }),
-      "thread_001",
-    );
+    for (const route of routes) {
+      const response = route();
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      session: {
-        session_id: "thread_001",
-        workspace_id: "ws_alpha",
-        title: "Fix build error",
-        status: "stopped",
-        created_at: "2026-03-27T05:12:34Z",
-        updated_at: "2026-03-27T05:24:00Z",
-        started_at: "2026-03-27T05:13:00Z",
-        last_message_at: "2026-03-27T05:23:00Z",
-        active_approval_id: null,
-        can_send_message: false,
-        can_start: false,
-        can_stop: false,
-      },
-      canceled_approval: {
-        approval_id: "apr_001",
-        session_id: "thread_001",
-        workspace_id: "ws_alpha",
-        status: "canceled",
-        resolution: "canceled",
-        approval_category: "external_side_effect",
-        title: "Run git push",
-        description: "Codex requests permission to push changes to remote.",
-        requested_at: "2026-03-27T05:18:00Z",
-        resolved_at: "2026-03-27T05:24:00Z",
-      },
-    });
-  });
-
-  it("maps approval detail and approval action responses to public fields", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        approval_id: "apr_001",
-        session_id: "thread_001",
-        workspace_id: "ws_alpha",
-        status: "pending",
-        resolution: null,
-        approval_category: "external_side_effect",
-        summary: "Run git push",
-        reason: "Codex requests permission to push changes to remote.",
-        operation_summary: "git push origin main",
-        context: {
-          command: "git push origin main",
-        },
-        created_at: "2026-03-27T05:18:00Z",
-        resolved_at: null,
-        native_request_kind: "approval_request",
-      }),
-    );
-
-    const detailResponse = await getApproval(
-      new Request("http://localhost/api/v1/approvals/apr_001"),
-      "apr_001",
-    );
-
-    expect(detailResponse.status).toBe(200);
-    expect(await detailResponse.json()).toEqual({
-      approval_id: "apr_001",
-      session_id: "thread_001",
-      workspace_id: "ws_alpha",
-      status: "pending",
-      resolution: null,
-      approval_category: "external_side_effect",
-      title: "Run git push",
-      description: "Codex requests permission to push changes to remote.",
-      operation_summary: "git push origin main",
-      requested_at: "2026-03-27T05:18:00Z",
-      resolved_at: null,
-      context: {
-        command: "git push origin main",
-      },
-    });
-
-    fetchMock.mockReset();
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse({
-          approval: {
-            approval_id: "apr_001",
-            session_id: "thread_001",
-            workspace_id: "ws_alpha",
-            status: "approved",
-            resolution: "approved",
-            approval_category: "external_side_effect",
-            summary: "Run git push",
-            reason: "Codex requests permission to push changes to remote.",
-            operation_summary: "git push origin main",
-            context: {
-              command: "git push origin main",
-            },
-            created_at: "2026-03-27T05:18:00Z",
-            resolved_at: "2026-03-27T05:19:00Z",
-            native_request_kind: "approval_request",
-          },
-          session: {
-            session_id: "thread_001",
-            workspace_id: "ws_alpha",
-            title: "Fix build error",
-            status: "running",
-            created_at: "2026-03-27T05:12:34Z",
-            updated_at: "2026-03-27T05:19:00Z",
-            started_at: "2026-03-27T05:13:00Z",
-            last_message_at: "2026-03-27T05:18:00Z",
-            active_approval_id: null,
-            current_turn_id: "turn_009",
-            app_session_overlay_state: "open",
-          },
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          workspace_id: "ws_alpha",
-          workspace_name: "alpha",
-          directory_name: "alpha",
-          created_at: "2026-03-27T05:12:34Z",
-          updated_at: "2026-03-27T05:19:00Z",
-          active_session_id: "thread_001",
-          active_session_summary: {
-            session_id: "thread_001",
-            status: "running",
-            last_message_at: "2026-03-27T05:18:00Z",
-          },
-          pending_approval_count: 0,
-        }),
-      );
-
-    const actionResponse = await approveApproval(
-      new Request("http://localhost/api/v1/approvals/apr_001/approve", {
-        method: "POST",
-      }),
-      "apr_001",
-    );
-
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      1,
-      "http://127.0.0.1:3001/api/v1/approvals/apr_001/resolve",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          resolution: "approved",
-        }),
-      }),
-    );
-
-    expect(actionResponse.status).toBe(200);
-    expect(await actionResponse.json()).toEqual({
-      approval: {
-        approval_id: "apr_001",
-        session_id: "thread_001",
-        workspace_id: "ws_alpha",
-        status: "approved",
-        resolution: "approved",
-        approval_category: "external_side_effect",
-        title: "Run git push",
-        description: "Codex requests permission to push changes to remote.",
-        requested_at: "2026-03-27T05:18:00Z",
-        resolved_at: "2026-03-27T05:19:00Z",
-      },
-      session: {
-        session_id: "thread_001",
-        workspace_id: "ws_alpha",
-        title: "Fix build error",
-        status: "running",
-        created_at: "2026-03-27T05:12:34Z",
-        updated_at: "2026-03-27T05:19:00Z",
-        started_at: "2026-03-27T05:13:00Z",
-        last_message_at: "2026-03-27T05:18:00Z",
-        active_approval_id: null,
-        can_send_message: false,
-        can_start: false,
-        can_stop: true,
-      },
-    });
-  });
-
-  it("removes native_event_name from public event responses", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        items: [
-          {
-            event_id: "evt_001",
-            session_id: "thread_001",
-            event_type: "approval.requested",
-            sequence: 8,
-            occurred_at: "2026-03-27T05:18:00Z",
-            payload: {
-              approval_id: "apr_001",
-              summary: "Run git push",
-            },
-            native_event_name: "request/started",
-          },
-        ],
-        next_cursor: null,
-        has_more: false,
-      }),
-    );
-
-    const response = await listEvents(
-      new Request("http://localhost/api/v1/sessions/thread_001/events"),
-      "thread_001",
-    );
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      items: [
-        {
-          event_id: "evt_001",
-          session_id: "thread_001",
-          event_type: "approval.requested",
-          sequence: 8,
-          occurred_at: "2026-03-27T05:18:00Z",
-          payload: {
-            approval_id: "apr_001",
-            summary: "Run git push",
+      expect(response.status).toBe(410);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "legacy_route_retired",
+          message:
+            "Legacy approvals routes are retired; use v0.9 thread and request endpoints instead.",
+          details: {
+            route_family: "approvals",
+            replacement_endpoints: [
+              "/api/v1/workspaces/{workspace_id}/threads",
+              "/api/v1/threads/{thread_id}",
+              "/api/v1/threads/{thread_id}/view",
+              "/api/v1/threads/{thread_id}/pending_request",
+              "/api/v1/requests/{request_id}",
+              "/api/v1/requests/{request_id}/response",
+            ],
           },
         },
-      ],
-      next_cursor: null,
-      has_more: false,
-    });
-  });
-
-  it("relays session stream events using the public envelope", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValueOnce(
-      sseResponse([
-        ": connected\n\n",
-        `data: ${JSON.stringify({
-          event_id: "evt_001",
-          session_id: "thread_001",
-          event_type: "message.assistant.delta",
-          sequence: 12,
-          occurred_at: "2026-03-27T05:20:10Z",
-          payload: {
-            message_id: "msg_assistant_003",
-            delta: "Updated the config",
-          },
-          native_event_name: "item/delta",
-        })}\n\n`,
-      ]),
-    );
-
-    const request = new Request("http://localhost/api/v1/sessions/thread_001/stream");
-    const response = await getSessionStream(request, "thread_001");
-
-    expect(response.headers.get("content-type")).toContain("text/event-stream");
-    await expect(response.text()).resolves.toContain(
-      `data: ${JSON.stringify({
-        event_id: "evt_001",
-        session_id: "thread_001",
-        event_type: "message.assistant.delta",
-        sequence: 12,
-        occurred_at: "2026-03-27T05:20:10Z",
-        payload: {
-          message_id: "msg_assistant_003",
-          delta: "Updated the config",
-        },
-      })}`,
-    );
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:3001/api/v1/sessions/thread_001/stream",
-      expect.objectContaining({
-        headers: {
-          accept: "text/event-stream",
-        },
-        cache: "no-store",
-        signal: request.signal,
-      }),
-    );
-  });
-
-  it("maps approval stream payloads from summary to title", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValueOnce(
-      sseResponse([
-        `data: ${JSON.stringify({
-          event_id: "evt_apr_001",
-          session_id: "thread_001",
-          event_type: "approval.requested",
-          occurred_at: "2026-03-27T05:18:00Z",
-          payload: {
-            approval_id: "apr_001",
-            workspace_id: "ws_alpha",
-            summary: "Run git push",
-            approval_category: "external_side_effect",
-          },
-          native_event_name: "request/started",
-        })}\n\n`,
-      ]),
-    );
-
-    const request = new Request("http://localhost/api/v1/approvals/stream");
-    const response = await getApprovalStream(request);
-
-    expect(response.headers.get("content-type")).toContain("text/event-stream");
-    await expect(response.text()).resolves.toContain(
-      `data: ${JSON.stringify({
-        event_id: "evt_apr_001",
-        session_id: "thread_001",
-        event_type: "approval.requested",
-        occurred_at: "2026-03-27T05:18:00Z",
-        payload: {
-          approval_id: "apr_001",
-          workspace_id: "ws_alpha",
-          title: "Run git push",
-          approval_category: "external_side_effect",
-        },
-      })}`,
-    );
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:3001/api/v1/approvals/stream",
-      expect.objectContaining({
-        headers: {
-          accept: "text/event-stream",
-        },
-        cache: "no-store",
-        signal: request.signal,
-      }),
-    );
+      });
+    }
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("relays thread stream events on the v0.9 thread stream path", async () => {

--- a/artifacts/issue-168-legacy-surface-validation/360-no-horizontal-scroll-measurements.json
+++ b/artifacts/issue-168-legacy-surface-validation/360-no-horizontal-scroll-measurements.json
@@ -1,0 +1,32 @@
+{
+  "measuredAt": "2026-04-22T05:44:25.950Z",
+  "baseURL": "http://127.0.0.1:3000",
+  "cssViewportWidth": 360,
+  "measurements": [
+    {
+      "name": "Home",
+      "path": "/",
+      "viewportWidth": 360,
+      "documentElementClientWidth": 360,
+      "documentElementScrollWidth": 360,
+      "passed": true
+    },
+    {
+      "name": "Chat thread",
+      "path": "/chat?workspaceId=ws_alpha&threadId=thread_001",
+      "viewportWidth": 360,
+      "documentElementClientWidth": 360,
+      "documentElementScrollWidth": 360,
+      "passed": true
+    },
+    {
+      "name": "Chat request detail",
+      "path": "/chat?workspaceId=ws_alpha&threadId=thread_request",
+      "viewportWidth": 360,
+      "documentElementClientWidth": 360,
+      "documentElementScrollWidth": 360,
+      "passed": true
+    }
+  ],
+  "passed": true
+}

--- a/artifacts/issue-168-legacy-surface-validation/browser-validation-2026-04-22.md
+++ b/artifacts/issue-168-legacy-surface-validation/browser-validation-2026-04-22.md
@@ -1,0 +1,217 @@
+# Issue #168 Browser Validation Evidence - 2026-04-22
+
+## Worktree and status
+
+- Worktree: `/workspace/.worktrees/issue-168-legacy-surface-validation`
+- Branch: `issue-168-legacy-surface-validation`
+- Status at evidence start: existing implementation changes were present in `apps/frontend-bff/**`, `tasks/README.md`, `apps/frontend-bff/src/retired-routes.ts`, and `tasks/issue-168-legacy-surface-validation/`. This evidence-capture slice intentionally edited only files under `artifacts/issue-168-legacy-surface-validation/` plus the approved task README sections.
+
+Commands:
+
+```text
+pwd
+/workspace/.worktrees/issue-168-legacy-surface-validation
+
+git branch --show-current
+issue-168-legacy-surface-validation
+
+git status --short
+ M apps/frontend-bff/app/api/v1/approvals/[approvalId]/approve/route.ts
+ M apps/frontend-bff/app/api/v1/approvals/[approvalId]/deny/route.ts
+ M apps/frontend-bff/app/api/v1/approvals/[approvalId]/route.ts
+ M apps/frontend-bff/app/api/v1/approvals/route.ts
+ M apps/frontend-bff/app/api/v1/approvals/stream/route.ts
+ M apps/frontend-bff/app/api/v1/sessions/[sessionId]/events/route.ts
+ M apps/frontend-bff/app/api/v1/sessions/[sessionId]/messages/route.ts
+ M apps/frontend-bff/app/api/v1/sessions/[sessionId]/route.ts
+ M apps/frontend-bff/app/api/v1/sessions/[sessionId]/start/route.ts
+ M apps/frontend-bff/app/api/v1/sessions/[sessionId]/stop/route.ts
+ M apps/frontend-bff/app/api/v1/sessions/[sessionId]/stream/route.ts
+ M apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/sessions/route.ts
+ M apps/frontend-bff/e2e/helpers/browser-mocks.ts
+ M apps/frontend-bff/src/browser-state-matrix.ts
+ M apps/frontend-bff/tests/browser-state-matrix.test.ts
+ M apps/frontend-bff/tests/routes.test.ts
+ M tasks/README.md
+?? apps/frontend-bff/src/retired-routes.ts
+?? tasks/issue-168-legacy-surface-validation/
+```
+
+## Evidence matrix
+
+| Issue #168 behavior | Desktop coverage | Mobile coverage | Evidence and observed assertions |
+| --- | --- | --- | --- |
+| First-input start | Passed in `e2e/chat-flow.spec.ts` and `e2e/chat-flow.runtime.spec.ts`. | Passed in `e2e/chat-flow.spec.ts` and `e2e/chat-flow.runtime.spec.ts`. | Mocked flow fills `First input`, enables `Start new thread`, shows `Started thread thread_001.`, and renders heading `thread_001`. Runtime flow starts a live runtime-backed thread, captures a non-empty thread id, and observes `/api/v1/threads/{threadId}/stream`. |
+| Follow-up input | Passed in `e2e/chat-flow.spec.ts` and `e2e/chat-flow.runtime.spec.ts`. | Passed in `e2e/chat-flow.spec.ts` and `e2e/chat-flow.runtime.spec.ts`. | Mocked flow fills `Send follow-up input`, enables `Send reply`, shows `Input accepted. Waiting for thread updates.`, and later renders assistant text `Here is the explanation.` Runtime flow reloads/reconnects, fills follow-up input, sees the accepted state, and verifies the user article contains `Please explain the diff.` |
+| Pending request response | Passed in `e2e/approval-flow.spec.ts` and `tests/chat-page-client.test.tsx`. | Passed in `e2e/approval-flow.spec.ts`; component coverage is viewport-independent jsdom. | `approval-flow.spec.ts` opens `/chat?workspaceId=ws_alpha&threadId=thread_001`, renders `.request-detail-card`, sees `Apply the prepared deployment plan.`, clicks `Approve request` and `Deny request`, then sees `Latest request: approved` or `Latest request: denied`. `tests/chat-page-client.test.tsx` verifies `respondToPendingRequest` is called from thread context with `req_001`, not from the approvals page. |
+| Interrupt | Passed in `e2e/chat-flow.spec.ts` and `e2e/chat-flow.runtime.spec.ts`. | Passed in `e2e/chat-flow.spec.ts` and `e2e/chat-flow.runtime.spec.ts`. | Mocked flow verifies `Interrupt thread` is enabled while running, clicks it, sees `Interrupt requested.` and `Thread interrupted.`, then sends another follow-up. Runtime flow checks the interrupt button and either submits an interrupt when enabled or verifies it is disabled after the runtime already returned to waiting input. |
+| Reload/reconnect | Passed in `e2e/chat-flow.runtime.spec.ts`. | Passed in `e2e/chat-flow.runtime.spec.ts`. | Runtime flow records `/api/v1/threads/{threadId}/view` and `/api/v1/threads/{threadId}/stream` request counts, reloads `/chat?workspaceId={workspaceId}`, verifies the selected thread heading returns, and asserts both view reacquisition and stream reconnect counts increase. |
+| Background high-priority promotion | Covered by `tests/home-page-client.test.tsx` and `tests/chat-page-client.test.tsx`. | Component coverage is viewport-independent jsdom. | Home test observes `EventSource` URL `/api/v1/notifications/stream`, emits `approval.requested` with `high_priority: true`, verifies `fetchHomeData` is called twice, and checks text `High-priority background thread needs attention.`, `Resume here first`, and `Needs your response`. Chat test emits a background `approval.requested` notification and verifies `High-priority background thread needs attention.` appears. |
+| No horizontal scroll | Existing e2e assertions passed in `e2e/chat-flow.spec.ts` and `e2e/approval-flow.spec.ts`; explicit 360 CSS px measurements passed. | Existing e2e assertions passed in mobile `e2e/chat-flow.spec.ts` and `e2e/approval-flow.spec.ts`; explicit 360 CSS px measurements passed. | Existing helper asserts `document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1`. Explicit measurements are recorded below and in `360-no-horizontal-scroll-measurements.json`. |
+
+## Required local validation
+
+All required local commands were run from the repo root of the active worktree.
+
+```text
+npm run test --prefix apps/frontend-bff -- tests/chat-page-client.test.tsx tests/home-page-client.test.tsx
+Result: passed
+Files: 2 passed
+Tests: 14 passed
+Duration: 8.73s
+```
+
+```text
+npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts --project=desktop-chromium --reporter=line
+Result: passed
+Tests: 3 passed
+Duration: 1.7m
+```
+
+```text
+npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts --project=mobile-chromium --reporter=line
+Result: passed
+Tests: 3 passed
+Duration: 1.4m
+```
+
+```text
+npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line
+Result: passed
+Tests: 1 passed
+Duration: 2.0m
+```
+
+```text
+npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line
+Result: passed
+Tests: 1 passed
+Duration: 2.1m
+```
+
+## 360 CSS px no-horizontal-scroll measurements
+
+Measurement command:
+
+```text
+CODEX_WEBUI_RUNTIME_BASE_URL=http://127.0.0.1:3999 npm run dev --prefix apps/frontend-bff -- --hostname 127.0.0.1 --port 3000
+node artifacts/issue-168-legacy-surface-validation/measure-360-no-horizontal-scroll.mjs
+```
+
+The measurement script uses a 360 x 800 CSS pixel Chromium viewport, browser-side API stubs, and a stubbed `EventSource`. It records exact metrics in `360-no-horizontal-scroll-measurements.json`.
+
+| Surface | Path | Viewport width | `documentElement.clientWidth` | `documentElement.scrollWidth` | Result |
+| --- | --- | ---: | ---: | ---: | --- |
+| Home | `/` | 360 | 360 | 360 | Pass |
+| Chat thread | `/chat?workspaceId=ws_alpha&threadId=thread_001` | 360 | 360 | 360 | Pass |
+| Chat request detail | `/chat?workspaceId=ws_alpha&threadId=thread_request` | 360 | 360 | 360 | Pass |
+
+## Ngrok remote-browser smoke
+
+Prerequisite discovery:
+
+```text
+command -v ngrok
+/usr/local/bin/ngrok
+
+ngrok version
+ngrok version 3.38.0
+
+ngrok config check
+ERROR:  stat /home/dev/.config/ngrok/ngrok.yml: no such file or directory
+
+environment check
+NGROK_AUTHTOKEN=present
+NGROK_BASIC_AUTH=present
+PLAYWRIGHT_BASE_URL=missing
+PLAYWRIGHT_HTTP_USERNAME=missing
+PLAYWRIGHT_HTTP_PASSWORD=missing
+
+curl --silent --show-error --fail http://127.0.0.1:4040/api/tunnels
+curl: (7) Failed to connect to 127.0.0.1 port 4040 after 0 ms: Couldn't connect to server
+```
+
+Because `NGROK_AUTHTOKEN` and `NGROK_BASIC_AUTH` were present, the supported launcher path was runnable even though no tunnel was already active.
+
+Launcher command:
+
+```text
+scripts/start-codex-webui.sh --with-ngrok --ngrok-basic-auth="$NGROK_BASIC_AUTH"
+```
+
+Launcher outcome:
+
+```text
+codex-runtime ready at http://127.0.0.1:3001/api/v1/workspaces
+frontend-bff ready at http://127.0.0.1:3000/
+ngrok ready at https://humbly-salute-shredding.ngrok-free.dev
+ngrok Basic Auth: enabled
+```
+
+Remote smoke command:
+
+```text
+PLAYWRIGHT_BASE_URL=https://humbly-salute-shredding.ngrok-free.dev
+PLAYWRIGHT_HTTP_USERNAME="${NGROK_BASIC_AUTH%%:*}"
+PLAYWRIGHT_HTTP_PASSWORD="${NGROK_BASIC_AUTH#*:}"
+node remote browser smoke
+```
+
+Remote smoke result:
+
+```text
+Authenticated browser reached https://humbly-salute-shredding.ngrok-free.dev
+HTTP status: 200
+Visible heading: Home
+Result: passed
+```
+
+Basic Auth boundary check:
+
+```text
+curl unauthenticated status: 401
+curl authenticated status: 200
+```
+
+Additional observation: full `e2e/chat-flow.runtime.spec.ts` was attempted over the ngrok URL for both `mobile-chromium` and `desktop-chromium`. Both attempts reached the remote app but failed waiting for the post-start `Waiting for your input` assertion after the runtime created a pending request. This is not counted as passing full remote runtime workflow coverage; the required ngrok outcome for this slice is the narrower remote-browser smoke above.
+
+## Final scope check
+
+Final command requested by the planner:
+
+```text
+git diff --name-only
+apps/frontend-bff/app/api/v1/approvals/[approvalId]/approve/route.ts
+apps/frontend-bff/app/api/v1/approvals/[approvalId]/deny/route.ts
+apps/frontend-bff/app/api/v1/approvals/[approvalId]/route.ts
+apps/frontend-bff/app/api/v1/approvals/route.ts
+apps/frontend-bff/app/api/v1/approvals/stream/route.ts
+apps/frontend-bff/app/api/v1/sessions/[sessionId]/events/route.ts
+apps/frontend-bff/app/api/v1/sessions/[sessionId]/messages/route.ts
+apps/frontend-bff/app/api/v1/sessions/[sessionId]/route.ts
+apps/frontend-bff/app/api/v1/sessions/[sessionId]/start/route.ts
+apps/frontend-bff/app/api/v1/sessions/[sessionId]/stop/route.ts
+apps/frontend-bff/app/api/v1/sessions/[sessionId]/stream/route.ts
+apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/sessions/route.ts
+apps/frontend-bff/e2e/helpers/browser-mocks.ts
+apps/frontend-bff/src/browser-state-matrix.ts
+apps/frontend-bff/tests/browser-state-matrix.test.ts
+apps/frontend-bff/tests/routes.test.ts
+tasks/README.md
+```
+
+Because the approved evidence files and active task package are currently untracked, `git diff --name-only` reports only tracked pre-existing implementation changes. `git status --short` also reports:
+
+```text
+?? apps/frontend-bff/src/retired-routes.ts
+?? artifacts/issue-168-legacy-surface-validation/
+?? tasks/issue-168-legacy-surface-validation/
+```
+
+Scope result: the overall worktree diff does not stay within this evidence-capture write scope because pre-existing implementation changes are still present. The files intentionally created or edited by this worker are limited to the approved scope:
+
+- `artifacts/issue-168-legacy-surface-validation/browser-validation-2026-04-22.md`
+- `artifacts/issue-168-legacy-surface-validation/measure-360-no-horizontal-scroll.mjs`
+- `artifacts/issue-168-legacy-surface-validation/360-no-horizontal-scroll-measurements.json`
+- `artifacts/issue-168-legacy-surface-validation/ngrok-remote-browser-smoke.json`
+- `tasks/issue-168-legacy-surface-validation/README.md`

--- a/artifacts/issue-168-legacy-surface-validation/measure-360-no-horizontal-scroll.mjs
+++ b/artifacts/issue-168-legacy-surface-validation/measure-360-no-horizontal-scroll.mjs
@@ -1,0 +1,252 @@
+import { chromium } from "../../apps/frontend-bff/node_modules/@playwright/test/index.mjs";
+import { writeFile } from "node:fs/promises";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000";
+const outputPath =
+  process.env.MEASURE_360_OUTPUT ??
+  "artifacts/issue-168-legacy-surface-validation/360-no-horizontal-scroll-measurements.json";
+
+const timestamps = {
+  created: "2026-04-22T13:00:00Z",
+  updated: "2026-04-22T13:01:00Z",
+  requested: "2026-04-22T13:02:00Z",
+};
+
+function json(route, body, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+function threadSummary(threadId, status = "idle") {
+  return {
+    thread_id: threadId,
+    workspace_id: "ws_alpha",
+    native_status: {
+      thread_status: status,
+      active_flags: status === "running" ? ["waiting_on_request"] : [],
+      latest_turn_status: status === "running" ? "running" : "completed",
+    },
+    updated_at: timestamps.updated,
+  };
+}
+
+function threadListItem(threadId, status = "idle") {
+  return {
+    ...threadSummary(threadId, status),
+    current_activity:
+      status === "running"
+        ? { kind: "waiting_on_approval", label: "Approval required" }
+        : { kind: "waiting_on_user_input", label: "Waiting for your input" },
+    badge: status === "running" ? { kind: "approval_required", label: "Approval required" } : null,
+    blocked_cue:
+      status === "running" ? { kind: "approval_required", label: "Needs your response" } : null,
+    resume_cue: {
+      reason_kind: status === "running" ? "waiting_on_approval" : "active_thread",
+      priority_band: status === "running" ? "highest" : "low",
+      label: status === "running" ? "Resume here first" : "Resume here",
+    },
+  };
+}
+
+function threadView(threadId, withRequest = false) {
+  return {
+    thread: threadSummary(threadId, withRequest ? "running" : "idle"),
+    current_activity: withRequest
+      ? { kind: "waiting_on_approval", label: "Approval required" }
+      : { kind: "waiting_on_user_input", label: "Waiting for your input" },
+    pending_request: withRequest
+      ? {
+          request_id: "req_001",
+          thread_id: threadId,
+          turn_id: "turn_001",
+          item_id: "item_001",
+          request_kind: "approval",
+          status: "pending",
+          risk_category: "external_side_effect",
+          summary: "Run deployment",
+          requested_at: timestamps.requested,
+        }
+      : null,
+    latest_resolved_request: null,
+    composer: {
+      accepting_user_input: !withRequest,
+      interrupt_available: withRequest,
+      blocked_by_request: withRequest,
+    },
+    timeline: {
+      items: [
+        {
+          timeline_item_id: "evt_001",
+          thread_id: threadId,
+          turn_id: null,
+          item_id: null,
+          sequence: 1,
+          occurred_at: timestamps.updated,
+          kind: withRequest ? "approval.requested" : "message.assistant.completed",
+          payload: {
+            summary: withRequest ? "Run deployment" : "Thread ready for follow-up input.",
+            content: withRequest ? undefined : "Thread ready for follow-up input.",
+          },
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    },
+  };
+}
+
+async function installBrowserStubs(page) {
+  await page.addInitScript(() => {
+    class MockEventSource {
+      onopen = null;
+      onmessage = null;
+      onerror = null;
+      readyState = 1;
+      withCredentials = false;
+
+      constructor(url) {
+        this.url = url;
+        window.setTimeout(() => this.onopen?.(), 0);
+      }
+
+      close() {}
+    }
+
+    Object.defineProperty(window, "EventSource", {
+      configurable: true,
+      writable: true,
+      value: MockEventSource,
+    });
+  });
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const { pathname } = new URL(request.url());
+
+    if (pathname === "/api/v1/home" && request.method() === "GET") {
+      return json(route, {
+        workspaces: [
+          {
+            workspace_id: "ws_alpha",
+            workspace_name: "alpha",
+            created_at: timestamps.created,
+            updated_at: timestamps.updated,
+            active_session_summary: null,
+            pending_approval_count: 1,
+          },
+        ],
+        resume_candidates: [threadListItem("thread_request", "running")],
+        pending_approval_count: 1,
+        updated_at: timestamps.updated,
+      });
+    }
+
+    if (pathname === "/api/v1/workspaces/ws_alpha/threads" && request.method() === "GET") {
+      return json(route, {
+        items: [threadListItem("thread_001"), threadListItem("thread_request", "running")],
+        next_cursor: null,
+        has_more: false,
+      });
+    }
+
+    if (pathname === "/api/v1/threads/thread_001/view" && request.method() === "GET") {
+      return json(route, threadView("thread_001"));
+    }
+
+    if (pathname === "/api/v1/threads/thread_request/view" && request.method() === "GET") {
+      return json(route, threadView("thread_request", true));
+    }
+
+    if (pathname === "/api/v1/requests/req_001" && request.method() === "GET") {
+      return json(route, {
+        request_id: "req_001",
+        thread_id: "thread_request",
+        turn_id: "turn_001",
+        item_id: "item_001",
+        request_kind: "approval",
+        status: "pending",
+        risk_category: "external_side_effect",
+        summary: "Run deployment",
+        reason: "Apply the prepared deployment plan.",
+        operation_summary: "Deploy the latest checked-in build to staging.",
+        requested_at: timestamps.requested,
+        responded_at: null,
+        decision: null,
+        decision_options: {
+          policy_scope_supported: false,
+          default_policy_scope: "once",
+        },
+        context: {
+          environment: "staging",
+          change_ticket: "CHG-168",
+        },
+      });
+    }
+
+    return route.abort("blockedbyclient");
+  });
+}
+
+async function measure(page, name, path, readyLocator) {
+  await page.goto(`${baseURL}${path}`);
+  await readyLocator(page).waitFor({ timeout: 15_000 });
+  await page.waitForTimeout(250);
+  const metrics = await page.evaluate(() => ({
+    viewportWidth: window.innerWidth,
+    documentElementClientWidth: document.documentElement.clientWidth,
+    documentElementScrollWidth: document.documentElement.scrollWidth,
+  }));
+
+  return {
+    name,
+    path,
+    ...metrics,
+    passed:
+      metrics.viewportWidth === 360 &&
+      metrics.documentElementScrollWidth <= metrics.documentElementClientWidth + 1,
+  };
+}
+
+const browser = await chromium.launch();
+const page = await browser.newPage({
+  viewport: { width: 360, height: 800 },
+  isMobile: true,
+  hasTouch: true,
+  deviceScaleFactor: 3,
+});
+
+try {
+  await installBrowserStubs(page);
+
+  const measurements = [
+    await measure(page, "Home", "/", (nextPage) =>
+      nextPage.getByRole("heading", { name: "Home", exact: true }),
+    ),
+    await measure(page, "Chat thread", "/chat?workspaceId=ws_alpha&threadId=thread_001", (nextPage) =>
+      nextPage.getByRole("heading", { name: "thread_001", exact: true }),
+    ),
+    await measure(
+      page,
+      "Chat request detail",
+      "/chat?workspaceId=ws_alpha&threadId=thread_request",
+      (nextPage) => nextPage.locator(".request-detail-card"),
+    ),
+  ];
+
+  const result = {
+    measuredAt: new Date().toISOString(),
+    baseURL,
+    cssViewportWidth: 360,
+    measurements,
+    passed: measurements.every((entry) => entry.passed),
+  };
+
+  await writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`);
+  console.log(JSON.stringify(result, null, 2));
+  process.exitCode = result.passed ? 0 : 1;
+} finally {
+  await browser.close();
+}

--- a/artifacts/issue-168-legacy-surface-validation/ngrok-remote-browser-smoke.json
+++ b/artifacts/issue-168-legacy-surface-validation/ngrok-remote-browser-smoke.json
@@ -1,0 +1,8 @@
+{
+  "startedAt": "2026-04-22T05:13:33.377Z",
+  "completedAt": "2026-04-22T05:13:34.045Z",
+  "baseURL": "https://humbly-salute-shredding.ngrok-free.dev",
+  "httpStatus": 200,
+  "heading": "Home",
+  "passed": true
+}

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-168-legacy-surface-validation](./archive/issue-168-legacy-surface-validation/README.md)
 - [issue-167-home-shell-resume](./archive/issue-167-home-shell-resume/README.md)
 - [issue-166-request-detail-recovery](./archive/issue-166-request-detail-recovery/README.md)
 - [issue-165-thread-first-shell](./archive/issue-165-thread-first-shell/README.md)

--- a/tasks/archive/issue-168-legacy-surface-validation/README.md
+++ b/tasks/archive/issue-168-legacy-surface-validation/README.md
@@ -1,0 +1,86 @@
+# Issue 168 Legacy Surface Validation
+
+## Purpose
+
+- Retire or explicitly quarantine browser-unused legacy session/approval public surfaces and harden validation for the v0.9 thread-first UI refresh.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/168
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`, section 5.3
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `tasks/archive/issue-164-ui-state-matrix/README.md`
+- `tasks/archive/issue-166-request-detail-recovery/README.md`
+- `tasks/archive/issue-167-home-shell-resume/README.md`
+
+## Scope for this package
+
+- Remove or quarantine browser-unused `sessions` and standalone `approvals` public route behavior in `apps/frontend-bff`.
+- Remove or update route, component, and e2e test fixtures that still enforce the old session/approval worldview as browser-critical behavior.
+- Keep any remaining compatibility behavior explicitly non-browser-critical.
+- Add or harden focused coverage for thread/request browser behavior, including request response from thread context, REST reacquisition, interrupt, and background promotion signals.
+- Capture desktop and mobile validation evidence, including a 360 CSS px no-horizontal-scroll check and ngrok remote-browser smoke where relevant.
+
+## Exit criteria
+
+- Maintained browser workflows do not depend on standalone session/approval public APIs.
+- Remaining legacy compatibility is explicitly quarantined or tracked as non-browser-critical.
+- Focused route/unit/component coverage protects the v0.9 thread/request browser paths.
+- Validation evidence covers desktop and smartphone paths for first-input start, follow-up input, pending request response, interrupt, reload/reconnect, and background promotion.
+- The dedicated pre-push validation gate passes before archive or publish-oriented handoff.
+
+## Work plan
+
+- Audit `apps/frontend-bff` legacy session/approval route handlers, route files, tests, and browser mocks.
+- Remove or quarantine public legacy route handlers and update tests to assert v0.9 thread/request behavior instead of old browser-critical session/approval paths.
+- Extend focused browser route/component coverage for request detail, notification-triggered refresh, REST reacquisition, and mobile layout constraints.
+- Run local validation in the `frontend-bff` app, then capture required browser evidence under `artifacts/`.
+- Update this package with validation evidence and hand off to pre-push validation before archive/publish work.
+
+## Artifacts / evidence
+
+- Browser validation evidence: [`browser-validation-2026-04-22.md`](../../artifacts/issue-168-legacy-surface-validation/browser-validation-2026-04-22.md).
+- 360 CSS px measurements: [`360-no-horizontal-scroll-measurements.json`](../../artifacts/issue-168-legacy-surface-validation/360-no-horizontal-scroll-measurements.json); Home, Chat thread, and Chat request detail all recorded `clientWidth=360`, `scrollWidth=360`, pass.
+- Ngrok smoke: [`ngrok-remote-browser-smoke.json`](../../artifacts/issue-168-legacy-surface-validation/ngrok-remote-browser-smoke.json); authenticated browser reached the current ngrok URL and rendered `Home`; unauthenticated status was `401`, authenticated status was `200`.
+- Route-retirement sprint validation:
+  - `npm run check` passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - `node ./node_modules/vitest/vitest.mjs run tests/routes.test.ts tests/browser-state-matrix.test.ts tests/chat-data.test.ts` passed with 30 tests.
+  - `npm test` passed with 57 tests.
+  - `npm run build` passed.
+  - `node ./node_modules/@playwright/test/cli.js test e2e/approval-flow.spec.ts` passed with 4 tests.
+- Evidence-capture sprint validation:
+  - `npm run test --prefix apps/frontend-bff -- tests/chat-page-client.test.tsx tests/home-page-client.test.tsx` passed with 14 tests.
+  - `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts --project=desktop-chromium --reporter=line` passed with 3 tests.
+  - `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts --project=mobile-chromium --reporter=line` passed with 3 tests.
+  - `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line` passed with 1 test.
+  - `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line` passed with 1 test.
+- Dedicated pre-push validation gate: passed after rerunning the 360 measurement with a temporary local BFF server.
+
+## Status / handoff notes
+
+- Status: `locally complete; archived after pre-push validation`
+- Active branch: `issue-168-legacy-surface-validation`
+- Active worktree: `.worktrees/issue-168-legacy-surface-validation`
+- Notes:
+  - Retired browser-unused legacy public session and standalone approval route families behind deterministic `410 legacy_route_retired` responses.
+  - Updated route tests, the browser state matrix, and e2e browser mocks so maintained browser workflows rely on v0.9 thread/request surfaces.
+  - Captured desktop/mobile validation evidence for first-input start, follow-up input, pending request response, interrupt, reload/reconnect, background promotion, 360 CSS px no-horizontal-scroll, and current ngrok remote-browser smoke.
+  - Full runtime e2e over ngrok was attempted on mobile and desktop but failed at the post-start `Waiting for your input` assertion after reaching the remote app; the narrower supported ngrok remote-browser smoke passed and is recorded as current #168 evidence.
+  - Completion retrospective:
+    - Completion boundary: package archive after sprint approvals and dedicated pre-push validation.
+    - Contract check: package exit criteria are satisfied by the route retirement implementation, focused/full validation commands, browser validation artifact, 360 CSS px measurements, and ngrok smoke evidence.
+    - What worked: separating route retirement from evidence capture kept the implementation and validation artifacts reviewable.
+    - Workflow problems: the first pre-push validator run used the 360 measurement script without starting the BFF dev server, so it failed with `ERR_CONNECTION_REFUSED` before a corrected rerun passed.
+    - Improvements to adopt: when a validation helper assumes a local server, include the server startup in the validator command framing or make the helper self-starting.
+    - Skill candidates or skill updates: consider tightening future evidence-capture planner prompts to specify self-contained measurement commands.
+    - Follow-up updates: commit, push, PR, merge to `main`, parent checkout sync, worktree cleanup, Issue close, and Project `Done` remain pending.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, pre-push validation has passed, completion retrospective is recorded, and handoff notes are updated.


### PR DESCRIPTION
## Summary

- retire legacy public `sessions` and standalone `approvals` BFF routes behind deterministic `410 legacy_route_retired` responses
- update browser-critical state matrix, route coverage, and e2e request mocks to rely on v0.9 thread/request surfaces
- add Issue #168 browser validation evidence, 360 CSS px measurements, ngrok smoke evidence, and archive the active task package

## Validation

- `npm run check --prefix apps/frontend-bff`
- `node apps/frontend-bff/node_modules/typescript/bin/tsc --noEmit --pretty false --project apps/frontend-bff/tsconfig.json`
- `npm test --prefix apps/frontend-bff`
- `npm run build --prefix apps/frontend-bff`
- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts --project=desktop-chromium --reporter=line`
- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts --project=mobile-chromium --reporter=line`
- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=desktop-chromium --reporter=line`
- `npm run test:e2e --prefix apps/frontend-bff -- e2e/chat-flow.runtime.spec.ts --project=mobile-chromium --reporter=line`
- 360 measurement with temporary local BFF server passed

Closes #168
