### PR TITLE
docs: align UX renewal source of truth

### DIFF
--- a/docs/codex_webui_mvp_roadmap_v0_1.md
+++ b/docs/codex_webui_mvp_roadmap_v0_1.md
@@ -16,10 +16,13 @@ This roadmap depends on the following maintained documents:
 - `docs/specs/codex_webui_common_spec_v0_9.md`
 - `docs/specs/codex_webui_internal_api_v0_9.md`
 - `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
 - `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
 - `docs/validation/app_server_behavior_validation_plan_checklist.md`
 
 GitHub Issues and Projects track execution state. This roadmap remains the maintained source of truth for sequencing, scope boundaries, and completion conditions.
+
+Where this roadmap touches UX, interpret it as sequencing guidance only. The maintained current UX model is governed by `docs/specs/codex_webui_ui_layout_spec_v0_9.md` together with the v0.9 requirements and API specifications.
 
 ## 3. Current State
 
@@ -164,7 +167,7 @@ Replace the current session-first Chat and standalone Approval UI with a v0.9 th
 
 #### Main workstreams
 
-1. Rework Home to emphasize workspace selection, resume candidates, and thread list cues.
+1. Absorb the former Home responsibilities into navigation, workspace switching, thread list presentation, resume cues, and empty states instead of preserving Home as a primary screen.
 2. Rework the main interaction surface around `thread_view`, `timeline`, `current_activity`, `composer`, and thread-context request helpers.
 3. Make first user input the canonical new-thread start path from the browser.
 4. Present pending and just-resolved request information from thread context instead of a standalone approval domain flow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Codex WebUI LLM Wiki Index
 
-Last updated: 2026-04-20
+Last updated: 2026-04-23
 
 ## Purpose
 
@@ -31,7 +31,7 @@ Read this file first when you need to locate maintained knowledge across source-
 ## Cross-cutting guidance
 
 - [AGENTS.md](../AGENTS.md): repo-wide workflow rules, including wiki promotion and update triggers
-- [docs/codex_webui_mvp_roadmap_v0_1.md](./codex_webui_mvp_roadmap_v0_1.md): phase breakdown and delivery order
+- [docs/codex_webui_mvp_roadmap_v0_1.md](./codex_webui_mvp_roadmap_v0_1.md): phase breakdown and delivery order; for UX questions, treat it as sequencing guidance and use the v0.9 UI layout spec plus v0.9 requirements/specs as the current UX source of truth
 - [docs/codex_webui_dev_container_onboarding.md](./codex_webui_dev_container_onboarding.md): development container and tunnel workflow
 - [docs/README.md](./README.md): wiki maintenance workflow and category-specific placement rules
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,6 +1,6 @@
 # Codex WebUI LLM Wiki Log
 
-Last updated: 2026-04-21
+Last updated: 2026-04-23
 
 ## Purpose
 
@@ -28,6 +28,28 @@ After the heading, keep the body concise:
 - short note on what changed or remains deferred
 
 ## Entries
