### PR TITLE
feat(frontend-bff): replace Home with Navigation shell

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -38,7 +38,8 @@ a {
 
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
 }
 
@@ -143,7 +144,8 @@ select {
   padding-top: 8px;
 }
 
-.workspace-switcher select {
+.workspace-switcher select,
+.workspace-switcher input {
   width: 100%;
   border: 1px solid rgba(35, 24, 15, 0.14);
   border-radius: 14px;
@@ -152,7 +154,8 @@ select {
   padding: 10px 12px;
 }
 
-.workspace-switcher select:focus {
+.workspace-switcher select:focus,
+.workspace-switcher input:focus {
   outline: 2px solid rgba(184, 77, 36, 0.22);
   outline-offset: 1px;
 }
@@ -434,6 +437,50 @@ select {
   max-height: 28rem;
   overflow-y: auto;
   padding-right: 4px;
+}
+
+.thread-list-group {
+  display: grid;
+  gap: 8px;
+}
+
+.thread-list-group h3 {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.workspace-option-list,
+.workspace-create-form {
+  display: grid;
+  gap: 8px;
+}
+
+.workspace-option-card {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.68);
+  padding: 12px;
+  color: var(--text-main);
+  text-align: left;
+  cursor: pointer;
+}
+
+.workspace-option-card.active {
+  border-color: rgba(184, 77, 36, 0.4);
+  background: rgba(243, 223, 209, 0.45);
+}
+
+.first-input-card {
+  border: 1px solid rgba(35, 24, 15, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.58);
+  padding: 14px;
 }
 
 .thread-summary-card {

--- a/apps/frontend-bff/app/page.tsx
+++ b/apps/frontend-bff/app/page.tsx
@@ -1,7 +1,7 @@
-import { HomePageClient } from "@/src/home-page-client";
+import { ChatPageClient } from "@/src/chat-page-client";
 
 export const dynamic = "force-dynamic";
 
 export default function HomePage() {
-  return <HomePageClient />;
+  return <ChatPageClient />;
 }

--- a/apps/frontend-bff/src/chat-data.ts
+++ b/apps/frontend-bff/src/chat-data.ts
@@ -1,5 +1,6 @@
 import type { PublicListResponse } from "./chat-types";
 import { isErrorEnvelope } from "./errors";
+import type { HomeResponse } from "./runtime-types";
 import type {
   PublicRequestDetail,
   PublicRequestResponseResult,
@@ -10,6 +11,7 @@ import type {
 } from "./thread-types";
 
 type FetchLike = typeof fetch;
+export type PublicWorkspaceSummary = HomeResponse["workspaces"][number];
 
 async function readJson<T>(response: Response) {
   const payload = (await response.json()) as unknown;
@@ -34,6 +36,32 @@ export async function listWorkspaceThreads(workspaceId: string, fetchImpl: Fetch
   });
 
   return readJson<PublicListResponse<PublicThreadListItem>>(response);
+}
+
+export async function listChatWorkspaces(fetchImpl: FetchLike = fetch) {
+  const response = await fetchImpl("/api/v1/workspaces", {
+    cache: "no-store",
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  return readJson<PublicListResponse<PublicWorkspaceSummary>>(response);
+}
+
+export async function createWorkspaceFromChat(workspaceName: string, fetchImpl: FetchLike = fetch) {
+  const response = await fetchImpl("/api/v1/workspaces", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      workspace_name: workspaceName,
+    }),
+  });
+
+  return readJson<PublicWorkspaceSummary>(response);
 }
 
 export async function startThreadFromChat(

--- a/apps/frontend-bff/src/chat-page-client.tsx
+++ b/apps/frontend-bff/src/chat-page-client.tsx
@@ -4,9 +4,12 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 import {
+  createWorkspaceFromChat,
   interruptThreadFromChat,
+  listChatWorkspaces,
   listWorkspaceThreads,
   loadChatThreadBundle,
+  type PublicWorkspaceSummary,
   respondToPendingRequest,
   sendThreadInput,
   startThreadFromChat,
@@ -75,10 +78,36 @@ function hasStreamSequenceInconsistency(
   return maxSequence > 0 && nextEvent.sequence > maxSequence + 1;
 }
 
+function chooseDefaultWorkspaceId(workspaces: PublicWorkspaceSummary[]) {
+  return (
+    workspaces.toSorted((left, right) => right.updated_at.localeCompare(left.updated_at))[0]
+      ?.workspace_id ?? null
+  );
+}
+
+function replaceChatUrl(workspaceId: string | null, threadId: string | null) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const params = new URLSearchParams();
+  if (workspaceId) {
+    params.set("workspaceId", workspaceId);
+  }
+  if (threadId) {
+    params.set("threadId", threadId);
+  }
+
+  const nextUrl = params.size > 0 ? `/chat?${params.toString()}` : "/chat";
+  window.history.replaceState(null, "", nextUrl);
+}
+
 export function ChatPageClient() {
   const searchParams = useSearchParams();
-  const workspaceId = searchParams.get("workspaceId");
+  const initialWorkspaceId = searchParams.get("workspaceId");
   const initialThreadId = searchParams.get("threadId");
+  const [workspaces, setWorkspaces] = useState<PublicWorkspaceSummary[]>([]);
+  const [workspaceId, setWorkspaceId] = useState<string | null>(initialWorkspaceId);
   const [threads, setThreads] = useState<PublicThreadListItem[]>([]);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(initialThreadId);
   const [selectedThreadView, setSelectedThreadView] = useState<PublicThreadView | null>(null);
@@ -92,6 +121,9 @@ export function ChatPageClient() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isLoadingThreads, setIsLoadingThreads] = useState(false);
+  const [isLoadingWorkspaces, setIsLoadingWorkspaces] = useState(false);
+  const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
+  const [workspaceName, setWorkspaceName] = useState("");
   const [isLoadingThread, setIsLoadingThread] = useState(false);
   const [isCreatingThread, setIsCreatingThread] = useState(false);
   const [isSendingMessage, setIsSendingMessage] = useState(false);
@@ -119,6 +151,31 @@ export function ChatPageClient() {
     });
     selectedThreadIdRef.current = nextThreadId;
     setSelectedThreadId(nextThreadId);
+    replaceChatUrl(workspaceId, nextThreadId);
+  }
+
+  async function refreshWorkspaces(preferredWorkspaceId?: string | null) {
+    const nextPreferredWorkspaceId = preferredWorkspaceId ?? workspaceId;
+    setIsLoadingWorkspaces(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await listChatWorkspaces();
+      setWorkspaces(response.items);
+
+      const nextWorkspaceId =
+        nextPreferredWorkspaceId &&
+        response.items.some((workspace) => workspace.workspace_id === nextPreferredWorkspaceId)
+          ? nextPreferredWorkspaceId
+          : chooseDefaultWorkspaceId(response.items);
+
+      setWorkspaceId(nextWorkspaceId);
+      replaceChatUrl(nextWorkspaceId, selectedThreadIdRef.current);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Failed to load workspaces.");
+    } finally {
+      setIsLoadingWorkspaces(false);
+    }
   }
 
   async function convergeStartedThreadSendability(threadId: string) {
@@ -177,13 +234,10 @@ export function ChatPageClient() {
       const nextSelectedThreadId =
         preferredThreadId && response.items.some((thread) => thread.thread_id === preferredThreadId)
           ? preferredThreadId
-          : selectedThreadId &&
-              response.items.some((thread) => thread.thread_id === selectedThreadId)
-            ? selectedThreadId
-            : initialThreadId &&
-                response.items.some((thread) => thread.thread_id === initialThreadId)
-              ? initialThreadId
-              : (response.items[0]?.thread_id ?? null);
+          : selectedThreadIdRef.current &&
+              response.items.some((thread) => thread.thread_id === selectedThreadIdRef.current)
+            ? selectedThreadIdRef.current
+            : null;
 
       updateSelectedThreadId(nextSelectedThreadId, "refresh_threads", {
         refresh_id: refreshId,
@@ -246,8 +300,12 @@ export function ChatPageClient() {
   }
 
   useEffect(() => {
+    void refreshWorkspaces(initialWorkspaceId);
+  }, []);
+
+  useEffect(() => {
     void refreshThreads(initialThreadId);
-  }, [workspaceId, initialThreadId]);
+  }, [workspaceId]);
 
   useEffect(() => {
     selectedThreadIdRef.current = selectedThreadId;
@@ -463,7 +521,7 @@ export function ChatPageClient() {
 
   async function handleCreateThread() {
     if (!workspaceId) {
-      setErrorMessage("Choose a workspace from Home before starting a thread.");
+      setErrorMessage("Choose or create a workspace before starting a thread.");
       return;
     }
 
@@ -494,6 +552,58 @@ export function ChatPageClient() {
       setErrorMessage(error instanceof Error ? error.message : "Failed to start a new thread.");
     } finally {
       setIsCreatingThread(false);
+    }
+  }
+
+  async function handleSelectWorkspace(nextWorkspaceId: string) {
+    if (nextWorkspaceId === workspaceId) {
+      return;
+    }
+
+    setWorkspaceId(nextWorkspaceId);
+    setThreads([]);
+    updateSelectedThreadId(null, "user_select_workspace", {
+      workspace_id: nextWorkspaceId,
+    });
+    setSelectedThreadView(null);
+    setSelectedRequestDetail(null);
+    setStreamEvents([]);
+    streamEventsRef.current = [];
+    setDraftAssistantMessages({});
+    setStatusMessage(null);
+    setErrorMessage(null);
+    replaceChatUrl(nextWorkspaceId, null);
+  }
+
+  async function handleCreateWorkspace() {
+    const trimmedName = workspaceName.trim();
+    if (trimmedName.length === 0) {
+      return;
+    }
+
+    setIsCreatingWorkspace(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const workspace = await createWorkspaceFromChat(trimmedName);
+      setWorkspaceName("");
+      setStatusMessage(`Created workspace ${workspace.workspace_name}.`);
+      setWorkspaces((currentWorkspaces) => [
+        workspace,
+        ...currentWorkspaces.filter((item) => item.workspace_id !== workspace.workspace_id),
+      ]);
+      setWorkspaceId(workspace.workspace_id);
+      setThreads([]);
+      updateSelectedThreadId(null, "create_workspace_success", {
+        workspace_id: workspace.workspace_id,
+      });
+      replaceChatUrl(workspace.workspace_id, null);
+      void refreshWorkspaces(workspace.workspace_id);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Failed to create workspace.");
+    } finally {
+      setIsCreatingWorkspace(false);
     }
   }
 
@@ -577,21 +687,26 @@ export function ChatPageClient() {
       draftAssistantMessages={draftAssistantMessages}
       errorMessage={errorMessage}
       isCreatingThread={isCreatingThread}
+      isCreatingWorkspace={isCreatingWorkspace}
       isInterruptingThread={isInterruptingThread}
       isLoadingThread={isLoadingThread}
       isLoadingThreads={isLoadingThreads}
+      isLoadingWorkspaces={isLoadingWorkspaces}
       isRespondingToRequest={isRespondingToRequest}
       isSendingMessage={isSendingMessage}
       messageDraft={messageDraft}
       newThreadInput={newThreadInput}
       onApproveRequest={() => void handleRequestDecision("approved")}
       onCreateThread={() => void handleCreateThread()}
+      onCreateWorkspace={() => void handleCreateWorkspace()}
       onMessageDraftChange={setMessageDraft}
       onNewThreadInputChange={setNewThreadInput}
       onDenyRequest={() => void handleRequestDecision("denied")}
       onInterruptThread={() => void handleInterruptThread()}
+      onSelectWorkspace={(nextWorkspaceId) => void handleSelectWorkspace(nextWorkspaceId)}
       onSelectThread={(threadId) => updateSelectedThreadId(threadId, "user_select_thread")}
       onSendMessage={() => void handleSendMessage()}
+      onWorkspaceNameChange={setWorkspaceName}
       selectedRequestDetail={selectedRequestDetail}
       selectedThreadId={selectedThreadId}
       selectedThreadView={selectedThreadView}
@@ -599,6 +714,8 @@ export function ChatPageClient() {
       streamEvents={streamEvents}
       threads={threads}
       workspaceId={workspaceId}
+      workspaceName={workspaceName}
+      workspaces={workspaces}
     />
   );
 }

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import type { PublicWorkspaceSummary } from "./chat-data";
 import type {
   PublicRequestDetail,
   PublicThreadListItem,
@@ -11,6 +12,7 @@ import type {
 
 export interface ChatViewProps {
   workspaceId: string | null;
+  workspaces: PublicWorkspaceSummary[];
   threads: PublicThreadListItem[];
   selectedThreadId: string | null;
   selectedThreadView: PublicThreadView | null;
@@ -18,6 +20,8 @@ export interface ChatViewProps {
   streamEvents: PublicThreadStreamEvent[];
   draftAssistantMessages: Record<string, string>;
   isLoadingThreads: boolean;
+  isLoadingWorkspaces: boolean;
+  isCreatingWorkspace: boolean;
   isLoadingThread: boolean;
   isCreatingThread: boolean;
   isSendingMessage: boolean;
@@ -26,11 +30,15 @@ export interface ChatViewProps {
   connectionState: "idle" | "live" | "reconnecting";
   errorMessage: string | null;
   statusMessage: string | null;
+  workspaceName: string;
   newThreadInput: string;
   messageDraft: string;
+  onWorkspaceNameChange: (value: string) => void;
   onNewThreadInputChange: (value: string) => void;
   onMessageDraftChange: (value: string) => void;
   onCreateThread: () => void;
+  onCreateWorkspace: () => void;
+  onSelectWorkspace: (workspaceId: string) => void;
   onSelectThread: (threadId: string) => void;
   onSendMessage: () => void;
   onInterruptThread: () => void;
@@ -85,6 +93,54 @@ function formatMachineLabel(value: string | null | undefined) {
   return value ? value.replaceAll("_", " ") : "Not available";
 }
 
+function hasAttentionCue(thread: PublicThreadListItem) {
+  return (
+    thread.blocked_cue !== null ||
+    thread.resume_cue?.priority_band === "highest" ||
+    thread.current_activity.kind === "waiting_on_approval" ||
+    thread.current_activity.kind === "system_error" ||
+    thread.current_activity.kind === "latest_turn_failed"
+  );
+}
+
+function isActiveThread(thread: PublicThreadListItem) {
+  return thread.current_activity.kind === "running";
+}
+
+function groupThreads(threads: PublicThreadListItem[]) {
+  const attentionNeeded = threads.filter(hasAttentionCue);
+  const active = threads.filter(
+    (thread) =>
+      isActiveThread(thread) &&
+      !attentionNeeded.some((item) => item.thread_id === thread.thread_id),
+  );
+  const recent = threads.filter(
+    (thread) =>
+      !attentionNeeded.some((item) => item.thread_id === thread.thread_id) &&
+      !active.some((item) => item.thread_id === thread.thread_id),
+  );
+
+  return [
+    { label: "Attention needed", threads: attentionNeeded },
+    { label: "Active", threads: active },
+    { label: "Recent", threads: recent },
+  ].filter((group) => group.threads.length > 0);
+}
+
+function workspaceSummary(workspace: PublicWorkspaceSummary) {
+  if (workspace.pending_approval_count > 0) {
+    return `${workspace.pending_approval_count} approval${
+      workspace.pending_approval_count === 1 ? "" : "s"
+    }`;
+  }
+
+  if (workspace.active_session_summary) {
+    return `${formatMachineLabel(workspace.active_session_summary.status)} activity`;
+  }
+
+  return `Updated ${formatTimestamp(workspace.updated_at)}`;
+}
+
 type ThreadDetailSelection =
   | { kind: "request_detail" }
   | { kind: "timeline_item_detail"; timelineItemId: string };
@@ -95,6 +151,7 @@ function timelineItemLabel(item: PublicTimelineItem) {
 
 export function ChatView({
   workspaceId,
+  workspaces,
   threads,
   selectedThreadId,
   selectedThreadView,
@@ -102,6 +159,8 @@ export function ChatView({
   streamEvents,
   draftAssistantMessages,
   isLoadingThreads,
+  isLoadingWorkspaces,
+  isCreatingWorkspace,
   isLoadingThread,
   isCreatingThread,
   isSendingMessage,
@@ -110,11 +169,15 @@ export function ChatView({
   connectionState,
   errorMessage,
   statusMessage,
+  workspaceName,
   newThreadInput,
   messageDraft,
+  onWorkspaceNameChange,
   onNewThreadInputChange,
   onMessageDraftChange,
   onCreateThread,
+  onCreateWorkspace,
+  onSelectWorkspace,
   onSelectThread,
   onSendMessage,
   onInterruptThread,
@@ -124,6 +187,9 @@ export function ChatView({
   const draftEntries = Object.entries(draftAssistantMessages);
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
+  const selectedWorkspace =
+    workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
+  const threadGroups = groupThreads(threads);
   const selectedTimelineItem =
     detailSelection?.kind === "timeline_item_detail"
       ? (selectedThreadView?.timeline.items.find(
@@ -146,7 +212,7 @@ export function ChatView({
       <header className="chat-topbar">
         <div>
           <p className="eyebrow">thread_view</p>
-          <h1>Chat</h1>
+          <h1>{selectedWorkspace?.workspace_name ?? "Thread workspace"}</h1>
         </div>
         <div className="chat-topbar-actions">
           <button
@@ -156,20 +222,9 @@ export function ChatView({
           >
             {isNavigationOpen ? "Close threads" : "Threads"}
           </button>
-          <Link className="secondary-link" href="/">
-            Home
-          </Link>
         </div>
       </header>
       <div className="chat-layout">
-        {!workspaceId ? (
-          <section className="placeholder-card">
-            <p className="eyebrow">Missing workspace</p>
-            <h1>Start from Home</h1>
-            <p>Open Chat from the Home workspace cards so the workspace context is already set.</p>
-          </section>
-        ) : null}
-
         {errorMessage || statusMessage ? (
           <div aria-live="polite" className="chat-feedback-stack">
             {errorMessage ? (
@@ -185,57 +240,88 @@ export function ChatView({
           </div>
         ) : null}
 
-        {workspaceId ? (
-          <>
-            <section
-              className={
-                isNavigationOpen
-                  ? "chat-panel create-card thread-navigation open"
-                  : "chat-panel create-card thread-navigation"
-              }
-            >
-              <header>
-                <p className="eyebrow">Threads</p>
-                <h2>Start or resume a thread</h2>
-                <p className="field-hint">
-                  New threads start from first input. Existing threads reload from `thread_view` and
-                  `timeline`.
-                </p>
-              </header>
+        <section
+          className={
+            isNavigationOpen
+              ? "chat-panel create-card thread-navigation open"
+              : "chat-panel create-card thread-navigation"
+          }
+        >
+          <header>
+            <p className="eyebrow">Navigation</p>
+            <h2>{selectedWorkspace?.workspace_name ?? "Select workspace"}</h2>
+            <p className="workspace-meta">
+              {workspaceId ? `Workspace: ${workspaceId}` : "Choose or create a workspace."}
+            </p>
+          </header>
 
-              <div className="create-form">
-                <label className="form-label" htmlFor="thread-input">
-                  First input
-                  <textarea
-                    className="chat-textarea"
-                    id="thread-input"
-                    name="thread-input"
-                    onChange={(event) => onNewThreadInputChange(event.target.value)}
-                    placeholder="Describe the task to start a new thread."
-                    rows={4}
-                    value={newThreadInput}
+          <details className="workspace-switcher">
+            <summary>Switch workspace</summary>
+            <div className="workspace-switcher-control">
+              {isLoadingWorkspaces ? (
+                <p className="workspace-status">Loading workspaces...</p>
+              ) : null}
+              {workspaces.length > 0 ? (
+                <div className="workspace-option-list">
+                  {workspaces.map((workspace) => (
+                    <button
+                      className={
+                        workspace.workspace_id === workspaceId
+                          ? "workspace-option-card active"
+                          : "workspace-option-card"
+                      }
+                      key={workspace.workspace_id}
+                      onClick={() => onSelectWorkspace(workspace.workspace_id)}
+                      type="button"
+                    >
+                      <strong>{workspace.workspace_name}</strong>
+                      <span className="workspace-meta">{workspace.workspace_id}</span>
+                      <span className="workspace-meta">{workspaceSummary(workspace)}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : !isLoadingWorkspaces ? (
+                <p className="empty-state">Create a workspace to start scoped work.</p>
+              ) : null}
+
+              <div className="create-form workspace-create-form">
+                <label className="form-label" htmlFor="workspace-name">
+                  New workspace
+                  <input
+                    id="workspace-name"
+                    name="workspace-name"
+                    onChange={(event) => onWorkspaceNameChange(event.target.value)}
+                    placeholder="Workspace name"
+                    value={workspaceName}
                   />
                 </label>
                 <button
                   className="submit-button"
-                  disabled={isCreatingThread || newThreadInput.trim().length === 0}
-                  onClick={onCreateThread}
+                  disabled={isCreatingWorkspace || workspaceName.trim().length === 0}
+                  onClick={onCreateWorkspace}
                   type="button"
                 >
-                  {isCreatingThread ? "Starting thread..." : "Start new thread"}
+                  {isCreatingWorkspace ? "Creating..." : "Create workspace"}
                 </button>
               </div>
+            </div>
+          </details>
 
-              <div className="thread-list">
-                {isLoadingThreads ? <p className="workspace-status">Loading threads...</p> : null}
+          <div className="thread-list">
+            {isLoadingThreads ? <p className="workspace-status">Loading threads...</p> : null}
 
-                {!isLoadingThreads && threads.length === 0 ? (
-                  <p className="empty-state">
-                    No threads yet. Send first input above to start the thread flow.
-                  </p>
-                ) : null}
+            {!workspaceId && !isLoadingWorkspaces ? (
+              <p className="empty-state">Select a workspace to show its threads.</p>
+            ) : null}
 
-                {threads.map((thread) => (
+            {workspaceId && !isLoadingThreads && threads.length === 0 ? (
+              <p className="empty-state">No threads yet. Use Ask Codex in Thread View.</p>
+            ) : null}
+
+            {threadGroups.map((group) => (
+              <section className="thread-list-group" key={group.label}>
+                <h3>{group.label}</h3>
+                {group.threads.map((thread) => (
                   <button
                     className={
                       selectedThreadId === thread.thread_id
@@ -253,6 +339,16 @@ export function ChatView({
                       </span>
                     </div>
                     <strong>{thread.thread_id}</strong>
+                    {thread.badge ? (
+                      <span className="workspace-meta">
+                        {formatMachineLabel(thread.badge.label)}
+                      </span>
+                    ) : null}
+                    {thread.blocked_cue ? (
+                      <span className="workspace-meta">
+                        Blocked: {formatMachineLabel(thread.blocked_cue.label)}
+                      </span>
+                    ) : null}
                     <span className="workspace-meta">
                       Updated {formatTimestamp(thread.updated_at)}
                     </span>
@@ -263,66 +359,334 @@ export function ChatView({
                     ) : null}
                   </button>
                 ))}
+              </section>
+            ))}
+          </div>
+        </section>
+
+        <section className="chat-panel workspace-card thread-view-card">
+          <header>
+            <div className="workspace-meta-row">
+              <p className="eyebrow">Current thread</p>
+              {selectedThreadView ? (
+                <span className="status-badge success">
+                  {selectedThreadView.current_activity.label}
+                </span>
+              ) : null}
+            </div>
+            <h2>{selectedThreadView?.thread.thread_id ?? "Select a thread"}</h2>
+            <p className="workspace-meta">
+              {selectedThreadView
+                ? `Updated ${formatTimestamp(selectedThreadView.thread.updated_at)}`
+                : workspaceId
+                  ? "Ask Codex to start a new thread, or pick a thread from Navigation."
+                  : "Select or create a workspace from Navigation before starting work."}
+            </p>
+            <div className="hero-metrics thread-context-metrics">
+              <span className="metric-chip">Workspace: {workspaceId}</span>
+              <span className="metric-chip">
+                Stream:{" "}
+                {connectionState === "live"
+                  ? "live"
+                  : connectionState === "reconnecting"
+                    ? "reacquiring"
+                    : "idle"}
+              </span>
+              <span className="metric-chip">Threads: {threads.length}</span>
+              {workspaceId ? (
+                <Link
+                  className="secondary-link compact-link"
+                  href={threadChatHref(workspaceId, selectedThreadId ?? undefined)}
+                >
+                  Refresh
+                </Link>
+              ) : null}
+            </div>
+          </header>
+
+          {workspaceId && !selectedThreadView ? (
+            <div className="create-form first-input-card">
+              <label className="form-label" htmlFor="thread-input">
+                Ask Codex
+                <textarea
+                  className="chat-textarea"
+                  id="thread-input"
+                  name="thread-input"
+                  onChange={(event) => onNewThreadInputChange(event.target.value)}
+                  placeholder="Describe the task to start a new thread."
+                  rows={4}
+                  value={newThreadInput}
+                />
+              </label>
+              <button
+                className="submit-button"
+                disabled={isCreatingThread || newThreadInput.trim().length === 0}
+                onClick={onCreateThread}
+                type="button"
+              >
+                {isCreatingThread ? "Starting thread..." : "Start thread"}
+              </button>
+            </div>
+          ) : null}
+
+          {selectedThreadView?.pending_request ? (
+            <div className="request-detail-card pending-request-card">
+              <div className="workspace-meta-row">
+                <strong>Pending request</strong>
+                <span className={requestBadgeClass(selectedRequestDetail)}>
+                  {formatMachineLabel(selectedThreadView.pending_request.risk_category)}
+                </span>
               </div>
-            </section>
-
-            <section className="chat-panel workspace-card thread-view-card">
-              <header>
-                <div className="workspace-meta-row">
-                  <p className="eyebrow">Current thread</p>
-                  {selectedThreadView ? (
-                    <span className="status-badge success">
-                      {selectedThreadView.current_activity.label}
-                    </span>
-                  ) : null}
-                </div>
-                <h2>{selectedThreadView?.thread.thread_id ?? "Select a thread"}</h2>
-                <p className="workspace-meta">
-                  {selectedThreadView
-                    ? `Updated ${formatTimestamp(selectedThreadView.thread.updated_at)}`
-                    : "Pick a thread from the list to load current activity and requests."}
-                </p>
-                <div className="hero-metrics thread-context-metrics">
-                  <span className="metric-chip">Workspace: {workspaceId}</span>
-                  <span className="metric-chip">
-                    Stream:{" "}
-                    {connectionState === "live"
-                      ? "live"
-                      : connectionState === "reconnecting"
-                        ? "reacquiring"
-                        : "idle"}
-                  </span>
-                  <span className="metric-chip">Threads: {threads.length}</span>
-                  <Link
-                    className="secondary-link compact-link"
-                    href={threadChatHref(workspaceId, selectedThreadId ?? undefined)}
+              <p>{selectedThreadView.pending_request.summary}</p>
+              {selectedRequestDetail ? (
+                <p className="workspace-meta">{selectedRequestDetail.reason}</p>
+              ) : null}
+              <p className="workspace-meta">
+                Requested {formatTimestamp(selectedThreadView.pending_request.requested_at)}
+              </p>
+              <div className="workspace-actions">
+                <button
+                  className="primary-link action-button"
+                  disabled={isRespondingToRequest || selectedRequestDetail?.status !== "pending"}
+                  onClick={onApproveRequest}
+                  type="button"
+                >
+                  {isRespondingToRequest ? "Submitting..." : "Approve request"}
+                </button>
+                <button
+                  className="secondary-link action-button"
+                  disabled={isRespondingToRequest || selectedRequestDetail?.status !== "pending"}
+                  onClick={onDenyRequest}
+                  type="button"
+                >
+                  Deny request
+                </button>
+                {selectedRequestDetail ? (
+                  <button
+                    className="secondary-link action-button"
+                    onClick={() => setDetailSelection({ kind: "request_detail" })}
+                    type="button"
                   >
-                    Refresh
-                  </Link>
-                </div>
-              </header>
+                    Request detail
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          ) : selectedThreadView?.latest_resolved_request ? (
+            <div className="request-detail-card resolved-request-card">
+              <div className="workspace-meta-row">
+                <strong>Latest resolved request</strong>
+                <span className={requestBadgeClass(selectedRequestDetail)}>
+                  {selectedThreadView.latest_resolved_request.decision}
+                </span>
+              </div>
+              <p>Decision: {selectedThreadView.latest_resolved_request.decision}</p>
+              <p className="workspace-meta">
+                Responded {formatTimestamp(selectedThreadView.latest_resolved_request.responded_at)}
+              </p>
+              {selectedRequestDetail ? (
+                <button
+                  className="secondary-link action-button inline-detail-button"
+                  onClick={() => setDetailSelection({ kind: "request_detail" })}
+                  type="button"
+                >
+                  Reopen request detail
+                </button>
+              ) : null}
+            </div>
+          ) : null}
 
-              {selectedThreadView?.pending_request ? (
-                <div className="request-detail-card pending-request-card">
+          <div className="workspace-actions">
+            <button
+              className="secondary-link action-button"
+              disabled={!selectedThreadView?.composer.interrupt_available || isInterruptingThread}
+              onClick={onInterruptThread}
+              type="button"
+            >
+              {isInterruptingThread ? "Interrupting..." : "Interrupt thread"}
+            </button>
+          </div>
+
+          <section className="timeline-section" aria-label="Timeline">
+            <header>
+              <p className="eyebrow">Timeline</p>
+              <h2>Thread context</h2>
+            </header>
+
+            {isLoadingThread ? (
+              <p className="workspace-status">Refreshing thread detail...</p>
+            ) : null}
+
+            <div className="chat-message-list">
+              {!isLoadingThread &&
+              selectedThreadView &&
+              selectedThreadView.timeline.items.length === 0 &&
+              draftEntries.length === 0 ? (
+                <p className="empty-state">
+                  No timeline items yet. Start the thread or send follow-up input to continue.
+                </p>
+              ) : null}
+
+              {selectedThreadView?.timeline.items.map((item) => (
+                <article className="chat-message assistant" key={item.timeline_item_id}>
                   <div className="workspace-meta-row">
-                    <strong>Pending request</strong>
-                    <span className={requestBadgeClass(selectedRequestDetail)}>
-                      {formatMachineLabel(selectedThreadView.pending_request.risk_category)}
-                    </span>
+                    <strong>{item.kind}</strong>
+                    <span className="workspace-meta">{formatTimestamp(item.occurred_at)}</span>
                   </div>
-                  <p>{selectedThreadView.pending_request.summary}</p>
-                  {selectedRequestDetail ? (
-                    <p className="workspace-meta">{selectedRequestDetail.reason}</p>
-                  ) : null}
-                  <p className="workspace-meta">
-                    Requested {formatTimestamp(selectedThreadView.pending_request.requested_at)}
+                  <p>{timelineItemLabel(item)}</p>
+                  <button
+                    className="secondary-link action-button inline-detail-button"
+                    onClick={() =>
+                      setDetailSelection({
+                        kind: "timeline_item_detail",
+                        timelineItemId: item.timeline_item_id,
+                      })
+                    }
+                    type="button"
+                  >
+                    Timeline item detail
+                  </button>
+                </article>
+              ))}
+
+              {draftEntries.map(([messageId, content]) => (
+                <article className="chat-message assistant" key={messageId}>
+                  <div className="workspace-meta-row">
+                    <strong>assistant streaming</strong>
+                    <span className="workspace-meta">Live</span>
+                  </div>
+                  <p>{content}…</p>
+                </article>
+              ))}
+
+              {streamEvents.map((event) => (
+                <article className="chat-message user" key={event.event_id}>
+                  <div className="workspace-meta-row">
+                    <strong>{event.event_type}</strong>
+                    <span className="workspace-meta">{formatTimestamp(event.occurred_at)}</span>
+                  </div>
+                  <p>
+                    {String(
+                      event.payload.content ??
+                        event.payload.summary ??
+                        event.payload.message ??
+                        event.event_type,
+                    )}
                   </p>
-                  <div className="workspace-actions">
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <div className="chat-composer">
+            <label className="form-label" htmlFor="message-input">
+              Send follow-up input
+              <textarea
+                className="chat-textarea"
+                id="message-input"
+                name="message-input"
+                onChange={(event) => onMessageDraftChange(event.target.value)}
+                placeholder="Continue the current thread."
+                rows={4}
+                value={messageDraft}
+              />
+            </label>
+            <button
+              className="submit-button"
+              disabled={
+                !selectedThreadView?.composer.accepting_user_input ||
+                isSendingMessage ||
+                messageDraft.trim().length === 0
+              }
+              onClick={onSendMessage}
+              type="button"
+            >
+              {isSendingMessage ? "Sending..." : "Send reply"}
+            </button>
+          </div>
+        </section>
+
+        {detailSelection ? (
+          <aside className="chat-panel workspace-card thread-detail-surface">
+            <header>
+              <div className="workspace-meta-row">
+                <p className="eyebrow">Detail</p>
+                <button
+                  className="secondary-link action-button compact-button"
+                  onClick={() => setDetailSelection(null)}
+                  type="button"
+                >
+                  Close
+                </button>
+              </div>
+              <h2>
+                {detailSelection.kind === "request_detail"
+                  ? "Request detail"
+                  : "Timeline item detail"}
+              </h2>
+            </header>
+
+            {detailSelection.kind === "request_detail" && selectedRequestDetail ? (
+              <div className="detail-stack">
+                <div className="workspace-meta-row">
+                  <span className={requestBadgeClass(selectedRequestDetail)}>
+                    {selectedRequestDetail.status}
+                  </span>
+                  <span className="status-badge">
+                    {formatMachineLabel(selectedRequestDetail.risk_category)}
+                  </span>
+                </div>
+                <p>{selectedRequestDetail.summary}</p>
+                <dl className="request-detail-list">
+                  <div>
+                    <dt>Reason</dt>
+                    <dd>{selectedRequestDetail.reason}</dd>
+                  </div>
+                  {selectedRequestDetail.operation_summary ? (
+                    <div>
+                      <dt>Operation</dt>
+                      <dd>{selectedRequestDetail.operation_summary}</dd>
+                    </div>
+                  ) : null}
+                  <div>
+                    <dt>Requested</dt>
+                    <dd>{formatTimestamp(selectedRequestDetail.requested_at)}</dd>
+                  </div>
+                  <div>
+                    <dt>Thread</dt>
+                    <dd>{selectedRequestDetail.thread_id}</dd>
+                  </div>
+                  <div>
+                    <dt>Turn</dt>
+                    <dd>{selectedRequestDetail.turn_id ?? "Not available"}</dd>
+                  </div>
+                  <div>
+                    <dt>Item</dt>
+                    <dd>{selectedRequestDetail.item_id}</dd>
+                  </div>
+                  {selectedRequestDetail.decision ? (
+                    <div>
+                      <dt>Decision</dt>
+                      <dd>{selectedRequestDetail.decision}</dd>
+                    </div>
+                  ) : null}
+                  {selectedRequestDetail.responded_at ? (
+                    <div>
+                      <dt>Responded</dt>
+                      <dd>{formatTimestamp(selectedRequestDetail.responded_at)}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+                {selectedRequestDetail.operation_summary ? (
+                  <p className="request-operation-summary">
+                    Operation: {selectedRequestDetail.operation_summary}
+                  </p>
+                ) : null}
+                {selectedRequestDetail.status === "pending" ? (
+                  <div className="workspace-actions request-detail-actions">
                     <button
                       className="primary-link action-button"
-                      disabled={
-                        isRespondingToRequest || selectedRequestDetail?.status !== "pending"
-                      }
+                      disabled={isRespondingToRequest}
                       onClick={onApproveRequest}
                       type="button"
                     >
@@ -330,276 +694,29 @@ export function ChatView({
                     </button>
                     <button
                       className="secondary-link action-button"
-                      disabled={
-                        isRespondingToRequest || selectedRequestDetail?.status !== "pending"
-                      }
+                      disabled={isRespondingToRequest}
                       onClick={onDenyRequest}
                       type="button"
                     >
                       Deny request
                     </button>
-                    {selectedRequestDetail ? (
-                      <button
-                        className="secondary-link action-button"
-                        onClick={() => setDetailSelection({ kind: "request_detail" })}
-                        type="button"
-                      >
-                        Request detail
-                      </button>
-                    ) : null}
                   </div>
-                </div>
-              ) : selectedThreadView?.latest_resolved_request ? (
-                <div className="request-detail-card resolved-request-card">
-                  <div className="workspace-meta-row">
-                    <strong>Latest resolved request</strong>
-                    <span className={requestBadgeClass(selectedRequestDetail)}>
-                      {selectedThreadView.latest_resolved_request.decision}
-                    </span>
-                  </div>
-                  <p>Decision: {selectedThreadView.latest_resolved_request.decision}</p>
-                  <p className="workspace-meta">
-                    Responded{" "}
-                    {formatTimestamp(selectedThreadView.latest_resolved_request.responded_at)}
-                  </p>
-                  {selectedRequestDetail ? (
-                    <button
-                      className="secondary-link action-button inline-detail-button"
-                      onClick={() => setDetailSelection({ kind: "request_detail" })}
-                      type="button"
-                    >
-                      Reopen request detail
-                    </button>
-                  ) : null}
-                </div>
-              ) : null}
-
-              <div className="workspace-actions">
-                <button
-                  className="secondary-link action-button"
-                  disabled={
-                    !selectedThreadView?.composer.interrupt_available || isInterruptingThread
-                  }
-                  onClick={onInterruptThread}
-                  type="button"
-                >
-                  {isInterruptingThread ? "Interrupting..." : "Interrupt thread"}
-                </button>
+                ) : null}
               </div>
-
-              <section className="timeline-section" aria-label="Timeline">
-                <header>
-                  <p className="eyebrow">Timeline</p>
-                  <h2>Thread context</h2>
-                </header>
-
-                {isLoadingThread ? (
-                  <p className="workspace-status">Refreshing thread detail...</p>
-                ) : null}
-
-                <div className="chat-message-list">
-                  {!isLoadingThread &&
-                  selectedThreadView &&
-                  selectedThreadView.timeline.items.length === 0 &&
-                  draftEntries.length === 0 ? (
-                    <p className="empty-state">
-                      No timeline items yet. Start the thread or send follow-up input to continue.
-                    </p>
-                  ) : null}
-
-                  {selectedThreadView?.timeline.items.map((item) => (
-                    <article className="chat-message assistant" key={item.timeline_item_id}>
-                      <div className="workspace-meta-row">
-                        <strong>{item.kind}</strong>
-                        <span className="workspace-meta">{formatTimestamp(item.occurred_at)}</span>
-                      </div>
-                      <p>{timelineItemLabel(item)}</p>
-                      <button
-                        className="secondary-link action-button inline-detail-button"
-                        onClick={() =>
-                          setDetailSelection({
-                            kind: "timeline_item_detail",
-                            timelineItemId: item.timeline_item_id,
-                          })
-                        }
-                        type="button"
-                      >
-                        Timeline item detail
-                      </button>
-                    </article>
-                  ))}
-
-                  {draftEntries.map(([messageId, content]) => (
-                    <article className="chat-message assistant" key={messageId}>
-                      <div className="workspace-meta-row">
-                        <strong>assistant streaming</strong>
-                        <span className="workspace-meta">Live</span>
-                      </div>
-                      <p>{content}…</p>
-                    </article>
-                  ))}
-
-                  {streamEvents.map((event) => (
-                    <article className="chat-message user" key={event.event_id}>
-                      <div className="workspace-meta-row">
-                        <strong>{event.event_type}</strong>
-                        <span className="workspace-meta">{formatTimestamp(event.occurred_at)}</span>
-                      </div>
-                      <p>
-                        {String(
-                          event.payload.content ??
-                            event.payload.summary ??
-                            event.payload.message ??
-                            event.event_type,
-                        )}
-                      </p>
-                    </article>
-                  ))}
-                </div>
-              </section>
-
-              <div className="chat-composer">
-                <label className="form-label" htmlFor="message-input">
-                  Send follow-up input
-                  <textarea
-                    className="chat-textarea"
-                    id="message-input"
-                    name="message-input"
-                    onChange={(event) => onMessageDraftChange(event.target.value)}
-                    placeholder="Continue the current thread."
-                    rows={4}
-                    value={messageDraft}
-                  />
-                </label>
-                <button
-                  className="submit-button"
-                  disabled={
-                    !selectedThreadView?.composer.accepting_user_input ||
-                    isSendingMessage ||
-                    messageDraft.trim().length === 0
-                  }
-                  onClick={onSendMessage}
-                  type="button"
-                >
-                  {isSendingMessage ? "Sending..." : "Send reply"}
-                </button>
-              </div>
-            </section>
-
-            {detailSelection ? (
-              <aside className="chat-panel workspace-card thread-detail-surface">
-                <header>
-                  <div className="workspace-meta-row">
-                    <p className="eyebrow">Detail</p>
-                    <button
-                      className="secondary-link action-button compact-button"
-                      onClick={() => setDetailSelection(null)}
-                      type="button"
-                    >
-                      Close
-                    </button>
-                  </div>
-                  <h2>
-                    {detailSelection.kind === "request_detail"
-                      ? "Request detail"
-                      : "Timeline item detail"}
-                  </h2>
-                </header>
-
-                {detailSelection.kind === "request_detail" && selectedRequestDetail ? (
-                  <div className="detail-stack">
-                    <div className="workspace-meta-row">
-                      <span className={requestBadgeClass(selectedRequestDetail)}>
-                        {selectedRequestDetail.status}
-                      </span>
-                      <span className="status-badge">
-                        {formatMachineLabel(selectedRequestDetail.risk_category)}
-                      </span>
-                    </div>
-                    <p>{selectedRequestDetail.summary}</p>
-                    <dl className="request-detail-list">
-                      <div>
-                        <dt>Reason</dt>
-                        <dd>{selectedRequestDetail.reason}</dd>
-                      </div>
-                      {selectedRequestDetail.operation_summary ? (
-                        <div>
-                          <dt>Operation</dt>
-                          <dd>{selectedRequestDetail.operation_summary}</dd>
-                        </div>
-                      ) : null}
-                      <div>
-                        <dt>Requested</dt>
-                        <dd>{formatTimestamp(selectedRequestDetail.requested_at)}</dd>
-                      </div>
-                      <div>
-                        <dt>Thread</dt>
-                        <dd>{selectedRequestDetail.thread_id}</dd>
-                      </div>
-                      <div>
-                        <dt>Turn</dt>
-                        <dd>{selectedRequestDetail.turn_id ?? "Not available"}</dd>
-                      </div>
-                      <div>
-                        <dt>Item</dt>
-                        <dd>{selectedRequestDetail.item_id}</dd>
-                      </div>
-                      {selectedRequestDetail.decision ? (
-                        <div>
-                          <dt>Decision</dt>
-                          <dd>{selectedRequestDetail.decision}</dd>
-                        </div>
-                      ) : null}
-                      {selectedRequestDetail.responded_at ? (
-                        <div>
-                          <dt>Responded</dt>
-                          <dd>{formatTimestamp(selectedRequestDetail.responded_at)}</dd>
-                        </div>
-                      ) : null}
-                    </dl>
-                    {selectedRequestDetail.operation_summary ? (
-                      <p className="request-operation-summary">
-                        Operation: {selectedRequestDetail.operation_summary}
-                      </p>
-                    ) : null}
-                    {selectedRequestDetail.status === "pending" ? (
-                      <div className="workspace-actions request-detail-actions">
-                        <button
-                          className="primary-link action-button"
-                          disabled={isRespondingToRequest}
-                          onClick={onApproveRequest}
-                          type="button"
-                        >
-                          {isRespondingToRequest ? "Submitting..." : "Approve request"}
-                        </button>
-                        <button
-                          className="secondary-link action-button"
-                          disabled={isRespondingToRequest}
-                          onClick={onDenyRequest}
-                          type="button"
-                        >
-                          Deny request
-                        </button>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
-
-                {detailSelection.kind === "timeline_item_detail" && selectedTimelineItem ? (
-                  <div className="detail-stack">
-                    <p className="workspace-meta">
-                      {selectedTimelineItem.kind} at{" "}
-                      {formatTimestamp(selectedTimelineItem.occurred_at)}
-                    </p>
-                    <p>{timelineItemLabel(selectedTimelineItem)}</p>
-                    <pre className="detail-json">
-                      {JSON.stringify(selectedTimelineItem.payload, null, 2)}
-                    </pre>
-                  </div>
-                ) : null}
-              </aside>
             ) : null}
-          </>
+
+            {detailSelection.kind === "timeline_item_detail" && selectedTimelineItem ? (
+              <div className="detail-stack">
+                <p className="workspace-meta">
+                  {selectedTimelineItem.kind} at {formatTimestamp(selectedTimelineItem.occurred_at)}
+                </p>
+                <p>{timelineItemLabel(selectedTimelineItem)}</p>
+                <pre className="detail-json">
+                  {JSON.stringify(selectedTimelineItem.payload, null, 2)}
+                </pre>
+              </div>
+            ) : null}
+          </aside>
         ) : null}
       </div>
     </main>

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -19,7 +19,9 @@ const searchParams = new URLSearchParams({
 });
 
 const chatDataMocks = vi.hoisted(() => ({
+  createWorkspaceFromChat: vi.fn(),
   interruptThreadFromChat: vi.fn(),
+  listChatWorkspaces: vi.fn(),
   listWorkspaceThreads: vi.fn(),
   loadChatThreadBundle: vi.fn(),
   respondToPendingRequest: vi.fn(),
@@ -48,7 +50,9 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("../src/chat-data", () => ({
+  createWorkspaceFromChat: chatDataMocks.createWorkspaceFromChat,
   interruptThreadFromChat: chatDataMocks.interruptThreadFromChat,
+  listChatWorkspaces: chatDataMocks.listChatWorkspaces,
   listWorkspaceThreads: chatDataMocks.listWorkspaceThreads,
   loadChatThreadBundle: chatDataMocks.loadChatThreadBundle,
   respondToPendingRequest: chatDataMocks.respondToPendingRequest,
@@ -75,6 +79,18 @@ function buildThreadListItem(overrides: Partial<PublicThreadListItem> = {}): Pub
     badge: null,
     blocked_cue: null,
     resume_cue: null,
+    ...overrides,
+  };
+}
+
+function buildWorkspace(overrides: Record<string, unknown> = {}) {
+  return {
+    workspace_id: "ws_alpha",
+    workspace_name: "alpha",
+    created_at: "2026-03-27T05:00:00Z",
+    updated_at: "2026-03-27T05:22:00Z",
+    active_session_summary: null,
+    pending_approval_count: 0,
     ...overrides,
   };
 }
@@ -232,12 +248,19 @@ describe("ChatPageClient", () => {
     root = createRoot(container);
     MockEventSource.instances = [];
 
+    chatDataMocks.createWorkspaceFromChat.mockReset();
     chatDataMocks.interruptThreadFromChat.mockReset();
+    chatDataMocks.listChatWorkspaces.mockReset();
     chatDataMocks.listWorkspaceThreads.mockReset();
     chatDataMocks.loadChatThreadBundle.mockReset();
     chatDataMocks.respondToPendingRequest.mockReset();
     chatDataMocks.sendThreadInput.mockReset();
     chatDataMocks.startThreadFromChat.mockReset();
+    chatDataMocks.listChatWorkspaces.mockResolvedValue({
+      items: [buildWorkspace()],
+      next_cursor: null,
+      has_more: false,
+    });
   });
 
   afterEach(async () => {
@@ -637,7 +660,7 @@ describe("ChatPageClient", () => {
       await flushUi();
 
       const startThreadButton = Array.from(container.querySelectorAll("button")).find(
-        (button) => button.textContent === "Start new thread",
+        (button) => button.textContent === "Start thread",
       );
       expect(startThreadButton).not.toBeUndefined();
 
@@ -693,6 +716,154 @@ describe("ChatPageClient", () => {
         searchParams.set("threadId", originalThreadId);
       } else {
         searchParams.delete("threadId");
+      }
+    }
+  });
+
+  it("creates a workspace from Navigation and starts first input in that workspace", async () => {
+    const originalThreadId = searchParams.get("threadId");
+    const originalWorkspaceId = searchParams.get("workspaceId");
+    searchParams.delete("threadId");
+    searchParams.delete("workspaceId");
+
+    chatDataMocks.listChatWorkspaces
+      .mockResolvedValueOnce({
+        items: [],
+        next_cursor: null,
+        has_more: false,
+      })
+      .mockResolvedValue({
+        items: [
+          buildWorkspace({
+            workspace_id: "ws_created",
+            workspace_name: "created",
+            updated_at: "2026-03-27T05:30:00Z",
+          }),
+        ],
+        next_cursor: null,
+        has_more: false,
+      });
+    chatDataMocks.createWorkspaceFromChat.mockResolvedValue(
+      buildWorkspace({
+        workspace_id: "ws_created",
+        workspace_name: "created",
+        updated_at: "2026-03-27T05:30:00Z",
+      }),
+    );
+    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      has_more: false,
+    });
+    chatDataMocks.startThreadFromChat.mockResolvedValue(
+      buildAcceptedInputResponse({
+        accepted: {
+          thread_id: "thread_created",
+          turn_id: "turn_created_001",
+          input_item_id: "item_created_001",
+        },
+        thread: {
+          thread_id: "thread_created",
+          workspace_id: "ws_created",
+          native_status: {
+            thread_status: "running",
+            active_flags: ["turn_active"],
+            latest_turn_status: "running",
+          },
+          updated_at: "2026-03-27T05:31:00Z",
+        },
+      }),
+    );
+    chatDataMocks.loadChatThreadBundle.mockResolvedValue({
+      view: buildThreadView({
+        thread: {
+          thread_id: "thread_created",
+          workspace_id: "ws_created",
+          native_status: {
+            thread_status: "running",
+            active_flags: ["turn_active"],
+            latest_turn_status: "running",
+          },
+          updated_at: "2026-03-27T05:31:00Z",
+        },
+      }),
+      pendingRequestDetail: null,
+    });
+
+    try {
+      await act(async () => {
+        root.render(<ChatPageClient />);
+      });
+      await flushUi();
+
+      const workspaceInput = container.querySelector("#workspace-name");
+      expect(workspaceInput).not.toBeNull();
+
+      await act(async () => {
+        const setInputValue = Object.getOwnPropertyDescriptor(
+          HTMLInputElement.prototype,
+          "value",
+        )?.set;
+
+        setInputValue?.call(workspaceInput as HTMLInputElement, "created");
+        workspaceInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      await flushUi();
+
+      const createWorkspaceButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Create workspace",
+      );
+      expect(createWorkspaceButton).not.toBeUndefined();
+
+      await act(async () => {
+        createWorkspaceButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await flushUi();
+
+      expect(chatDataMocks.createWorkspaceFromChat).toHaveBeenCalledWith("created");
+      expect(container.textContent).toContain("Created workspace created.");
+      expect(container.textContent).toContain("Ask Codex");
+
+      const firstInputTextarea = container.querySelector("#thread-input");
+      expect(firstInputTextarea).not.toBeNull();
+
+      await act(async () => {
+        const setTextareaValue = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
+
+        setTextareaValue?.call(firstInputTextarea as HTMLTextAreaElement, "Start scoped work.");
+        firstInputTextarea!.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      await flushUi();
+
+      const startThreadButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Start thread",
+      );
+      expect(startThreadButton).not.toBeUndefined();
+
+      await act(async () => {
+        startThreadButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await flushUi();
+
+      expect(chatDataMocks.startThreadFromChat).toHaveBeenCalledWith(
+        "ws_created",
+        "Start scoped work.",
+        expect.stringMatching(/^input_start_/),
+      );
+    } finally {
+      if (originalThreadId) {
+        searchParams.set("threadId", originalThreadId);
+      } else {
+        searchParams.delete("threadId");
+      }
+
+      if (originalWorkspaceId) {
+        searchParams.set("workspaceId", originalWorkspaceId);
+      } else {
+        searchParams.delete("workspaceId");
       }
     }
   });

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -21,6 +21,145 @@ vi.mock("next/link", () => ({
 }));
 
 describe("ChatView", () => {
+  it("renders Navigation workspace switching, creation, and grouped thread cues", () => {
+    const markup = renderToStaticMarkup(
+      <ChatView
+        connectionState="idle"
+        draftAssistantMessages={{}}
+        errorMessage={null}
+        isCreatingThread={false}
+        isCreatingWorkspace={false}
+        isInterruptingThread={false}
+        isLoadingThread={false}
+        isLoadingThreads={false}
+        isLoadingWorkspaces={false}
+        isRespondingToRequest={false}
+        isSendingMessage={false}
+        messageDraft=""
+        newThreadInput=""
+        onApproveRequest={() => {}}
+        onCreateThread={() => {}}
+        onCreateWorkspace={() => {}}
+        onDenyRequest={() => {}}
+        onInterruptThread={() => {}}
+        onMessageDraftChange={() => {}}
+        onNewThreadInputChange={() => {}}
+        onSelectThread={() => {}}
+        onSelectWorkspace={() => {}}
+        onSendMessage={() => {}}
+        onWorkspaceNameChange={() => {}}
+        selectedRequestDetail={null}
+        selectedThreadId="thread_active"
+        selectedThreadView={null}
+        statusMessage={null}
+        streamEvents={[]}
+        threads={[
+          {
+            thread_id: "thread_approval",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "running",
+              active_flags: ["waiting_on_request"],
+              latest_turn_status: "running",
+            },
+            updated_at: "2026-03-27T05:22:00Z",
+            current_activity: {
+              kind: "waiting_on_approval",
+              label: "Approval required",
+            },
+            badge: {
+              kind: "approval",
+              label: "Waiting approval",
+            },
+            blocked_cue: {
+              kind: "approval_required",
+              label: "Needs response",
+            },
+            resume_cue: {
+              reason_kind: "waiting_on_approval",
+              priority_band: "highest",
+              label: "Resume here first",
+            },
+          },
+          {
+            thread_id: "thread_active",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "running",
+              active_flags: [],
+              latest_turn_status: "running",
+            },
+            updated_at: "2026-03-27T05:20:00Z",
+            current_activity: {
+              kind: "running",
+              label: "Running",
+            },
+            badge: null,
+            blocked_cue: null,
+            resume_cue: null,
+          },
+          {
+            thread_id: "thread_recent",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "waiting_input",
+              active_flags: [],
+              latest_turn_status: null,
+            },
+            updated_at: "2026-03-27T05:18:00Z",
+            current_activity: {
+              kind: "waiting_on_user_input",
+              label: "Waiting for your input",
+            },
+            badge: null,
+            blocked_cue: null,
+            resume_cue: {
+              reason_kind: "recent",
+              priority_band: "medium",
+              label: "Recently updated",
+            },
+          },
+        ]}
+        workspaceId="ws_alpha"
+        workspaceName=""
+        workspaces={[
+          {
+            workspace_id: "ws_alpha",
+            workspace_name: "alpha",
+            created_at: "2026-03-27T05:00:00Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            active_session_summary: null,
+            pending_approval_count: 1,
+          },
+          {
+            workspace_id: "ws_beta",
+            workspace_name: "beta",
+            created_at: "2026-03-27T04:00:00Z",
+            updated_at: "2026-03-27T05:10:00Z",
+            active_session_summary: {
+              session_id: "thread_beta",
+              status: "running",
+              last_message_at: "2026-03-27T05:10:00Z",
+            },
+            pending_approval_count: 0,
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Navigation");
+    expect(markup).toContain("Switch workspace");
+    expect(markup).toContain("Create workspace");
+    expect(markup).toContain("1 approval");
+    expect(markup).toContain("Attention needed");
+    expect(markup).toContain("Active");
+    expect(markup).toContain("Recent");
+    expect(markup).toContain("Blocked: Needs response");
+    expect(markup).toContain("Resume here first");
+    expect(markup).toContain("Recently updated");
+    expect(markup).not.toContain("Home");
+  });
+
   it("renders thread context, pending request controls, and timeline state", () => {
     const markup = renderToStaticMarkup(
       <ChatView
@@ -30,21 +169,26 @@ describe("ChatView", () => {
         }}
         errorMessage={null}
         isCreatingThread={false}
+        isCreatingWorkspace={false}
         isInterruptingThread={false}
         isLoadingThread={false}
         isLoadingThreads={false}
+        isLoadingWorkspaces={false}
         isRespondingToRequest={false}
         isSendingMessage={false}
         messageDraft=""
         newThreadInput=""
+        onCreateWorkspace={() => {}}
         onApproveRequest={() => {}}
         onCreateThread={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
         onMessageDraftChange={() => {}}
         onNewThreadInputChange={() => {}}
+        onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
         onSendMessage={() => {}}
+        onWorkspaceNameChange={() => {}}
         selectedRequestDetail={{
           request_id: "req_001",
           thread_id: "thread_001",
@@ -159,6 +303,17 @@ describe("ChatView", () => {
           },
         ]}
         workspaceId="ws_alpha"
+        workspaceName=""
+        workspaces={[
+          {
+            workspace_id: "ws_alpha",
+            workspace_name: "alpha",
+            created_at: "2026-03-27T05:00:00Z",
+            updated_at: "2026-03-27T05:22:00Z",
+            active_session_summary: null,
+            pending_approval_count: 1,
+          },
+        ]}
       />,
     );
 
@@ -177,21 +332,26 @@ describe("ChatView", () => {
         draftAssistantMessages={{}}
         errorMessage="Failed to interrupt the thread."
         isCreatingThread={false}
+        isCreatingWorkspace={false}
         isInterruptingThread={false}
         isLoadingThread={false}
         isLoadingThreads={false}
+        isLoadingWorkspaces={false}
         isRespondingToRequest={false}
         isSendingMessage={false}
         messageDraft=""
         newThreadInput=""
+        onCreateWorkspace={() => {}}
         onApproveRequest={() => {}}
         onCreateThread={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
         onMessageDraftChange={() => {}}
         onNewThreadInputChange={() => {}}
+        onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
         onSendMessage={() => {}}
+        onWorkspaceNameChange={() => {}}
         selectedRequestDetail={null}
         selectedThreadId={null}
         selectedThreadView={null}
@@ -199,6 +359,8 @@ describe("ChatView", () => {
         streamEvents={[]}
         threads={[]}
         workspaceId="ws_alpha"
+        workspaceName=""
+        workspaces={[]}
       />,
     );
 
@@ -217,21 +379,26 @@ describe("ChatView", () => {
         draftAssistantMessages={{}}
         errorMessage={null}
         isCreatingThread={false}
+        isCreatingWorkspace={false}
         isInterruptingThread={false}
         isLoadingThread={false}
         isLoadingThreads={false}
+        isLoadingWorkspaces={false}
         isRespondingToRequest={false}
         isSendingMessage={false}
         messageDraft=""
         newThreadInput=""
+        onCreateWorkspace={() => {}}
         onApproveRequest={() => {}}
         onCreateThread={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
         onMessageDraftChange={() => {}}
         onNewThreadInputChange={() => {}}
+        onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
         onSendMessage={() => {}}
+        onWorkspaceNameChange={() => {}}
         selectedRequestDetail={{
           request_id: "req_001",
           thread_id: "thread_001",
@@ -295,6 +462,8 @@ describe("ChatView", () => {
         streamEvents={[]}
         threads={[]}
         workspaceId="ws_alpha"
+        workspaceName=""
+        workspaces={[]}
       />,
     );
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-181-navigation-home-replacement](./archive/issue-181-navigation-home-replacement/README.md)
 - [issue-180-contract-audit](./archive/issue-180-contract-audit/README.md)
 - [issue-179-desktop-state-spec](./archive/issue-179-desktop-state-spec/README.md)
 - [issue-178-benchmark-agent-uis](./archive/issue-178-benchmark-agent-uis/README.md)

--- a/tasks/archive/issue-181-navigation-home-replacement/README.md
+++ b/tasks/archive/issue-181-navigation-home-replacement/README.md
@@ -1,0 +1,68 @@
+# Issue 181 Navigation Home Replacement
+
+## Purpose
+
+- Implement Navigation as the primary replacement for old Home responsibilities in the renewed v0.9 browser shell.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/181
+
+## Source docs
+
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Implement workspace switching and new-workspace entry points in Navigation.
+- Implement current-workspace thread discovery sections for attention-needed, active, and recent threads.
+- Add badges, blocked cues, resume cues, selected-thread state, and deep-link return behavior where supported by current public data.
+- Remove Home-dependent primary interactions from the desktop-first browser path.
+
+## Exit criteria
+
+- Users can switch workspace, start a thread, resume a thread, and find attention-needed threads from Navigation or contextual empty states without a primary Home screen.
+- Approval, error, failed, active, and recent threads are distinguishable in the thread list.
+- Reconnect return cues are visible from Navigation.
+- Focused frontend validation passes for the changed Navigation and app-shell behavior.
+
+## Work plan
+
+- Inspect the current `apps/frontend-bff` UI structure, public data hooks, and tests for Home, Navigation, workspace, and thread-list behavior.
+- Plan one bounded implementation slice around existing component and route patterns.
+- Update the Navigation/app-shell UI and any required client-side view model helpers.
+- Add or update focused tests for workspace switching, thread-list priority sections, cues, selection, and Home-independent desktop entry behavior.
+- Run targeted validation first, then the app-level validation commands required by `apps/frontend-bff/README.md` as scope permits.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-23T03-29-35Z-issue-181-close/events.ndjson`
+- Validation evidence:
+  - 2026-04-23: `npm test -- chat-view.test.tsx chat-page-client.test.tsx` passed, 2 files / 16 tests.
+  - 2026-04-23: `npm run check` passed, 69 files checked.
+  - 2026-04-23: `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - 2026-04-23: `npm test` passed, 10 files / 59 tests.
+
+## Status / handoff notes
+
+- Status: `completed; archived after pre-push validation`
+- Active branch: `issue-181-navigation-home-replacement`
+- Active worktree: `.worktrees/issue-181-navigation-home-replacement`
+- Notes: Root `/` now renders the thread-first chat shell. Navigation owns workspace switching, workspace creation, current-workspace thread grouping/cues, and Home-independent first input entry.
+- Completion retrospective:
+  - Completion boundary: package archive; Issue close still requires PR merge, parent checkout sync, worktree cleanup, and final GitHub tracking.
+  - Contract check: package exit criteria satisfied by changed UI/tests plus sprint evaluator approval and dedicated pre-push validation.
+  - What worked: reusing `ChatPageClient`/`ChatView` avoided a parallel shell and kept public API contracts unchanged.
+  - Workflow problems: the first worker disconnected after in-scope edits; rerunning a replacement worker against verified worktree state recovered cleanly.
+  - Improvements to adopt: keep replacement-worker prompts focused on existing candidate validation/fix when an allowed writer disconnects mid-sprint.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: publish through PR, merge to `main`, remove the active worktree, then close Issue #181 and set Project `Done`.
+
+## Archive conditions
+
+- Archive complete after exit criteria were met, dedicated pre-push validation passed, completion retrospective was recorded, and handoff notes were updated.


### PR DESCRIPTION
## Summary
- render the thread-first Chat shell at / so Home is no longer the primary desktop entry
- add Navigation workspace switching/creation plus grouped thread cues for attention-needed, active, and recent threads
- archive the Issue #181 task package after sprint approval and pre-push validation

## Validation
- npm test -- chat-view.test.tsx chat-page-client.test.tsx
- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm test

Closes #181