### PR TITLE
[codex] add visual inspection skill

### DIFF
--- a/.agents/skills/codex-webui-visual-inspection/SKILL.md
+++ b/.agents/skills/codex-webui-visual-inspection/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: codex-webui-visual-inspection
+description: Capture and inspect `codex-webui` browser UI screenshots with Playwright for Codex-led frontend work. Use when implementing or reviewing visual UI changes, checking desktop/mobile layout, comparing before/after screenshots, or collecting visual evidence under `artifacts/visual-inspection/`.
+---
+
+# Codex WebUI Visual Inspection
+
+## Overview
+
+Use this skill when Codex needs to see and evaluate the `codex-webui` browser UI, especially during frontend polish, responsive layout work, or visual regression checks.
+
+This skill standardizes screenshot capture and review. It does not replace functional E2E tests, sprint evaluation, or pre-push validation.
+
+## Build Context
+
+Read these before changing or inspecting the frontend:
+
+- `README.md`
+- `AGENTS.md`
+- `apps/frontend-bff/README.md`
+- `apps/frontend-bff/playwright.config.ts`
+
+If the visual change belongs to a specific app area, read the nearest relevant `README.md` before editing.
+
+## Standard Workflow
+
+1. Identify the UI state, route, viewport, and before/after need.
+2. Start the app stack if no usable `PLAYWRIGHT_BASE_URL` is already running.
+3. Capture screenshots with `scripts/capture-ui-screenshots.mjs`.
+4. Open the captured PNGs with `view_image`.
+5. Inspect layout, spacing, alignment, typography scale, overflow, text clipping, stacking, and mobile behavior.
+6. Make scoped UI changes only after reading the relevant frontend files.
+7. Capture the same screenshots again and compare before/after.
+8. Run the relevant frontend validation commands before declaring the UI work complete.
+
+Default capture command from the repo root:
+
+```bash
+node .agents/skills/codex-webui-visual-inspection/scripts/capture-ui-screenshots.mjs
+```
+
+Useful options:
+
+```bash
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 \
+  node .agents/skills/codex-webui-visual-inspection/scripts/capture-ui-screenshots.mjs \
+  --route / \
+  --route /sessions/example=thread-example \
+  --out artifacts/visual-inspection/manual-pass
+```
+
+The script writes PNGs and `manifest.json` under `artifacts/visual-inspection/<timestamp>/` by default.
+
+## Capture Expectations
+
+Capture at least:
+
+- desktop Chromium viewport
+- mobile Chromium viewport
+- the route or state directly affected by the change
+
+For UI work that changes flows, capture the important states, not only the landing route. Examples include:
+
+- empty or initial home state
+- active chat/thread state
+- assistant streaming or pending state
+- approval wait state
+- error or disconnected state
+- narrow mobile layout
+
+If a state requires scripted user actions, prefer adding a focused Playwright helper or temporary local capture script over hand-clicking in a headed browser.
+
+## Visual Review Checklist
+
+Review screenshots for:
+
+- text clipped, wrapped awkwardly, or too small for its container
+- controls that resize or shift when labels, badges, hover states, or loading text changes
+- overlapping panels, sticky bars, dialogs, or mobile safe-area issues
+- weak hierarchy in dense operational views
+- one-note color palettes or decorative treatments that distract from work-focused UI
+- desktop/mobile inconsistencies that change meaning or block common workflows
+
+Use concrete observations tied to screenshot filenames. Avoid vague visual judgments without evidence.
+
+## Validation
+
+For frontend UI edits under `apps/frontend-bff`, normally run:
+
+```bash
+npm run check
+node ./node_modules/typescript/bin/tsc --noEmit --pretty false
+npm test
+```
+
+Run from `apps/frontend-bff`. Add `npm run test:e2e` when the change affects user flows, responsive behavior covered by E2E tests, or Playwright helpers.
+
+## Guardrails
+
+- Do not treat screenshots as a substitute for functional tests.
+- Do not keep visual evidence outside `artifacts/visual-inspection/`.
+- Do not commit generated screenshots unless the user explicitly asks.
+- Do not make broad design-system rewrites for a narrow visual issue.
+- Do not inspect only desktop when mobile behavior is user-facing.
+- Do not claim visual verification without opening the generated images.

--- a/.agents/skills/codex-webui-visual-inspection/agents/openai.yaml
+++ b/.agents/skills/codex-webui-visual-inspection/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codex WebUI Visual Inspection"
+  short_description: "Capture and review UI screenshots."
+  default_prompt: "Use $codex-webui-visual-inspection to capture desktop and mobile screenshots, inspect the UI, and guide frontend polish."

