### PR TITLE
docs: audit thread view contracts

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -29,6 +29,27 @@ After the heading, keep the body concise:
 
 ## Entries
 
+## [2026-04-23] ingest | Issue #180 contract audit
+
+Source:
+
+- approved sprint slice for Issue #180
+- `tasks/issue-180-contract-audit/README.md`
+- v0.9 public, internal, and common API specs
+
+Updated:
+
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/log.md`
+- `tasks/issue-180-contract-audit/README.md`
+
+Notes:
+
+- tightened maintained contracts for thread Navigation cue material, `thread_view` helper shape, request-helper identity and confirmation fields, pending-request absence semantics, ordering and REST reacquisition triggers, first-input idempotency, and public absorption of internal open-required handling
+- preserved approval as thread-scoped request flow and did not add standalone canonical approval resources or a required global approval inbox
+
 ## [2026-04-23] ingest | Issue #179 desktop state specification
 
 Source:

--- a/docs/specs/codex_webui_common_spec_v0_9.md
+++ b/docs/specs/codex_webui_common_spec_v0_9.md
@@ -302,6 +302,8 @@ This document does not freeze the default sort for each resource.
 
 Thread-scoped event, timeline, and request-flow representations must have a stable ordering basis that supports deduplication and reacquisition convergence.
 
+For the maintained v0.9 public and internal contracts, that basis is `thread_id + sequence`.
+
 Implementations must provide at least one of:
 
 - a monotonic thread-comparable ordering key

--- a/docs/specs/codex_webui_internal_api_v0_9.md
+++ b/docs/specs/codex_webui_internal_api_v0_9.md
@@ -384,10 +384,15 @@ If it detects:
 - a sequence gap
 - duplicate sequence with incompatible payload
 - request-started and request-resolved mismatch
+- pending-request transition mismatch between helper state and timeline or stream evidence
 - item delta that does not converge to a completed item
 - inconsistent `occurred_at` and `sequence` order
+- projection inconsistency across `thread_summary`, `thread_view_helper`, request helpers, or timeline items
+- reconnect ambiguity
 
 then REST reacquisition is the recovery authority.
+
+SSE is not recovery authority. Runtime and `frontend-bff` may use SSE as a live-update transport, but recovery from the above cases must reacquire REST state that preserves the `thread_id + sequence` ordering basis.
 
 ### 9.6 Global notifications
 
@@ -397,6 +402,24 @@ It may be a stream or an equivalent internal contract, but it must not become:
 
 - the canonical ordering source
 - the authoritative source of thread state
+
+### 9.7 `thread_summary`
+
+`thread_summary` is the internal read model backing public `thread_list_item` and Navigation cue derivation.
+
+It must include or make derivable at least:
+
+- thread reference and workspace reference
+- native status snapshot or equivalent status material
+- `updated_at` used for stable list sorting
+- current activity material
+- badge material
+- blocked cue material
+- resume cue material
+- pending request presence, including request identity when pending
+- error or latest failed-turn presence when retained
+
+These fields are Navigation cue material only. They must not become canonical resources separate from native thread, turn, item, request flow, and the internal `thread_id + sequence` ordering basis.
 
 ---
 
@@ -445,6 +468,19 @@ If a view requires a prior `open`, runtime may return `409 thread_open_required`
 
 This keeps public and internal contracts aligned without exposing internal helper concerns directly to browsers.
 
+`thread_view_helper` must include or reference the minimum helper shape needed by `frontend-bff`:
+
+- thread snapshot
+- current activity material
+- pending request summary when pending
+- latest resolved request summary while retained
+- timeline slice using the thread-scoped `sequence` ordering basis
+- composer or input availability hints
+- interrupt availability
+- open/load recovery result or error material
+
+`thread_view_helper` remains a helper aggregate. Public `GET /api/v1/threads/{thread_id}/view` absorbs any internal `thread_open_required` response by calling `open` and retrying or by mapping failure to public unavailability; it must not expose `thread_open_required` as a public resource, screen, or user-facing state.
+
 ### 10.5 Reserved helper slots
 
 The internal API may reserve helper slots for:
@@ -471,6 +507,12 @@ The success boundary requires:
 4. the `client_request_id -> thread_id` mapping is persisted
 
 Summary and projection updates may follow after that success boundary.
+
+Idempotency rules:
+
+- the same `client_request_id` with the same request body must return the prior accepted result while the idempotency mapping is retained
+- the same `client_request_id` with a different request body must return `409 idempotency_conflict`
+- the persisted mapping must bind the accepted input to the generated `thread_id` so retries cannot create duplicate native threads for one accepted first input
 
 ### 11.2 Existing-thread input
 
@@ -521,7 +563,7 @@ Approval-kind outcomes such as `approved` or `denied` belong in decision fields 
 
 `pending_request_summary` is the current helper view of a thread's pending request.
 
-It should include at least:
+It must include at least:
 
 - `request_id`
 - `thread_id`
@@ -531,6 +573,8 @@ It should include at least:
 - `status`
 - risk classification
 - a short summary
+- consequence or reason when available
+- operation summary when available
 - request time
 
 ### 12.5 `latest_resolved_request_summary`
@@ -556,13 +600,16 @@ It should include at least:
 It must include at least:
 
 - risk level or classification
+- short summary
 - operation summary
-- reason for response
+- consequence or reason for response
 - request time
 - thread reference
 - turn or item reference
 - current lifecycle status
+- supported decision options
 - response decision when already resolved and still retained
+- response time when already resolved and still retained
 
 ### 12.7 Lifetime and reachability
 
@@ -611,6 +658,9 @@ When a just-resolved request is still retained for recovery, the same endpoint m
   "pending_request": null,
   "latest_resolved_request": {
     "request_id": "req_001",
+    "thread_id": "thread_123",
+    "turn_id": "turn_456",
+    "item_id": "item_789",
     "request_kind": "approval",
     "status": "resolved",
     "decision": "approved",

--- a/docs/specs/codex_webui_public_api_v0_9.md
+++ b/docs/specs/codex_webui_public_api_v0_9.md
@@ -346,6 +346,13 @@ Rules:
     "kind": "waiting_on_approval",
     "label": "Approval required"
   },
+  "pending_request": {
+    "present": true,
+    "request_id": "req_001",
+    "request_kind": "approval",
+    "summary": "Run git push"
+  },
+  "latest_error_or_failure": null,
   "badge": {
     "kind": "approval_required",
     "label": "Approval required"
@@ -365,8 +372,13 @@ Rules:
 Rules:
 
 - `thread_list_item` is a projection and display helper, not a canonical resource
+- `thread_list_item` must carry or allow derivation of the minimum Navigation cue material for current activity, badge, blocked cue, resume cue, pending request presence, error or latest failed-turn presence, and `updated_at` sorting
+- `current_activity`, `pending_request`, `latest_error_or_failure`, `badge`, `blocked_cue`, and `resume_cue` are display cue materials only and must not become canonical resources
+- `pending_request.present=true` must identify the pending request enough for thread-context navigation or inline response affordance; if no request is pending, `pending_request` may be `null` or use `present=false` consistently for the endpoint
+- `latest_error_or_failure` should identify user-visible system error or latest failed-turn evidence when retained, but it remains derived evidence rather than an error resource
 - `badge`, `blocked_cue`, and `resume_cue` may be embedded
 - `resume_cue.priority_band` is a hint band, not a fixed total-order score
+- workspace thread lists sort by `updated_at` using the stable tie-breakers defined by `GET /api/v1/workspaces/{workspace_id}/threads`; Navigation cues must not replace that sorting contract
 
 ### 7.4 ThreadView
 
@@ -391,7 +403,8 @@ Rules:
   "composer": {
     "accepting_user_input": true,
     "interrupt_available": false,
-    "blocked_by_request": false
+    "blocked_by_request": false,
+    "input_unavailable_reason": null
   },
   "timeline": {
     "items": [],
@@ -410,6 +423,9 @@ Rules:
 - `composer` is a display model
 - `composer.accepting_user_input` is an availability hint, not the final server-side admission source
 - final input acceptance is determined at request time from native facts and request/recovery state
+- `thread_view` must include or reference the minimum helper shape for the thread snapshot, current activity, pending request summary, latest resolved request summary during retention, timeline slice, composer/input availability hints, interrupt availability, and open/load recovery outcome
+- `timeline` is a slice and must expose paging fields; it shares the `thread_id + sequence` ordering basis with `GET /api/v1/threads/{thread_id}/timeline` and the thread-scoped stream
+- open/load recovery is absorbed into this public read; browsers must see either a normal `thread_view` or a public error/degraded response, never internal `thread_open_required`
 
 ### 7.5 TimelineItem
 
@@ -446,6 +462,8 @@ Rules:
   "status": "pending",
   "risk_category": "external_side_effect",
   "summary": "Run git push",
+  "reason": "Remote repository will be updated.",
+  "operation_summary": "git push origin main",
   "requested_at": "2026-04-07T08:32:00Z"
 }
 ```