+
+## [2026-04-23] lint | UX renewal source-of-truth alignment
+
+Source:
+
+- planner-approved docs-only sprint for Issue #176
+- `.tmp/CodexWebUI_UX重視_作業計画書_v0_1.md` as a working input only, not a normative source
+- review of remaining Home / Chat / Approval roadmap ambiguity against the maintained v0.9 UI layout direction
+
+Updated:
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/index.md`
+- `docs/log.md`
+
+Notes:
+
+- clarified that roadmap UX wording is sequencing guidance and that the v0.9 UI layout spec plus v0.9 requirements/specs govern the current thread-first UX model
+- retired Home as an active primary Phase 4B UI target by moving former Home responsibilities into navigation, workspace switching, thread lists, resume cues, and empty states
+- clarified that `home_overview` and `GET /api/v1/home` are helper aggregates for app-shell initialization, not canonical UI screen contracts
 
 ## [2026-04-21] operational pitfall | Vulkan SDK generic download and extraction validation
 

--- a/docs/specs/codex_webui_public_api_v0_9.md
+++ b/docs/specs/codex_webui_public_api_v0_9.md
@@ -161,7 +161,7 @@ The public API must not silently assume native enum values, native request capab
 | `blocked_cue` | display model | no | indicates user intervention is likely needed |
 | `resume_cue` | display model | no | indicates return priority and reason |
 | `composer` | display model | no | input availability hints |
-| `home_overview` | helper aggregate | no | app-shell and home initialization aggregate |
+| `home_overview` | helper aggregate | no | app-shell initialization aggregate |
 | `thread_stream_event` | transport projection | no | thread-scoped SSE delta event |
 | `notification_event` | transport projection | no | non-authoritative refresh trigger for the global notifications stream |
 
@@ -504,8 +504,9 @@ Rules:
 
 Rules:
 
-- `home_overview` is an app-shell helper aggregate
+- `home_overview` is an app-shell initialization helper aggregate
 - it is not a canonical domain resource
+- it does not imply a canonical or primary Home screen contract
 - `resume_candidates` is a resume-oriented helper path, not a replacement for thread lists
 - `resume_candidates` must reflect the minimum resume priority defined in section 6.8
 
@@ -517,11 +518,12 @@ Rules:
 
 #### `GET /api/v1/home`
 
-Returns the app-shell and home initialization aggregate.
+Returns the app-shell initialization aggregate.
 
 Rules:
 
 - this endpoint is a helper aggregate, not a canonical domain resource
+- this endpoint name does not define a canonical or primary Home screen contract
 - it may return `workspaces` and `resume_candidates` together
 - the shape may be extended compatibly over time
 

--- a/docs/specs/codex_webui_ui_layout_spec_v0_9.md
+++ b/docs/specs/codex_webui_ui_layout_spec_v0_9.md
@@ -61,6 +61,8 @@ The primary conversation unit is `thread`.
 
 UI layout must treat `thread_view` as the main user-facing screen for observing, intervening in, and continuing a single thread.
 
+The dedicated Home screen is not part of the primary v0.9 UI model. The maintained direction is thread-first: `thread_view` is primary, while navigation, workspace switching, thread lists, resume cues, empty states, notifications, and detail surfaces are supporting surfaces.
+
 ### 3.2 Main body of the primary screen
 
 The main body of `thread_view` must be the `timeline`.

--- a/tasks/archive/issue-176-ux-renewal-docs/README.md
+++ b/tasks/archive/issue-176-ux-renewal-docs/README.md
@@ -1,0 +1,79 @@
+# Issue 176 UX Renewal Docs
+
+## Purpose
+
+- Retire the active-doc dependency on old Home-first roadmap language and promote the stable UX renewal decisions into maintained `docs/` source-of-truth files.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/176
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `.tmp/CodexWebUI_UX重視_作業計画書_v0_1.md`
+
+## Scope for this package
+
+- Update maintained docs so the old Phase 4B Home / Chat / Approval roadmap language is no longer authoritative for active execution.
+- Add or update maintained UX renewal source-of-truth content under `docs/`.
+- Clarify that any `home` API/helper is non-primary aggregate support rather than the browser's primary Home screen contract.
+- Update `docs/index.md` and `docs/log.md` when maintained wiki navigation changes.
+
+## Exit criteria
+
+- No active execution doc treats the old Home-first roadmap as authoritative for the current UX renewal.
+- The UX renewal source of truth is discoverable under `docs/`.
+- `.tmp` drafts are referenced only as working inputs, not normative files.
+- Relevant docs validation passes for the changed files.
+
+## Work plan
+
+- Review the roadmap, requirements, public/internal/common specs, and existing UI layout spec for Home-first or page-split language.
+- Promote the stable UX renewal decisions from the `.tmp` working plan into maintained docs.
+- Update wiki navigation and log entries for any new or materially changed maintained page.
+- Run focused documentation checks and record evidence.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-23T00-00-00Z-issue-176-close/events.ndjson`
+- Sprint validation:
+  - `git diff --check`
+  - `rg -n "Home / Chat / Approval|Rework Home|dedicated Home|Home-first|\\.tmp/CodexWebUI_UX重視_作業計画書_v0_1.md" docs`
+  - manual review of remaining hits as legacy/current-state/helper-input/non-primary context
+- Pre-push validation:
+  - `git status --short --branch`
+  - `git diff --name-only`
+  - `git diff --check`
+  - focused `rg` scans for Home/Home-first and helper aggregate/thread-view language
+- Evaluator verdict: `approved`
+- Pre-push gate: `passed`
+
+## Status / handoff notes
+
+- Status: `locally complete; archived pending PR/merge follow-through`
+- Active branch: `issue-176-ux-renewal-docs`
+- Active worktree: `.worktrees/issue-176-ux-renewal-docs`
+- Notes:
+  - Updated maintained docs so roadmap UX wording is sequencing guidance and the v0.9 UI layout spec plus v0.9 requirements/specs govern the current thread-first UX model.
+  - Retired Home as an active primary Phase 4B UI target by moving former Home responsibilities into navigation, workspace switching, thread lists, resume cues, and empty states.
+  - Clarified that `home_overview` and `GET /api/v1/home` are helper aggregates for app-shell initialization, not canonical UI screen contracts.
+  - Updated `docs/index.md` and `docs/log.md`; `.tmp/CodexWebUI_UX重視_作業計画書_v0_1.md` is referenced only as a working input.
+  - Completion retrospective:
+    - Completion boundary: package archive, not Issue close.
+    - Contract check: package exit criteria satisfied by docs changes, evaluator approval, and pre-push validation; Issue close remains blocked until the branch is pushed, PR is merged to `main`, parent checkout is synced, and worktree cleanup is complete.
+    - What worked: planner/worker/evaluator split kept this docs-only slice narrow; validator evidence matched the package scope.
+    - Workflow problems: initial planner spawn with `fork_context` was rejected by tool constraints and logged as a recoverable anomaly.
+    - Improvements to adopt: keep future orchestrator sub-agent spawns compatible with the current tool constraint by avoiding explicit `agent_type` with full-history fork.
+    - Skill candidates or skill updates: none required from this one-off spawn-framing issue.
+    - Follow-up updates: PR/merge/completion tracking must be handled through the GitHub Projects workflow after archive.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate has passed, completion retrospective has run, and handoff notes are updated.


### PR DESCRIPTION
## Summary

- Clarify that roadmap UX wording is sequencing guidance and the v0.9 UI layout spec is the current UX source of truth
- Retire Home as a primary Phase 4B target and move former Home responsibilities into navigation/thread context
- Clarify that `home_overview` and `GET /api/v1/home` are helper aggregates, not canonical Home screen contracts
- Archive the completed Issue #176 package

## Validation

- `git diff --check`
- evaluator verdict: approved
- pre-push validation gate: passed

Closes #176