--- a/.agents/skills/codex-webui-visual-inspection/scripts/capture-ui-screenshots.mjs
+++ b/.agents/skills/codex-webui-visual-inspection/scripts/capture-ui-screenshots.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const repoRoot = process.cwd();
+const appDir = path.join(repoRoot, "apps", "frontend-bff");
+
+const timestamp = new Date().toISOString().replaceAll(":", "-").replace(/\.\d{3}Z$/, "Z");
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000",
+    fullPage: true,
+    outDir: path.join(repoRoot, "artifacts", "visual-inspection", timestamp),
+    routes: [],
+    waitMs: 750,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--base-url" && next) {
+      options.baseUrl = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--out" && next) {
+      options.outDir = path.resolve(repoRoot, next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--route" && next) {
+      options.routes.push(parseRoute(next));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--wait-ms" && next) {
+      const waitMs = Number.parseInt(next, 10);
+      if (Number.isNaN(waitMs) || waitMs < 0) {
+        throw new Error(`Invalid --wait-ms value: ${next}`);
+      }
+      options.waitMs = waitMs;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--no-full-page") {
+      options.fullPage = false;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown or incomplete argument: ${arg}`);
+  }
+
+  if (options.routes.length === 0) {
+    options.routes.push({ label: "home", route: "/" });
+  }
+
+  return options;
+}
+
+function parseRoute(value) {
+  const separator = value.lastIndexOf("=");
+  if (separator > 0 && separator < value.length - 1) {
+    return {
+      label: slugify(value.slice(separator + 1)),
+      route: value.slice(0, separator),
+    };
+  }
+
+  return {
+    label: slugify(value === "/" ? "home" : value),
+    route: value,
+  };
+}
+
+function slugify(value) {
+  return value
+    .replace(/^https?:\/\//, "")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
+
+function buildUrl(baseUrl, route) {
+  if (/^https?:\/\//.test(route)) {
+    return route;
+  }
+
+  return new URL(route, baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).toString();
+}
+
+function printHelp() {
+  console.log(`Capture codex-webui screenshots.
+
+Usage:
+  node .agents/skills/codex-webui-visual-inspection/scripts/capture-ui-screenshots.mjs [options]
+
+Options:
+  --base-url <url>       App URL. Defaults to PLAYWRIGHT_BASE_URL or http://127.0.0.1:3000.
+  --route <path[=name]>  Route or absolute URL to capture. Repeatable. Defaults to /.
+  --out <dir>            Output directory. Defaults to artifacts/visual-inspection/<timestamp>.
+  --wait-ms <ms>         Delay after page load before screenshot. Defaults to 750.
+  --no-full-page         Capture viewport only instead of full page.
+  -h, --help             Show this help.
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const requireFromApp = createRequire(path.join(appDir, "package.json"));
+  const { chromium, devices } = requireFromApp("playwright");
+  const viewportProfiles = [
+    {
+      name: "desktop-chromium",
+      context: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 960 },
+      },
+    },
+    {
+      name: "mobile-chromium",
+      context: {
+        ...devices["Pixel 7"],
+      },
+    },
+  ];
+
+  await mkdir(options.outDir, { recursive: true });
+
+  const httpCredentials =
+    process.env.PLAYWRIGHT_HTTP_USERNAME && process.env.PLAYWRIGHT_HTTP_PASSWORD
+      ? {
+          username: process.env.PLAYWRIGHT_HTTP_USERNAME,
+          password: process.env.PLAYWRIGHT_HTTP_PASSWORD,
+        }
+      : undefined;
+
+  const browser = await chromium.launch({ headless: true });
+  const captures = [];
+
+  try {
+    for (const profile of viewportProfiles) {
+      const context = await browser.newContext({
+        ...profile.context,
+        ...(httpCredentials ? { httpCredentials } : {}),
+      });
+
+      try {
+        const page = await context.newPage();
+
+        for (const routeEntry of options.routes) {
+          const url = buildUrl(options.baseUrl, routeEntry.route);
+          const fileName = `${profile.name}-${routeEntry.label}.png`;
+          const screenshotPath = path.join(options.outDir, fileName);
+
+          await page.goto(url, { waitUntil: "domcontentloaded" });
+          await page.waitForTimeout(options.waitMs);
+          await page.screenshot({ fullPage: options.fullPage, path: screenshotPath });
+
+          captures.push({
+            file: path.relative(repoRoot, screenshotPath),
+            fullPage: options.fullPage,
+            profile: profile.name,
+            route: routeEntry.route,
+            url,
+          });
+        }
+      } finally {
+        await context.close();
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const manifest = {
+    baseUrl: options.baseUrl,
+    captures,
+    createdAt: new Date().toISOString(),
+    waitMs: options.waitMs,
+  };
+
+  await writeFile(path.join(options.outDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`Wrote ${captures.length} screenshots to ${path.relative(repoRoot, options.outDir)}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Add a repo-local `$codex-webui-visual-inspection` skill for Codex-led UI screenshot review.
- Add an `agents/openai.yaml` entry so the skill is discoverable in the Codex UI.
- Add a Playwright-based capture script that writes desktop/mobile screenshots and a manifest under `artifacts/visual-inspection/`.

## Validation
- `node --check .agents/skills/codex-webui-visual-inspection/scripts/capture-ui-screenshots.mjs`
- `node .agents/skills/codex-webui-visual-inspection/scripts/capture-ui-screenshots.mjs --help`
- Smoke-tested screenshot capture against a temporary local HTML server and opened the generated desktop PNG with `view_image`.