@@ -454,7 +472,8 @@ Rules:
 
 - pending request information is embedded in thread context
 - approval is not restored as a standalone canonical resource
-- `latest_resolved_request` may reuse the same identity fields plus `decision` and `responded_at` while the immediate recovery window remains open
+- `pending_request` must include enough identity and context fields to reach minimum confirmation information before response: `request_id`, `thread_id`, request kind, status, risk or classification, short summary, request time, and turn, item, operation, or reason fields when available
+- `latest_resolved_request` may reuse the same identity and context fields plus `decision` and `responded_at` while the immediate recovery window remains open
 - thread-context request helpers must let the browser navigate to `request_detail` for both pending and just-resolved requests during the retention window
 
 ### 7.7 RequestDetail
@@ -470,6 +489,7 @@ Rules:
   "risk_category": "external_side_effect",
   "summary": "Run git push",
   "reason": "Remote repository will be updated.",
+  "consequence": "The remote repository may receive new commits.",
   "operation_summary": "git push origin main",
   "requested_at": "2026-04-07T08:32:00Z",
   "responded_at": null,
@@ -488,6 +508,8 @@ Rules:
 
 - `request_detail` is a helper facade rather than a canonical resource
 - the public contract must preserve the minimum confirmation information needed before response
+- minimum confirmation information includes risk or classification, short summary, consequence or reason, operation summary when available, request time, thread reference, turn/item or equivalent context, status, and decision options
+- when resolved detail is retained, it must also include the retained decision and response time
 - `request_detail` must remain readable while the request is pending
 - `request_detail` should remain readable for at least the post-resolution recovery window while the thread context still supports safe reacquisition
 - `404 request_not_found` should be reserved for request identifiers that are no longer reachable, retained, or valid
