### PR TITLE
feat(frontend-bff): unify thread view composer

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -476,11 +476,17 @@ textarea {
   background: rgba(243, 223, 209, 0.45);
 }
 
-.first-input-card {
+.first-input-card,
+.current-activity-card {
   border: 1px solid rgba(35, 24, 15, 0.08);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.58);
   padding: 14px;
+}
+
+.current-activity-card {
+  display: grid;
+  gap: 8px;
 }
 
 .thread-summary-card {
@@ -534,6 +540,17 @@ textarea {
 .chat-composer {
   display: grid;
   gap: 12px;
+  border: 1px solid rgba(35, 24, 15, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.58);
+  padding: 14px;
+}
+
+.composer-guidance {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  line-height: 1.4;
 }
 
 .chat-textarea {

--- a/apps/frontend-bff/src/chat-page-client.tsx
+++ b/apps/frontend-bff/src/chat-page-client.tsx
@@ -116,8 +116,7 @@ export function ChatPageClient() {
   );
   const [streamEvents, setStreamEvents] = useState<PublicThreadStreamEvent[]>([]);
   const [draftAssistantMessages, setDraftAssistantMessages] = useState<Record<string, string>>({});
-  const [newThreadInput, setNewThreadInput] = useState("");
-  const [messageDraft, setMessageDraft] = useState("");
+  const [composerDraft, setComposerDraft] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isLoadingThreads, setIsLoadingThreads] = useState(false);
@@ -519,14 +518,33 @@ export function ChatPageClient() {
     };
   }, [workspaceId]);
 
