### PR TITLE
docs: specify desktop thread view states

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -29,6 +29,36 @@ After the heading, keep the body concise:
 
 ## Entries
 
+## [2026-04-23] ingest | Issue #179 desktop state specification
+
+Source:
+
+- planner-approved docs-only sprint for Issue #179
+- `tasks/issue-179-desktop-state-spec/README.md`
+- Issue #179 body and comments inspected read-only for a desktop layout image asset or attachment
+- parent-checkout draft `.tmp/CodexWebUI_UX重視_作業計画書_v0_1.md`, which mentions `codexwebui_approval_interface_screenshot.png` as a filename but does not provide a maintained or normative image asset
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
+- `docs/notes/codex_webui_agent_ui_benchmark_note_v0_1.md`
+
+Updated:
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/log.md`
+- `tasks/issue-179-desktop-state-spec/README.md`
+
+Notes:
+
+- added implementation-ready desktop region ownership rules for Navigation, Thread View, and Detail Surface while preserving the thread-first v0.9 model
+- added a desktop state matrix for waiting on input, in progress, waiting on approval, system error / failed turn, `notLoaded`, and open-required recovery
+- kept approval as thread-scoped request flow, kept resume and blocked cues as derived display cues, and explicitly rejected old Home / Chat / Approval primary page separation
+- no maintained desktop layout image asset was found in the repo or Issue #179; the only local draft reference found is the `.tmp` filename mention, which is not itself a maintained or normative asset
+- mobile behavior remains deferred to the existing v0.9 mobile reachability rules
+
 ## [2026-04-23] ingest | Agent UI benchmark note
 
 Source:

--- a/docs/specs/codex_webui_ui_layout_spec_v0_9.md
+++ b/docs/specs/codex_webui_ui_layout_spec_v0_9.md
@@ -218,6 +218,78 @@ On desktop, the detail surface must:
 
 The desktop layout must preserve side-by-side reading of the timeline and selected detail without forcing thread-context loss or separate screen navigation.
 
+### 5.5 Desktop region ownership
+
+Desktop implementation must use the existing two-state composition as the normative screen model:
+
+- default: `[ Navigation ] [ Thread View ]`
+- selected detail open: `[ Navigation ] [ Thread View ] [ Detail Surface ]`
+
+These are region responsibilities, not separate primary pages. The old Home / Chat / Approval primary page separation is explicitly rejected for v0.9 desktop implementation. Former Home-style return and discovery responsibilities belong to Navigation, conversation and intervention belong to Thread View, and expanded inspection belongs to Detail Surface.
+
+Navigation owns:
+
+- current workspace identity and workspace switching
+- current-workspace thread discovery
+- thread list row summaries
+- filters, sort, and priority-aware return order
+- lightweight badges for approval, error, failed, active, and similar states when those facts are available
+- resume cue and blocked cue display as derived lightweight signals
+- cross-workspace high-priority summaries through the workspace switcher, notifications, or equivalent lightweight affordances
+
+Thread View owns:
+
+- thread header
+- current activity
+- pending request summary and response affordances
+- timeline as the main body
+- single composer or first-input composer state
+- interrupt affordance when available
+- no-thread-selected, `notLoaded`, and open-required recovery presentation as thread opening or resume flow
+
+Detail Surface owns selected-item inspection only. It may show request detail, error detail, failure detail, selected timeline item detail, file or diff summaries, and long supporting content. It must not become an always-on activity monitor, a global approval inbox, or the only place where approval, error, failed-turn, resume, or blocked state is discoverable.
+
+### 5.6 Desktop state matrix
+
+The following matrix defines desktop state ownership for implementation. The listed states are user-facing interpretations of native facts, helper aggregates, and recent evidence; they are not new canonical WebUI lifecycle resources.
+
+| Desktop state | Navigation responsibility | Thread View responsibility | Detail Surface responsibility |
+| --- | --- | --- | --- |
+| waiting on input | Thread row remains selectable and may show no blocking badge; `resume_cue` may emphasize last viewed or recently updated threads according to priority order. | Header identifies the selected thread and workspace. Current activity states that input is accepted or that the thread is idle. Timeline remains visible. Composer is enabled as the normal continuation path. | Closed by default. Opens only if the user selects an existing timeline item, request resolution, file summary, or other detail affordance. |
+| in progress | Thread row shows active badge or equivalent lightweight state. Navigation may keep the active thread visible in priority-aware sorting without auto-switching away from another selected thread. | Header remains stable. Current activity summarizes execution, streaming, tool use, or progress. Timeline remains visible and updates in thread order. Composer availability follows native-derived availability; interrupt is visible when supported. | Closed by default. Opens only from user selection of current-activity detail, command/tool detail, timeline item, file summary, or similar detail affordance. |
+| waiting on approval | Thread row shows waiting approval badge and blocked cue when available. Resume cue priority follows the requirements-level order, where `waitingOnApproval` is highest priority. Navigation may expose filters or workspace summaries, but must not route the user to a global approval inbox. | Header remains in thread context. Current activity states that approval is required. A pending request summary appears inside `thread_view` with concise risk/summary information, approve/deny response affordances or a path to them, and a path to detail when minimum confirmation information does not fit inline. Timeline remains visible and includes the approval request. Normal composer must not compete with request-response controls. | Opens only when the user selects pending request detail or a targeted notification/badge/detail affordance. Detail may show minimum confirmation information before approve/deny, but response remains thread-scoped request flow rather than a separate Approval screen. |
+| system error / failed turn | Thread row shows error or failed badge and blocked cue when available. Resume cue priority emphasizes `systemError` before latest-turn failed, after waiting approval. Navigation may surface the condition through filters, sort, workspace summaries, banners, or toasts without auto-opening detail. | Header remains stable. Current activity summarizes the system error or latest failed turn and the next available recovery action when known. Timeline remains visible and includes the error, failed evidence, or recovery status in chronology. Composer availability follows native-derived recovery/input availability rather than a WebUI-owned failed state. | Closed by default. Opens when the user selects the error item, failed-turn item, current-activity detail, notification, or badge affordance. Detail owns expanded error/failure diagnostics and recovery guidance, but the thread remains selected and visible. |
+| `notLoaded` | Thread row remains selectable from Navigation and may carry resume cue emphasis based on persisted summary, updated time, or high-priority helper data when available. Navigation does not expose `notLoaded` as a separate primary destination. | Selecting the row targets `thread_view`. Thread View shows an opening, loading, or resume-in-progress state while the facade establishes the App Server thread view. Timeline may show a loading placeholder until reacquisition succeeds; once loaded, the normal timeline is shown. | Closed by default. The selected detail state is preserved only if still valid after the thread view loads; otherwise the Detail Surface remains closed or empty. |
+| open-required recovery | Navigation treats the thread as the same selected or resumable thread and may show lightweight unavailable or retry emphasis only if the public facade cannot complete recovery. It must not expose internal `thread_open_required` as a user-facing screen or resource. | Internal open-required recovery is absorbed by the facade as part of the same `thread_view` opening flow. Thread View may show opening, retrying, temporarily unavailable, or resume guidance according to the public result, but must not require the user to visit Home or a separate recovery page. | Closed by default. Opens only after a user selects available error/recovery detail from Thread View or a targeted notification/badge. Internal helper names such as `thread_open_required` are not shown as the primary user model. |
+
+### 5.7 Desktop ownership details
+
+Thread header belongs to Thread View. It identifies the selected thread, enough workspace context to make action scope clear, and high-level state when that state affects immediate action.
+
+Current activity belongs to Thread View. It is a pinned, derived summary for running, waiting on input, waiting on approval, system error, latest failed turn, opening, or temporarily unavailable conditions. It must be rebuilt from native facts, helper aggregates, and recent evidence rather than stored as standalone canonical state.
+
+Pending request summary belongs to Thread View. It is the default desktop approval intervention surface and must keep response/detail affordances inside `thread_view`. Navigation may advertise that approval is needed, and Detail Surface may inspect expanded confirmation detail, but neither replaces the thread-scoped request flow.
+
+Timeline belongs to Thread View and remains visible for waiting on input, in progress, waiting on approval, system error / failed turn, and loaded recovery states. During `notLoaded` or open-required recovery, Thread View may show an opening placeholder until timeline reacquisition succeeds. Error, failed-turn, approval request, and approval resolution evidence should remain represented in timeline chronology when available.
+
+Composer belongs to Thread View. There is one normal composer path for first input or selected-thread continuation. Request-response controls and interrupt controls may sit near current activity or the composer area, but they are not separate approval or task composers.
+
+Thread list row belongs to Navigation. The row is the compact discovery and return unit for a thread; it carries title, current-activity summary, updated time, badges, and lightweight resume/blocked cues when available.
+
+Badges belong primarily to Navigation and may also appear inside Thread View summaries. They are lightweight state markers, not canonical resources. At minimum, desktop rows must be able to distinguish approval, error, failed, and active situations when those facts are available.
+
+Blocked cue belongs to Navigation and may also be reflected in Thread View current activity. It is a derived display cue for intervention-needed states such as `waitingOnApproval`, `systemError`, or latest failed evidence. It must not be implemented as a standalone canonical resource or required standalone module.
+
+Resume cue belongs to Navigation and lightweight notifications. It is a derived return-priority cue based on native status, active flags, latest failure evidence, last viewed thread, updated time, and workspace context. It must not auto-switch the selected thread by itself and must not require a dedicated standalone resume module.
+
+### 5.8 Desktop image reference status
+
+No desktop layout image is normative unless a maintained source or Issue reference explicitly provides an image asset. A filename mention in an unmaintained `.tmp` draft is not itself a maintained or normative asset. If a desktop layout image is later added, its regions must map to these rules: left region as Navigation, center region as Thread View, and right selected-item region as Detail Surface. Image labels or visual affordances must not override the normative rejection of Home / Chat / Approval primary page separation, the thread-scoped approval flow, or the selection-driven Detail Surface rule.
+
+### 5.9 Mobile deferral for desktop states
+
+Issue #179 defines desktop state ownership only. Mobile remains governed by the existing v0.9 mobile reachability rules in section 6 and the v0.9 requirements. This desktop state matrix must not expand mobile behavior beyond that existing reachability model.
+
 ---
 
 ## 6. Mobile layout

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-179-desktop-state-spec](./archive/issue-179-desktop-state-spec/README.md)
 - [issue-178-benchmark-agent-uis](./archive/issue-178-benchmark-agent-uis/README.md)
 - [issue-177-thread-view-ia](./archive/issue-177-thread-view-ia/README.md)
 - [issue-168-legacy-surface-validation](./archive/issue-168-legacy-surface-validation/README.md)

--- a/tasks/archive/issue-179-desktop-state-spec/README.md
+++ b/tasks/archive/issue-179-desktop-state-spec/README.md
@@ -1,0 +1,70 @@
+# Issue 179 Desktop State Spec
+
+## Purpose
+
+- Create implementation-ready desktop screen specifications for Navigation, Thread View, and Detail Surface states in the renewed v0.9 UX.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/179
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/notes/codex_webui_agent_ui_benchmark_note_v0_1.md`
+
+## Scope for this package
+
+- Add or update maintained docs so engineers can implement the desktop shell without guessing layout ownership.
+- Specify the three-region desktop model across Navigation, Thread View, and Detail Surface.
+- Define desktop states for waiting on input, in progress, waiting on approval, system error / failed turn, not loaded, and open-required recovery.
+- Specify responsibilities for thread header, current activity, pending request summary, timeline, composer, thread list row, badges, blocked cue, and resume cue.
+- Keep mobile as an explicitly deferred follow-up and avoid restoring Home / Chat / Approval as separate primary screens.
+
+## Exit criteria
+
+- The maintained desktop state specification is reachable under `docs/` and linked from the relevant wiki entrypoints if needed.
+- The spec covers the Issue #179 acceptance criteria in implementation-ready terms.
+- The package has passed the local sprint evaluator and the dedicated pre-push validation gate before archive or publish handoff.
+
+## Work plan
+
+- Identify the correct maintained doc location for the desktop screen state specification.
+- Draft desktop state rules that extend the existing v0.9 layout spec without duplicating source-of-truth language unnecessarily.
+- Update `docs/index.md` and `docs/log.md` only if discoverability materially changes.
+- Run focused docs validation and any available lint/type checks appropriate to the touched files.
+- Record evidence and handoff notes before pre-push validation.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-23T02-32-27Z-issue-179-close/events.ndjson`
+- Desktop layout image status: no maintained image asset or Issue #179 attachment/comment image was found. The only local draft reference found is the parent-checkout `.tmp/CodexWebUI_UX重視_作業計画書_v0_1.md` filename mention of `codexwebui_approval_interface_screenshot.png`; that mention is not itself a maintained or normative asset, and no matching PNG file was found. Written rules are anchored to the existing textual desktop compositions in `docs/specs/codex_webui_ui_layout_spec_v0_9.md`.
+- Touched docs:
+  - `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+  - `docs/log.md`
+  - `tasks/issue-179-desktop-state-spec/README.md`
+- Validation evidence:
+  - `git diff -- docs/specs/codex_webui_ui_layout_spec_v0_9.md docs/log.md docs/index.md tasks/issue-179-desktop-state-spec/README.md` showed tracked changes in `docs/specs/codex_webui_ui_layout_spec_v0_9.md` and `docs/log.md`; `docs/index.md` had no diff. The task README is untracked in this worktree, so it is visible through `git status --short` rather than tracked diff.
+  - `rg -n "Home / Chat / Approval|global approval inbox|open-required|notLoaded|waiting on approval|Detail Surface|Navigation|Thread View|resume cue|blocked cue" docs/specs/codex_webui_ui_layout_spec_v0_9.md` found the desktop composition, state matrix, thread-scoped approval, recovery, and cue ownership terms.
+  - `rg -n "issue-179|desktop state|Desktop|layout" docs/log.md tasks/issue-179-desktop-state-spec/README.md` found the new log entry and package evidence/status notes.
+  - Follow-up image-reference validation confirmed the maintained docs now distinguish the `.tmp` filename mention from a maintained/normative image asset, and no matching `codexwebui_approval_interface_screenshot.png` file was found.
+  - `git status --short -- docs/specs/codex_webui_ui_layout_spec_v0_9.md docs/log.md docs/index.md tasks/issue-179-desktop-state-spec/README.md` showed modified tracked docs and untracked task README.
+  - Docs lint/check discovery found no documented docs-only lint command; only app-local lint guidance was present, and no app files were changed.
+
+## Status / handoff notes
+
+- Status: `locally complete - archived for publish handoff`
+- Active branch: `issue-179-desktop-state-spec`
+- Active worktree: `.worktrees/issue-179-desktop-state-spec`
+- Notes: Added desktop state ownership rules for Navigation, Thread View, and Detail Surface. The spec covers waiting on input, in progress, waiting on approval, system error / failed turn, `notLoaded`, and open-required recovery without restoring Home / Chat / Approval as primary pages. Mobile remains deferred to existing v0.9 mobile reachability rules.
+- Sprint result: evaluator approved the docs-only slice.
+- Pre-push validation: passed with no blocking failures or gaps.
+- Completion retrospective: Package archive boundary only. Contract check is satisfied locally by the maintained layout spec update, docs log entry, task evidence, evaluator approval, and dedicated pre-push validation. What worked: the slice stayed in the docs-only write scope and the missing image asset was handled as a maintained-source distinction instead of inventing a new normative asset. Workflow problems: the initial task package included one wrong note path, an initial `gh pr list` command used an unsupported JSON field, and the image reference required a follow-up check to distinguish `.tmp` filename mentions from maintained assets. Improvements to adopt: validate source-doc paths immediately when creating packages, and describe missing visual assets as maintained-asset status rather than broad "no reference" language. Skill candidates or skill updates: none. Follow-up updates: commit and publish the branch, open/merge a PR, sync parent `main`, remove the active worktree, update Issue/Project completion tracking, and close Issue #179 only after the work is reachable on `main` and local state is clean.
+
+## Archive conditions
+
+- Archive this package after the desktop spec exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and the Issue execution metadata points to the archived package.


### PR DESCRIPTION
## Summary

- Add implementation-ready desktop region ownership and state matrix rules to the v0.9 UI layout spec.
- Record the Issue #179 wiki log entry and archived task package evidence.
- Clarify that no maintained desktop layout image asset exists; the .tmp filename mention is non-normative.

## Validation

- Sprint evaluator: approved.
- Dedicated pre-push validation: passed.
- `git diff --check`
- Targeted `rg` checks for desktop state, cue, approval, recovery, and image-reference language.

Closes #179