@@ -626,8 +648,9 @@ Response `202 Accepted`:
 
 Idempotency rules:
 
-- the same `client_request_id` with the same request body may return the prior accepted result
+- the same `client_request_id` with the same request body must return the prior accepted result when the idempotency record is retained
 - the same `client_request_id` with a different body must return `409 idempotency_conflict`
+- the accepted result maps to the generated `thread_id`; retrying the same accepted first input must not create a duplicate thread
 
 #### `GET /api/v1/threads/{thread_id}`
 
@@ -643,7 +666,8 @@ Rules:
 - if the target thread is `notLoaded`, `frontend-bff` may internally absorb the internal `open` helper
 - when that internal helper succeeds, the public endpoint returns the normal `thread_view`
 - if open or load cannot be completed, the public endpoint may return `503 thread_temporarily_unavailable`
-- the public contract must not expose internal `thread_open_required`
+- the public contract must not expose internal `thread_open_required` as a public resource, screen, or user-facing state
+- public `GET /api/v1/threads/{thread_id}/view` absorbs internal open-required/open-helper handling as part of the same read flow
 
 #### `GET /api/v1/threads/{thread_id}/timeline`
 
@@ -767,10 +791,15 @@ Pending request exists:
   "thread_id": "thread_123",
   "pending_request": {
     "request_id": "req_001",
+    "thread_id": "thread_123",
+    "turn_id": "turn_456",
+    "item_id": "item_789",
     "request_kind": "approval",
     "status": "pending",
     "risk_category": "external_side_effect",
     "summary": "Run git push",
+    "reason": "Remote repository will be updated.",
+    "operation_summary": "git push origin main",
     "requested_at": "2026-04-07T08:32:00Z"
   },
   "latest_resolved_request": null,
@@ -803,6 +832,7 @@ Rules:
 
 - absence must be represented unambiguously as `pending_request: null`
 - request absence within thread context must not use `404`
+- missing, expired, invalid, or unreachable request detail remains resource-specific `404 request_not_found` on request-detail endpoints
 - `latest_resolved_request` is optional and may be present only during the immediate recovery window
 - a thread-context helper path for just-resolved requests is required while the recovery window remains open
 - when `pending_request` is non-null, `latest_resolved_request` must be `null`
@@ -911,7 +941,8 @@ Logical event envelope:
 Rules:
 
 - `thread_id + sequence` is the canonical public dedupe and ordering basis