-  async function handleCreateThread() {
-    if (!workspaceId) {
-      setErrorMessage("Choose or create a workspace before starting a thread.");
+  async function handleSubmitComposer() {
+    const trimmedDraft = composerDraft.trim();
+    if (trimmedDraft.length === 0) {
       return;
     }
 
-    const trimmedInput = newThreadInput.trim();
-    if (trimmedInput.length === 0) {
+    if (selectedThreadId) {
+      setIsSendingMessage(true);
+      setErrorMessage(null);
+      setStatusMessage(null);
+
+      try {
+        await sendThreadInput(selectedThreadId, trimmedDraft, createClientId("input_followup"));
+        setComposerDraft("");
+        setStatusMessage("Input accepted. Waiting for thread updates.");
+        await refreshSelectedThreadAndList(selectedThreadId);
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : "Failed to send input.");
+      } finally {
+        setIsSendingMessage(false);
+      }
+
+      return;
+    }
+
+    if (!workspaceId) {
+      setErrorMessage("Choose or create a workspace before starting a thread.");
       return;
     }
 
@@ -537,13 +555,13 @@ export function ChatPageClient() {
     try {
       const result = await startThreadFromChat(
         workspaceId,
-        trimmedInput,
+        trimmedDraft,
         createClientId("input_start"),
       );
       logLiveChatDebug("chat-stream", "created thread from chat", {
         thread_id: result.thread.thread_id,
       });
-      setNewThreadInput("");
+      setComposerDraft("");
       setStatusMessage(`Started thread ${result.thread.thread_id}.`);
       updateSelectedThreadId(result.thread.thread_id, "create_thread_success");
       await refreshThreads(result.thread.thread_id);
@@ -604,32 +622,6 @@ export function ChatPageClient() {
       setErrorMessage(error instanceof Error ? error.message : "Failed to create workspace.");
     } finally {
       setIsCreatingWorkspace(false);
-    }
-  }
-
-  async function handleSendMessage() {
-    if (!selectedThreadId) {
-      return;
-    }
-
-    const trimmedDraft = messageDraft.trim();
-    if (trimmedDraft.length === 0) {
-      return;
-    }
-
-    setIsSendingMessage(true);
-    setErrorMessage(null);
-    setStatusMessage(null);
-
-    try {
-      await sendThreadInput(selectedThreadId, trimmedDraft, createClientId("input_followup"));
-      setMessageDraft("");
-      setStatusMessage("Input accepted. Waiting for thread updates.");
-      await refreshSelectedThreadAndList(selectedThreadId);
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "Failed to send input.");
-    } finally {
-      setIsSendingMessage(false);
     }
   }
 
@@ -694,18 +686,15 @@ export function ChatPageClient() {
       isLoadingWorkspaces={isLoadingWorkspaces}
       isRespondingToRequest={isRespondingToRequest}
       isSendingMessage={isSendingMessage}
-      messageDraft={messageDraft}
-      newThreadInput={newThreadInput}
+      composerDraft={composerDraft}
       onApproveRequest={() => void handleRequestDecision("approved")}
-      onCreateThread={() => void handleCreateThread()}
+      onComposerDraftChange={setComposerDraft}
       onCreateWorkspace={() => void handleCreateWorkspace()}
-      onMessageDraftChange={setMessageDraft}
-      onNewThreadInputChange={setNewThreadInput}
       onDenyRequest={() => void handleRequestDecision("denied")}
       onInterruptThread={() => void handleInterruptThread()}
       onSelectWorkspace={(nextWorkspaceId) => void handleSelectWorkspace(nextWorkspaceId)}
       onSelectThread={(threadId) => updateSelectedThreadId(threadId, "user_select_thread")}
-      onSendMessage={() => void handleSendMessage()}
+      onSubmitComposer={() => void handleSubmitComposer()}
       onWorkspaceNameChange={setWorkspaceName}
       selectedRequestDetail={selectedRequestDetail}
       selectedThreadId={selectedThreadId}

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -31,16 +31,13 @@ export interface ChatViewProps {
   errorMessage: string | null;
   statusMessage: string | null;
   workspaceName: string;
-  newThreadInput: string;
-  messageDraft: string;
+  composerDraft: string;
   onWorkspaceNameChange: (value: string) => void;
-  onNewThreadInputChange: (value: string) => void;
-  onMessageDraftChange: (value: string) => void;
-  onCreateThread: () => void;
+  onComposerDraftChange: (value: string) => void;
+  onSubmitComposer: () => void;
   onCreateWorkspace: () => void;
   onSelectWorkspace: (workspaceId: string) => void;
   onSelectThread: (threadId: string) => void;
-  onSendMessage: () => void;
   onInterruptThread: () => void;
   onApproveRequest: () => void;
   onDenyRequest: () => void;
@@ -149,6 +146,32 @@ function timelineItemLabel(item: PublicTimelineItem) {
   return String(item.payload.content ?? item.payload.summary ?? item.kind);
 }
 
+function composerUnavailableReason(threadView: PublicThreadView | null) {
+  if (!threadView) {
+    return null;
+  }
+
+  if (threadView.composer.blocked_by_request || threadView.pending_request) {
+    return "Input is paused while this thread waits for your approval response.";
+  }
+
+  if (threadView.current_activity.kind === "running") {
+    return threadView.composer.interrupt_available
+      ? "Codex is running. Interrupt is available if you need to regain control."
+      : "Codex is running. New input will be available when the turn finishes.";
+  }
+
+  if (threadView.composer.input_unavailable_reason) {
+    return `Input unavailable: ${formatMachineLabel(threadView.composer.input_unavailable_reason)}.`;
+  }
+
+  if (!threadView.composer.accepting_user_input) {
+    return "Input is not available for the current thread state.";
+  }
+
+  return null;
+}
+
 export function ChatView({
   workspaceId,
   workspaces,
@@ -170,16 +193,13 @@ export function ChatView({
   errorMessage,
   statusMessage,
   workspaceName,
-  newThreadInput,
-  messageDraft,
+  composerDraft,
   onWorkspaceNameChange,
-  onNewThreadInputChange,
-  onMessageDraftChange,
-  onCreateThread,
+  onComposerDraftChange,
+  onSubmitComposer,
   onCreateWorkspace,
   onSelectWorkspace,
   onSelectThread,
-  onSendMessage,
   onInterruptThread,
   onApproveRequest,
   onDenyRequest,
@@ -190,6 +210,36 @@ export function ChatView({
   const selectedWorkspace =
     workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
   const threadGroups = groupThreads(threads);
+  const hasSelectedThread = selectedThreadId !== null;
+  const isOpeningSelectedThread = hasSelectedThread && !selectedThreadView;
+  const isStartingThread = !hasSelectedThread;
+  const isSubmittingComposer = isCreatingThread || isSendingMessage;
+  const unavailableReason = composerUnavailableReason(selectedThreadView);
+  const isThreadAcceptingInput = selectedThreadView?.composer.accepting_user_input ?? false;
+  const isComposerDisabled =
+    !workspaceId ||
+    isOpeningSelectedThread ||
+    isSubmittingComposer ||
+    (selectedThreadView ? !isThreadAcceptingInput : false) ||
+    composerDraft.trim().length === 0;
+  const composerLabel = isStartingThread ? "Ask Codex" : "Send input";
+  const composerPlaceholder = !workspaceId
+    ? "Select a workspace before asking Codex."
+    : isStartingThread
+      ? "Describe the task to start a new thread."
+      : "Continue the current thread.";
+  const composerSubmitLabel = isSubmittingComposer
+    ? isStartingThread
+      ? "Starting thread..."
+      : "Sending..."
+    : isStartingThread
+      ? "Start thread"
+      : "Send input";
+  const composerGuidance = !workspaceId
+    ? "Select or create a workspace from Navigation before starting work."
+    : isOpeningSelectedThread
+      ? "Opening the selected thread before accepting input."
+      : unavailableReason;
   const selectedTimelineItem =
     detailSelection?.kind === "timeline_item_detail"
       ? (selectedThreadView?.timeline.items.find(
@@ -372,15 +422,28 @@ export function ChatView({
                 <span className="status-badge success">
                   {selectedThreadView.current_activity.label}
                 </span>
+              ) : isOpeningSelectedThread ? (
+                <span className="status-badge">Opening</span>
+              ) : workspaceId ? (
+                <span className="status-badge">Ready to start</span>
               ) : null}
             </div>
-            <h2>{selectedThreadView?.thread.thread_id ?? "Select a thread"}</h2>
+            <h2>
+              {selectedThreadView?.thread.thread_id ??
+                (isOpeningSelectedThread
+                  ? "Opening thread"
+                  : workspaceId
+                    ? "New thread"
+                    : "Select workspace")}
+            </h2>
             <p className="workspace-meta">
               {selectedThreadView
                 ? `Updated ${formatTimestamp(selectedThreadView.thread.updated_at)}`
-                : workspaceId
-                  ? "Ask Codex to start a new thread, or pick a thread from Navigation."
-                  : "Select or create a workspace from Navigation before starting work."}
+                : isOpeningSelectedThread
+                  ? `Loading ${selectedThreadId}.`
+                  : workspaceId
+                    ? "Ask Codex to start a new thread, or pick a thread from Navigation."
+                    : "Select or create a workspace from Navigation before starting work."}
             </p>
             <div className="hero-metrics thread-context-metrics">
               <span className="metric-chip">Workspace: {workspaceId}</span>
@@ -404,30 +467,28 @@ export function ChatView({
             </div>
           </header>
 
-          {workspaceId && !selectedThreadView ? (
-            <div className="create-form first-input-card">
-              <label className="form-label" htmlFor="thread-input">
-                Ask Codex
-                <textarea
-                  className="chat-textarea"
-                  id="thread-input"
-                  name="thread-input"
-                  onChange={(event) => onNewThreadInputChange(event.target.value)}
-                  placeholder="Describe the task to start a new thread."
-                  rows={4}
-                  value={newThreadInput}
-                />
-              </label>
-              <button
-                className="submit-button"
-                disabled={isCreatingThread || newThreadInput.trim().length === 0}
-                onClick={onCreateThread}
-                type="button"
-              >
-                {isCreatingThread ? "Starting thread..." : "Start thread"}
-              </button>
+          <div className="current-activity-card">
+            <div className="workspace-meta-row">
+              <strong>Current activity</strong>
+              <span className="status-badge">
+                {selectedThreadView?.current_activity.label ??
+                  (isOpeningSelectedThread
+                    ? "Opening"
+                    : workspaceId
+                      ? "Ready for first input"
+                      : "Workspace required")}
+              </span>
             </div>
-          ) : null}
+            <p className="workspace-meta">
+              {selectedThreadView
+                ? formatMachineLabel(selectedThreadView.current_activity.kind)
+                : isOpeningSelectedThread
+                  ? "Thread details are loading."
+                  : workspaceId
+                    ? "First input will create a new thread in this workspace."
+                    : "Choose a workspace to enable the composer."}
+            </p>
+          </div>
 
           {selectedThreadView?.pending_request ? (
             <div className="request-detail-card pending-request-card">
@@ -496,16 +557,18 @@ export function ChatView({
             </div>
           ) : null}
 
-          <div className="workspace-actions">
-            <button
-              className="secondary-link action-button"
-              disabled={!selectedThreadView?.composer.interrupt_available || isInterruptingThread}
-              onClick={onInterruptThread}
-              type="button"
-            >
-              {isInterruptingThread ? "Interrupting..." : "Interrupt thread"}
-            </button>
-          </div>
+          {selectedThreadView?.composer.interrupt_available ? (
+            <div className="workspace-actions thread-interrupt-actions">
+              <button
+                className="secondary-link action-button"
+                disabled={isInterruptingThread}
+                onClick={onInterruptThread}
+                type="button"
+              >
+                {isInterruptingThread ? "Interrupting..." : "Interrupt thread"}
+              </button>
+            </div>
+          ) : null}
 
           <section className="timeline-section" aria-label="Timeline">
             <header>
@@ -578,30 +641,43 @@ export function ChatView({
             </div>
           </section>
 
-          <div className="chat-composer">
-            <label className="form-label" htmlFor="message-input">
-              Send follow-up input
+          <div className="chat-composer" data-composer-mode={isStartingThread ? "start" : "send"}>
+            <label className="form-label" htmlFor="thread-composer-input">
+              {composerLabel}
               <textarea
                 className="chat-textarea"
-                id="message-input"
-                name="message-input"
-                onChange={(event) => onMessageDraftChange(event.target.value)}
-                placeholder="Continue the current thread."
+                disabled={
+                  !workspaceId ||
+                  isOpeningSelectedThread ||
+                  isSubmittingComposer ||
+                  Boolean(unavailableReason)
+                }
+                id="thread-composer-input"
+                name="thread-composer-input"
+                onChange={(event) => onComposerDraftChange(event.target.value)}
+                placeholder={composerPlaceholder}
                 rows={4}
-                value={messageDraft}
+                value={composerDraft}
               />
             </label>
+            {composerGuidance ? (
+              <p className="composer-guidance" role="status">
+                {composerGuidance}
+              </p>
+            ) : (
+              <p className="composer-guidance" role="status">
+                {isStartingThread
+                  ? "First input starts a new thread in this workspace."
+                  : "Input will continue the selected thread."}
+              </p>
+            )}
             <button
               className="submit-button"
-              disabled={
-                !selectedThreadView?.composer.accepting_user_input ||
-                isSendingMessage ||
-                messageDraft.trim().length === 0
-              }
-              onClick={onSendMessage}
+              disabled={isComposerDisabled}
+              onClick={onSubmitComposer}
               type="button"
             >
-              {isSendingMessage ? "Sending..." : "Send reply"}
+              {composerSubmitLabel}
             </button>
           </div>
         </section>

--- a/apps/frontend-bff/src/mappings.ts
+++ b/apps/frontend-bff/src/mappings.ts
@@ -313,6 +313,7 @@ export function mapThreadView(
       accepting_user_input: view.thread.derived_hints.accepting_user_input,
       interrupt_available: view.thread.native_status.thread_status === "running",
       blocked_by_request: view.thread.derived_hints.has_pending_request,
+      input_unavailable_reason: view.thread.derived_hints.blocked_reason,
     },
     timeline: mapTimeline(timeline),
   };

--- a/apps/frontend-bff/src/thread-types.ts
+++ b/apps/frontend-bff/src/thread-types.ts
@@ -113,6 +113,7 @@ export interface PublicComposer {
   accepting_user_input: boolean;
   interrupt_available: boolean;
   blocked_by_request: boolean;
+  input_unavailable_reason: string | null;
 }
 
 export interface PublicThreadView {

--- a/apps/frontend-bff/tests/chat-data.test.ts
+++ b/apps/frontend-bff/tests/chat-data.test.ts
@@ -168,6 +168,7 @@ describe("chat data access", () => {
             accepting_user_input: false,
             interrupt_available: true,
             blocked_by_request: true,
+            input_unavailable_reason: null,
           },
           timeline: {
             items: [],

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -117,6 +117,7 @@ function buildThreadView(overrides: Partial<PublicThreadView> = {}): PublicThrea
       accepting_user_input: true,
       interrupt_available: true,
       blocked_by_request: false,
+      input_unavailable_reason: null,
     },
     timeline: {
       items: [
@@ -326,6 +327,7 @@ describe("ChatPageClient", () => {
             accepting_user_input: true,
             interrupt_available: false,
             blocked_by_request: false,
+            input_unavailable_reason: null,
           },
           timeline: {
             items: [],
@@ -345,6 +347,7 @@ describe("ChatPageClient", () => {
             accepting_user_input: false,
             interrupt_available: true,
             blocked_by_request: false,
+            input_unavailable_reason: null,
           },
           timeline: {
             items: [
@@ -392,8 +395,9 @@ describe("ChatPageClient", () => {
     expect(container.textContent).toContain("Waiting for your input");
     expect(MockEventSource.instances[0]?.url).toBe("/api/v1/threads/thread_001/stream");
 
-    const textarea = container.querySelector("#message-input");
+    const textarea = container.querySelector("#thread-composer-input");
     expect(textarea).not.toBeNull();
+    expect(container.querySelectorAll("textarea")).toHaveLength(1);
 
     await act(async () => {
       const setTextareaValue = Object.getOwnPropertyDescriptor(
@@ -407,7 +411,7 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     const sendButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === "Send reply",
+      (button) => button.textContent === "Send input",
     );
     expect(sendButton).not.toBeUndefined();
 
@@ -422,6 +426,7 @@ describe("ChatPageClient", () => {
       expect.stringMatching(/^input_followup_/),
     );
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
+    expect((textarea as HTMLTextAreaElement).value).toBe("");
     expect(container.textContent).toContain("Running");
     expect(container.textContent).toContain("Continue with the fix.");
   });
@@ -451,6 +456,7 @@ describe("ChatPageClient", () => {
         accepting_user_input: false,
         interrupt_available: true,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
       timeline: {
         items: [
@@ -491,6 +497,7 @@ describe("ChatPageClient", () => {
         accepting_user_input: true,
         interrupt_available: false,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
       timeline: {
         items: [
@@ -531,6 +538,7 @@ describe("ChatPageClient", () => {
         accepting_user_input: false,
         interrupt_available: true,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
       timeline: {
         items: [
@@ -645,8 +653,9 @@ describe("ChatPageClient", () => {
       });
       await flushUi();
 
-      const firstInputTextarea = container.querySelector("#thread-input");
+      const firstInputTextarea = container.querySelector("#thread-composer-input");
       expect(firstInputTextarea).not.toBeNull();
+      expect(container.querySelectorAll("textarea")).toHaveLength(1);
 
       await act(async () => {
         const setTextareaValue = Object.getOwnPropertyDescriptor(
@@ -677,11 +686,13 @@ describe("ChatPageClient", () => {
       expect(container.textContent).toContain("Started thread thread_new.");
       expect(container.textContent).toContain("Waiting for your input");
 
-      const followUpTextarea = container.querySelector("#message-input");
+      const followUpTextarea = container.querySelector("#thread-composer-input");
       expect(followUpTextarea).not.toBeNull();
+      expect(container.querySelectorAll("textarea")).toHaveLength(1);
+      expect((followUpTextarea as HTMLTextAreaElement).value).toBe("");
 
       const sendButton = Array.from(container.querySelectorAll("button")).find(
-        (button) => button.textContent === "Send reply",
+        (button) => button.textContent === "Send input",
       );
       expect(sendButton).not.toBeUndefined();
       expect((sendButton as HTMLButtonElement).disabled).toBe(true);
@@ -796,6 +807,14 @@ describe("ChatPageClient", () => {
       });
       await flushUi();
 
+      expect(container.textContent).toContain(
+        "Select or create a workspace from Navigation before starting work.",
+      );
+      const disabledComposer = container.querySelector("#thread-composer-input");
+      expect(disabledComposer).not.toBeNull();
+      expect((disabledComposer as HTMLTextAreaElement).disabled).toBe(true);
+      expect(container.querySelectorAll("textarea")).toHaveLength(1);
+
       const workspaceInput = container.querySelector("#workspace-name");
       expect(workspaceInput).not.toBeNull();
 
@@ -824,8 +843,9 @@ describe("ChatPageClient", () => {
       expect(container.textContent).toContain("Created workspace created.");
       expect(container.textContent).toContain("Ask Codex");
 
-      const firstInputTextarea = container.querySelector("#thread-input");
+      const firstInputTextarea = container.querySelector("#thread-composer-input");
       expect(firstInputTextarea).not.toBeNull();
+      expect(container.querySelectorAll("textarea")).toHaveLength(1);
 
       await act(async () => {
         const setTextareaValue = Object.getOwnPropertyDescriptor(
@@ -1356,6 +1376,7 @@ describe("ChatPageClient", () => {
         accepting_user_input: false,
         interrupt_available: true,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
     });
     const waitingThreadView = buildThreadView({
@@ -1377,6 +1398,7 @@ describe("ChatPageClient", () => {
         accepting_user_input: true,
         interrupt_available: false,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
     });
 
@@ -1449,6 +1471,7 @@ describe("ChatPageClient", () => {
         accepting_user_input: true,
         interrupt_available: false,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
     });
     const runningThreadView = buildThreadView({
@@ -1470,6 +1493,7 @@ describe("ChatPageClient", () => {
         accepting_user_input: false,
         interrupt_available: true,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
       timeline: {
         items: [
@@ -1510,6 +1534,7 @@ describe("ChatPageClient", () => {
         accepting_user_input: true,
         interrupt_available: false,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
       timeline: {
         items: [
@@ -1582,8 +1607,9 @@ describe("ChatPageClient", () => {
     });
     await flushUi();
 
-    const textarea = container.querySelector("#message-input");
+    const textarea = container.querySelector("#thread-composer-input");
     expect(textarea).not.toBeNull();
+    expect(container.querySelectorAll("textarea")).toHaveLength(1);
 
     await act(async () => {
       const setTextareaValue = Object.getOwnPropertyDescriptor(
@@ -1597,7 +1623,7 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     const sendButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === "Send reply",
+      (button) => button.textContent === "Send input",
     );
     expect(sendButton).not.toBeUndefined();
 

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -35,18 +35,15 @@ describe("ChatView", () => {
         isLoadingWorkspaces={false}
         isRespondingToRequest={false}
         isSendingMessage={false}
-        messageDraft=""
-        newThreadInput=""
+        composerDraft=""
         onApproveRequest={() => {}}
-        onCreateThread={() => {}}
+        onSubmitComposer={() => {}}
         onCreateWorkspace={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
-        onMessageDraftChange={() => {}}
-        onNewThreadInputChange={() => {}}
+        onComposerDraftChange={() => {}}
         onSelectThread={() => {}}
         onSelectWorkspace={() => {}}
-        onSendMessage={() => {}}
         onWorkspaceNameChange={() => {}}
         selectedRequestDetail={null}
         selectedThreadId="thread_active"
@@ -157,6 +154,10 @@ describe("ChatView", () => {
     expect(markup).toContain("Blocked: Needs response");
     expect(markup).toContain("Resume here first");
     expect(markup).toContain("Recently updated");
+    expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
+    expect(markup).toContain('id="thread-composer-input"');
+    expect(markup).not.toContain('id="thread-input"');
+    expect(markup).not.toContain('id="message-input"');
     expect(markup).not.toContain("Home");
   });
 
@@ -176,18 +177,15 @@ describe("ChatView", () => {
         isLoadingWorkspaces={false}
         isRespondingToRequest={false}
         isSendingMessage={false}
-        messageDraft=""
-        newThreadInput=""
+        composerDraft=""
         onCreateWorkspace={() => {}}
         onApproveRequest={() => {}}
-        onCreateThread={() => {}}
+        onSubmitComposer={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
-        onMessageDraftChange={() => {}}
-        onNewThreadInputChange={() => {}}
+        onComposerDraftChange={() => {}}
         onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
-        onSendMessage={() => {}}
         onWorkspaceNameChange={() => {}}
         selectedRequestDetail={{
           request_id: "req_001",
@@ -241,6 +239,7 @@ describe("ChatView", () => {
             accepting_user_input: false,
             interrupt_available: true,
             blocked_by_request: true,
+            input_unavailable_reason: null,
           },
           timeline: {
             items: [
@@ -320,9 +319,15 @@ describe("ChatView", () => {
     expect(markup).toContain("thread_001");
     expect(markup).toContain("Approval required");
     expect(markup).toContain("Approve request");
+    expect(markup).toContain("Input is paused while this thread waits for your approval response.");
+    expect(markup).toContain("Interrupt thread");
     expect(markup).toContain("Please explain the diff.");
     expect(markup).toContain("Streaming update");
     expect(markup).toContain("approval.requested");
+    expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
+    expect(markup).toContain('id="thread-composer-input"');
+    expect(markup).not.toContain('id="thread-input"');
+    expect(markup).not.toContain('id="message-input"');
   });
 
   it("renders transient feedback above the chat panels", () => {
@@ -339,18 +344,15 @@ describe("ChatView", () => {
         isLoadingWorkspaces={false}
         isRespondingToRequest={false}
         isSendingMessage={false}
-        messageDraft=""
-        newThreadInput=""
+        composerDraft=""
         onCreateWorkspace={() => {}}
         onApproveRequest={() => {}}
-        onCreateThread={() => {}}
+        onSubmitComposer={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
-        onMessageDraftChange={() => {}}
-        onNewThreadInputChange={() => {}}
+        onComposerDraftChange={() => {}}
         onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
-        onSendMessage={() => {}}
         onWorkspaceNameChange={() => {}}
         selectedRequestDetail={null}
         selectedThreadId={null}
@@ -386,18 +388,15 @@ describe("ChatView", () => {
         isLoadingWorkspaces={false}
         isRespondingToRequest={false}
         isSendingMessage={false}
-        messageDraft=""
-        newThreadInput=""
+        composerDraft=""
         onCreateWorkspace={() => {}}
         onApproveRequest={() => {}}
-        onCreateThread={() => {}}
+        onSubmitComposer={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
-        onMessageDraftChange={() => {}}
-        onNewThreadInputChange={() => {}}
+        onComposerDraftChange={() => {}}
         onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
-        onSendMessage={() => {}}
         onWorkspaceNameChange={() => {}}
         selectedRequestDetail={{
           request_id: "req_001",
@@ -451,6 +450,7 @@ describe("ChatView", () => {
             accepting_user_input: true,
             interrupt_available: false,
             blocked_by_request: false,
+            input_unavailable_reason: null,
           },
           timeline: {
             items: [],
@@ -472,5 +472,76 @@ describe("ChatView", () => {
     expect(markup).toContain("Reopen request detail");
     expect(markup).not.toContain("Approve request");
     expect(markup).not.toContain("Deny request");
+  });
+
+  it("renders recovery input-unavailable reason as the single disabled composer state", () => {
+    const markup = renderToStaticMarkup(
+      <ChatView
+        connectionState="idle"
+        draftAssistantMessages={{}}
+        errorMessage={null}
+        isCreatingThread={false}
+        isCreatingWorkspace={false}
+        isInterruptingThread={false}
+        isLoadingThread={false}
+        isLoadingThreads={false}
+        isLoadingWorkspaces={false}
+        isRespondingToRequest={false}
+        isSendingMessage={false}
+        composerDraft="Follow up after recovery."
+        onCreateWorkspace={() => {}}
+        onApproveRequest={() => {}}
+        onSubmitComposer={() => {}}
+        onDenyRequest={() => {}}
+        onInterruptThread={() => {}}
+        onComposerDraftChange={() => {}}
+        onSelectWorkspace={() => {}}
+        onSelectThread={() => {}}
+        onWorkspaceNameChange={() => {}}
+        selectedRequestDetail={null}
+        selectedThreadId="thread_001"
+        selectedThreadView={{
+          thread: {
+            thread_id: "thread_001",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "idle",
+              active_flags: [],
+              latest_turn_status: "failed",
+            },
+            updated_at: "2026-03-27T05:22:00Z",
+          },
+          current_activity: {
+            kind: "latest_turn_failed",
+            label: "Latest turn failed",
+          },
+          pending_request: null,
+          latest_resolved_request: null,
+          composer: {
+            accepting_user_input: false,
+            interrupt_available: false,
+            blocked_by_request: false,
+            input_unavailable_reason: "recovery_pending",
+          },
+          timeline: {
+            items: [],
+            next_cursor: null,
+            has_more: false,
+          },
+        }}
+        statusMessage={null}
+        streamEvents={[]}
+        threads={[]}
+        workspaceId="ws_alpha"
+        workspaceName=""
+        workspaces={[]}
+      />,
+    );
+
+    expect(markup).toContain("Input unavailable: recovery pending.");
+    expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
+    expect(markup).toContain("disabled");
+    expect(markup).not.toContain('id="thread-input"');
+    expect(markup).not.toContain('id="message-input"');
   });
 });

--- a/apps/frontend-bff/tests/routes.test.ts
+++ b/apps/frontend-bff/tests/routes.test.ts
@@ -944,6 +944,7 @@ describe("frontend-bff route handlers", () => {
         accepting_user_input: true,
         interrupt_available: false,
         blocked_by_request: false,
+        input_unavailable_reason: null,
       },
       timeline: {
         items: [

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-182-thread-view-composer](./archive/issue-182-thread-view-composer/README.md)
 - [issue-181-navigation-home-replacement](./archive/issue-181-navigation-home-replacement/README.md)
 - [issue-180-contract-audit](./archive/issue-180-contract-audit/README.md)
 - [issue-179-desktop-state-spec](./archive/issue-179-desktop-state-spec/README.md)

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-182-thread-view-composer](./issue-182-thread-view-composer/README.md)
 - [issue-178-benchmark-agent-uis](./issue-178-benchmark-agent-uis/README.md)
 - [issue-167-home-shell-resume](./issue-167-home-shell-resume/README.md)
 - [issue-150-ngrok-sse-validation](./issue-150-ngrok-sse-validation/README.md)

--- a/tasks/archive/issue-182-thread-view-composer/README.md
+++ b/tasks/archive/issue-182-thread-view-composer/README.md
@@ -1,0 +1,73 @@
+# Issue 182 Thread View Composer
+
+## Purpose
+
+- Implement the v0.9 thread view shell and single composer flow for Issue #182.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/182
+
+## Source docs
+
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Implement thread header and current activity presentation in the browser thread surface.
+- Replace separate thread-creation and chat composers with one composer path for new-thread start and existing-thread continuation.
+- Implement composer availability states for accepting input, approval pending, interrupt recommended, and recovery pending.
+- Keep the composer visible and understandable while streaming or blocked, without adding a standalone approval flow.
+
+## Exit criteria
+
+- The UI no longer exposes separate thread-creation and chat composers.
+- First workspace-context send starts a thread through the v0.9 path.
+- Opening a thread makes current state and available action clear without leaving thread context.
+- Focused frontend validation covers the changed thread view and composer behavior.
+
+## Work plan
+
+- Inspect the current `apps/frontend-bff` UI structure, view-model helpers, and tests for thread view, Navigation, composer, and request-state behavior.
+- Plan a bounded implementation slice around existing component and route patterns.
+- Update the thread shell, header/current activity display, and composer state handling.
+- Add or update focused tests for single-composer behavior, first-input thread start, existing-thread continuation, and blocked/streaming states.
+- Run targeted validation first, then app-level validation required by `apps/frontend-bff/README.md` as scope permits.
+
+## Artifacts / evidence
+
+- 2026-04-23 worker sprint validation:
+  - `npm run check` in `apps/frontend-bff` passed.
+  - `npm test -- tests/chat-view.test.tsx tests/chat-page-client.test.tsx tests/chat-data.test.ts tests/routes.test.ts` passed: 4 files, 40 tests.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+- 2026-04-23 sprint evaluator approved the planner-defined implementation slice.
+- 2026-04-23 dedicated pre-push validation passed:
+  - `npm run check` passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - Targeted Vitest passed: 4 files, 40 tests.
+  - Full Vitest passed: 10 files, 60 tests.
+  - `npm run build` passed.
+
+## Status / handoff notes
+
+- Status: `sprint evaluator approved; dedicated pre-push validation passed; package archived pending publish follow-through`
+- Active branch: `issue-182-thread-view-composer`
+- Active worktree: `.worktrees/issue-182-thread-view-composer`
+- Retrospective:
+  - Completion boundary: package archive only; Issue close is not yet eligible because the work is not reachable on `main`.
+  - Contract check: package exit criteria are satisfied by evaluator approval and pre-push validation; Issue close conditions are not applicable at this boundary.
+  - What worked: the sprint evaluator and pre-push gates gave clear local completion evidence before archive.
+  - Workflow problems: none requiring a separate artifact.
+  - Improvements to adopt: keep archive notes explicit that package completion is separate from PR, merge, sync, cleanup, and final Issue/Project completion.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: commit and PR, merge to `main`, sync the parent checkout, clean up the active worktree, then close Issue #182 and set the Project item to `Done` only after the repo is clean and synced.
+- Notes: Implemented the planner-approved single Thread View composer slice for Issue #182. This package is being archived now; no commit was created, no PR was opened, no GitHub Project state was changed, and no server was started.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, dedicated pre-push validation passes, completion retrospective is recorded, and handoff notes are updated.


### PR DESCRIPTION
## Summary

- Collapse the browser Thread View to a single normal composer for both first workspace input and selected-thread continuation.
- Route composer submission by context through the existing v0.9 workspace/thread input helpers.
- Surface disabled composer guidance for approval, running/interrupt, opening, no-workspace, and recovery states.
- Add focused tests and archive the completed Issue #182 work package.

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- tests/chat-view.test.tsx tests/chat-page-client.test.tsx tests/chat-data.test.ts tests/routes.test.ts`
- `npm test`
- `npm run build`

Closes #182