-- if the client detects a gap, incompatible duplicate, or ambiguous state, it must reacquire via REST
+- if the client detects a gap, incompatible duplicate, pending-request transition mismatch, projection inconsistency, reconnect ambiguity, or other ambiguous state, it must reacquire via REST
+- SSE is not recovery authority
 - public SSE event names are facade event names for browsers and do not guarantee a one-to-one mapping with native App Server event names
 
 ### 9.3 Global notifications stream
@@ -962,6 +993,9 @@ The client should reacquire `thread_view` or `timeline` when it detects:
 - a mismatch between pending-request transitions and the visible thread state
 - a timeline convergence inconsistency
 - reconnect followed by ambiguous state
+- a projection inconsistency between current activity, pending request helpers, thread snapshot, or timeline evidence
+
+SSE is not recovery authority for these cases; REST reacquisition is.
 
 ### 10.5 Partial-failure degrade rule
 
@@ -976,6 +1010,13 @@ The browser-facing contract must prefer explicit REST retryable unavailability o
 ### 11.1 First-input start
 
 `POST /api/v1/workspaces/{workspace_id}/inputs` uses `client_request_id` for idempotency.
+
+Rules:
+
+- the same `client_request_id` with the same request body must return the prior accepted result when the idempotency record is retained
+- the same `client_request_id` with a different body must return `409 idempotency_conflict`
+- the retained accepted result maps to the generated `thread_id`, `turn_id`, and input item when available
+- retrying a successfully accepted first input must not create a duplicate thread
 
 ### 11.2 Existing-thread input
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-180-contract-audit](./archive/issue-180-contract-audit/README.md)
 - [issue-179-desktop-state-spec](./archive/issue-179-desktop-state-spec/README.md)
 - [issue-178-benchmark-agent-uis](./archive/issue-178-benchmark-agent-uis/README.md)
 - [issue-177-thread-view-ia](./archive/issue-177-thread-view-ia/README.md)

--- a/tasks/archive/issue-180-contract-audit/README.md
+++ b/tasks/archive/issue-180-contract-audit/README.md
@@ -1,0 +1,77 @@
+# Issue 180 Contract Audit
+
+## Purpose
+
+- Audit the maintained v0.9 runtime/BFF contracts that the UX renewal depends on before UI implementation starts.
+- Capture missing or ambiguous contract fields as maintained spec updates or follow-up issues instead of letting UI work rely on assumptions.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/180
+
+## Source docs
+
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+
+## Scope for this package
+
+- Audit `thread_list_item` and thread summary fields for Navigation sections, attention cues, blocked cues, and resume cues.
+- Audit `thread_view` helper shape for snapshot, current activity, pending request summary, timeline slice, and open-required handling.
+- Audit `pending_request_summary` and `request_detail_view` for the minimum approval confirmation information required by the renewed UI.
+- Audit feed, timeline, stream ordering, `(thread_id, sequence)` dedupe, sequence gap handling, and REST reacquisition responsibilities.
+- Audit first-input idempotency through `client_request_id`.
+- Update maintained docs when the intended contract can be clarified directly; create follow-up tracking when implementation or product decisions remain outside this audit slice.
+
+## Exit criteria
+
+- The audit findings are captured in maintained docs, a maintained validation note, or linked follow-up issues.
+- UI implementation issues can rely on documented v0.9 public/internal contracts for the covered surfaces.
+- The audit does not reintroduce a standalone canonical approval resource.
+- Focused validation confirms the changed docs are internally consistent enough for follow-on UI work.
+
+## Work plan
+
+- Compare the Issue #180 audit questions against v0.9 public, internal, common, UI layout, and requirements docs.
+- Inspect runtime and BFF implementation surfaces only to identify drift between maintained contracts and current code.
+- Patch the source-of-truth docs where the intended contract is clear.
+- Create or identify follow-up issues for missing implementation work that should not be fixed in this contract-audit package.
+- Run targeted docs/search validation and any lightweight tests needed to verify consistency.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-23T03-05-14Z-issue-180-close/events.ndjson`
+- Planned evidence: command outputs and final validation summary in this package's status notes or `artifacts/` if the evidence becomes too large for a concise note.
+- Validation 2026-04-23:
+  - `git diff -- docs/specs/codex_webui_public_api_v0_9.md docs/specs/codex_webui_internal_api_v0_9.md docs/specs/codex_webui_common_spec_v0_9.md docs/requirements/codex_webui_mvp_requirements_v0_9.md docs/specs/codex_webui_ui_layout_spec_v0_9.md docs/specs/codex_webui_app_server_contract_matrix_v0_9.md docs/log.md tasks/issue-180-contract-audit/README.md`
+  - `rg -n "thread_list_item|thread_summary|thread_view|thread_view_helper|pending_request_summary|pending_request|latest_resolved_request|request_detail_view|request_detail|client_request_id|thread_open_required|sequence|reacquisition|canonical approval|standalone canonical|global approval inbox" docs/requirements/codex_webui_mvp_requirements_v0_9.md docs/specs/codex_webui_common_spec_v0_9.md docs/specs/codex_webui_public_api_v0_9.md docs/specs/codex_webui_internal_api_v0_9.md docs/specs/codex_webui_ui_layout_spec_v0_9.md docs/specs/codex_webui_app_server_contract_matrix_v0_9.md tasks/issue-180-contract-audit/README.md`
+  - `rg -n "GET /api/v1/approvals|/approvals/stream|ApprovalSummary|ApprovalDetail|canonical approval resource|standalone approval resource|independent approval resource" docs/requirements/codex_webui_mvp_requirements_v0_9.md docs/specs/codex_webui_common_spec_v0_9.md docs/specs/codex_webui_public_api_v0_9.md docs/specs/codex_webui_internal_api_v0_9.md docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+  - Result: tracked diff shows only approved maintained docs changed; the task package was already untracked in this worktree, and direct readback confirmed this README carries the validation and handoff notes. Contract search confirms the requested v0.9 surfaces are now explicit; approval-resource search found no approval endpoints or approval summary/detail schemas, only prohibitive text rejecting canonical or independent approval resources.
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-180-contract-audit`
+- Active worktree: `.worktrees/issue-180-contract-audit`
+- Notes: package opened for the Issue #180 contract audit. No PR has been opened yet.
+- Sprint update 2026-04-23: tightened maintained v0.9 contracts in public/internal/common API specs for Navigation cue material, `thread_view` / `thread_view_helper` helper shape, request-helper identity and minimum confirmation fields, pending-request absence versus missing request detail, `thread_id + sequence` ordering and REST reacquisition triggers, first-input idempotency, and public absorption of internal `thread_open_required`.
+- Follow-up drift discovered: none from implementation surfaces; this sprint was limited to maintained documentation audit and did not inspect or change app implementation. Later UI/BFF/runtime implementation issues should verify their code against the documented contracts above.
+- Pre-push validation 2026-04-23: passed through the dedicated validator gate. Commands covered status, required diff, contract-term search, approval-resource regression search, and `git diff --check`.
+- Completion retrospective 2026-04-23:
+  - Completion boundary: package archive, not Issue close.
+  - Contract check: package exit criteria are satisfied by maintained spec updates, docs log entry, sprint evaluator approval, and passed pre-push validation.
+  - What worked: the orchestrator kept package setup, sprint approval, and pre-push validation as separate gates.
+  - Workflow problems: the active task package remained untracked until archive time, so plain `git diff` did not show the package README; validator readback covered it, but future workers should mention untracked task-package files explicitly in evidence.
+  - Improvements to adopt: keep docs-only contract audits scoped to maintained specs and record implementation conformance as follow-on validation unless the issue explicitly requires code changes.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: publish branch/PR, merge to `main`, sync parent checkout, remove active worktree, then close Issue #180 and set Project status to `Done`.
+
+## Archive conditions
+
+- Archive this package after the audit slice is locally complete, the dedicated pre-push validation gate passes, and the status notes are updated.
+- Do not close Issue #180 or set Project status to `Done` until the work is reachable on `main`, the parent checkout is synced, and the active worktree is cleaned up.


### PR DESCRIPTION
## Summary

- tighten v0.9 public/internal/common contracts for thread list cues, thread_view helpers, request-helper confirmation fields, ordering/reacquisition, first-input idempotency, and open-required absorption
- record the maintained docs update in docs/log.md
- archive the completed Issue #180 work package

## Validation

- sprint evaluator approved the docs-only contract audit
- dedicated pre-push validation passed
- git diff --check
- rg contract-term coverage for thread_view/request/order/idempotency/open-required terms
- rg approval-resource regression search found prohibitive wording only

Closes #180