### PR TITLE
feat(frontend-bff): group thread timeline rows

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -569,14 +569,91 @@ textarea {
 }
 
 .chat-message,
-.chat-event {
+.chat-event,
+.timeline-row {
   display: grid;
   gap: 8px;
-  border-radius: 20px;
-  padding: 14px;
+  border-radius: 14px;
   background: rgba(255, 255, 255, 0.66);
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.chat-message,
+.chat-event {
+  padding: 14px;
+}
+
+.timeline-turn-group,
+.timeline-ungrouped-item {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.timeline-turn-group {
+  border-left: 3px solid rgba(35, 24, 15, 0.16);
+  padding-left: 12px;
+}
+
+.timeline-turn-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  min-width: 0;
+}
+
+.timeline-turn-label span {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.timeline-turn-label strong {
+  overflow-wrap: anywhere;
+}
+
+.timeline-row {
+  padding: 12px 14px;
+}
+
+.timeline-row-primary {
+  gap: 10px;
+  padding: 16px;
+}
+
+.timeline-row-primary p {
+  font-size: 1rem;
+}
+
+.timeline-row-prominent {
+  border: 1px solid rgba(143, 91, 20, 0.24);
+  background: rgba(255, 247, 236, 0.82);
+}
+
+.timeline-row-compact {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 5px;
+  border: 1px solid rgba(35, 24, 15, 0.07);
+  background: rgba(255, 255, 255, 0.46);
+  padding: 9px 12px;
+}
+
+.timeline-row-compact p,
+.timeline-row-compact .workspace-meta-row {
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
+.timeline-row-user {
+  border: 1px solid rgba(184, 77, 36, 0.22);
+}
+
+.timeline-row-assistant {
+  border: 1px solid rgba(35, 24, 15, 0.1);
 }
 
 .chat-message.user {
@@ -589,6 +666,7 @@ textarea {
 
 .chat-message p,
 .chat-event p,
+.timeline-row p,
 .request-signal {
   margin: 0;
   line-height: 1.5;

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -9,6 +9,7 @@ import type {
   PublicThreadView,
   PublicTimelineItem,
 } from "./thread-types";
+import { buildTimelineDisplayModel, type TimelineDisplayRow } from "./timeline-display-model";
 
 export interface ChatViewProps {
   workspaceId: string | null;
@@ -146,6 +147,10 @@ function timelineItemLabel(item: PublicTimelineItem) {
   return String(item.payload.content ?? item.payload.summary ?? item.kind);
 }
 
+function timelineRowClass(row: TimelineDisplayRow) {
+  return `timeline-row timeline-row-${row.density} timeline-row-${row.role}`;
+}
+
 function composerUnavailableReason(threadView: PublicThreadView | null) {
   if (!threadView) {
     return null;
@@ -204,7 +209,6 @@ export function ChatView({
   onApproveRequest,
   onDenyRequest,
 }: ChatViewProps) {
-  const draftEntries = Object.entries(draftAssistantMessages);
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
   const selectedWorkspace =
@@ -246,6 +250,11 @@ export function ChatView({
           (item) => item.timeline_item_id === detailSelection.timelineItemId,
         ) ?? null)
       : null;
+  const timelineModel = buildTimelineDisplayModel({
+    timelineItems: selectedThreadView?.timeline.items ?? [],
+    streamEvents,
+    draftAssistantMessages,
+  });
 
   useEffect(() => {
     setIsNavigationOpen(false);
@@ -581,62 +590,50 @@ export function ChatView({
             ) : null}
 
             <div className="chat-message-list">
-              {!isLoadingThread &&
-              selectedThreadView &&
-              selectedThreadView.timeline.items.length === 0 &&
-              draftEntries.length === 0 ? (
+              {!isLoadingThread && selectedThreadView && timelineModel.groups.length === 0 ? (
                 <p className="empty-state">
                   No timeline items yet. Start the thread or send follow-up input to continue.
                 </p>
               ) : null}
 
-              {selectedThreadView?.timeline.items.map((item) => (
-                <article className="chat-message assistant" key={item.timeline_item_id}>
-                  <div className="workspace-meta-row">
-                    <strong>{item.kind}</strong>
-                    <span className="workspace-meta">{formatTimestamp(item.occurred_at)}</span>
-                  </div>
-                  <p>{timelineItemLabel(item)}</p>
-                  <button
-                    className="secondary-link action-button inline-detail-button"
-                    onClick={() =>
-                      setDetailSelection({
-                        kind: "timeline_item_detail",
-                        timelineItemId: item.timeline_item_id,
-                      })
-                    }
-                    type="button"
-                  >
-                    Timeline item detail
-                  </button>
-                </article>
-              ))}
-
-              {draftEntries.map(([messageId, content]) => (
-                <article className="chat-message assistant" key={messageId}>
-                  <div className="workspace-meta-row">
-                    <strong>assistant streaming</strong>
-                    <span className="workspace-meta">Live</span>
-                  </div>
-                  <p>{content}…</p>
-                </article>
-              ))}
-
-              {streamEvents.map((event) => (
-                <article className="chat-message user" key={event.event_id}>
-                  <div className="workspace-meta-row">
-                    <strong>{event.event_type}</strong>
-                    <span className="workspace-meta">{formatTimestamp(event.occurred_at)}</span>
-                  </div>
-                  <p>
-                    {String(
-                      event.payload.content ??
-                        event.payload.summary ??
-                        event.payload.message ??
-                        event.event_type,
-                    )}
-                  </p>
-                </article>
+              {timelineModel.groups.map((group) => (
+                <section
+                  className={group.turnId ? "timeline-turn-group" : "timeline-ungrouped-item"}
+                  data-turn-id={group.turnId ?? undefined}
+                  key={group.id}
+                >
+                  {group.turnId ? (
+                    <div className="timeline-turn-label">
+                      <span>Turn</span>
+                      <strong>{group.turnId}</strong>
+                    </div>
+                  ) : null}
+                  {group.rows.map((row) => (
+                    <article className={timelineRowClass(row)} key={row.id}>
+                      <div className="workspace-meta-row">
+                        <strong>{row.label}</strong>
+                        <span className="workspace-meta">
+                          {row.isLive ? "Live" : formatTimestamp(row.occurredAt)}
+                        </span>
+                      </div>
+                      <p>{row.content}</p>
+                      {row.timelineItemId ? (
+                        <button
+                          className="secondary-link action-button inline-detail-button"
+                          onClick={() =>
+                            setDetailSelection({
+                              kind: "timeline_item_detail",
+                              timelineItemId: row.timelineItemId ?? "",
+                            })
+                          }
+                          type="button"
+                        >
+                          Timeline item detail
+                        </button>
+                      ) : null}
+                    </article>
+                  ))}
+                </section>
               ))}
             </div>
           </section>

--- a/apps/frontend-bff/src/timeline-display-model.ts
+++ b/apps/frontend-bff/src/timeline-display-model.ts
@@ -1,0 +1,320 @@
+import type { PublicThreadStreamEvent, PublicTimelineItem } from "./thread-types";
+
+export type TimelineRowDensity = "primary" | "prominent" | "compact";
+
+export type TimelineRowRole = "user" | "assistant" | "event";
+
+export interface TimelineDisplayRow {
+  id: string;
+  turnId: string | null;
+  sequence: number;
+  occurredAt: string | null;
+  label: string;
+  content: string;
+  density: TimelineRowDensity;
+  role: TimelineRowRole;
+  timelineItemId: string | null;
+  isLive: boolean;
+}
+
+export interface TimelineDisplayGroup {
+  id: string;
+  turnId: string | null;
+  rows: TimelineDisplayRow[];
+}
+
+export interface TimelineDisplayModel {
+  groups: TimelineDisplayGroup[];
+}
+
+const ASSISTANT_EVENT_TYPES = new Set(["message.assistant.delta", "message.assistant.completed"]);
+
+function asNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function payloadText(payload: Record<string, unknown>) {
+  return (
+    asNonEmptyString(payload.content) ??
+    asNonEmptyString(payload.delta) ??
+    asNonEmptyString(payload.summary) ??
+    asNonEmptyString(payload.message)
+  );
+}
+
+function timelineItemContent(item: PublicTimelineItem) {
+  return payloadText(item.payload) ?? item.kind;
+}
+
+function streamEventContent(event: PublicThreadStreamEvent) {
+  return payloadText(event.payload) ?? event.event_type;
+}
+
+function payloadTurnId(payload: Record<string, unknown>) {
+  return asNonEmptyString(payload.turn_id);
+}
+
+function streamAssistantKey(event: PublicThreadStreamEvent) {
+  return (
+    asNonEmptyString(event.payload.message_id) ??
+    asNonEmptyString(event.payload.item_id) ??
+    `sequence:${event.sequence}`
+  );
+}
+
+function timelineAssistantKeys(item: PublicTimelineItem) {
+  return [
+    asNonEmptyString(item.payload.message_id),
+    item.item_id,
+    asNonEmptyString(item.payload.item_id),
+  ].filter((value): value is string => value !== null);
+}
+
+function isAssistantTimelineItem(item: PublicTimelineItem) {
+  return item.kind.startsWith("message.assistant");
+}
+
+function isUserTimelineItem(item: PublicTimelineItem) {
+  return item.kind.startsWith("message.user");
+}
+
+export function classifyTimelineDensity(kind: string): TimelineRowDensity {
+  if (kind.startsWith("message.user") || kind.startsWith("message.assistant")) {
+    return "primary";
+  }
+
+  if (
+    kind.includes("approval") ||
+    kind.includes("request") ||
+    kind.includes("error") ||
+    kind.includes("failed") ||
+    kind.includes("file")
+  ) {
+    return "prominent";
+  }
+
+  return "compact";
+}
+
+function timelineRole(item: PublicTimelineItem): TimelineRowRole {
+  if (isUserTimelineItem(item)) {
+    return "user";
+  }
+
+  if (isAssistantTimelineItem(item)) {
+    return "assistant";
+  }
+
+  return "event";
+}
+
+function eventRole(event: PublicThreadStreamEvent): TimelineRowRole {
+  return event.event_type.startsWith("message.assistant") ? "assistant" : "event";
+}
+
+function buildGroups(rows: TimelineDisplayRow[]) {
+  const groups: TimelineDisplayGroup[] = [];
+
+  for (const row of rows) {
+    const previousGroup = groups.at(-1);
+
+    if (row.turnId && previousGroup?.turnId === row.turnId) {
+      previousGroup.rows.push(row);
+      continue;
+    }
+
+    groups.push({
+      id: row.turnId ? `turn:${row.turnId}:${row.id}` : `item:${row.id}`,
+      turnId: row.turnId,
+      rows: [row],
+    });
+  }
+
+  return groups;
+}
+
+function sortRows(rows: TimelineDisplayRow[]) {
+  return rows.toSorted((left, right) => {
+    if (left.sequence !== right.sequence) {
+      return left.sequence - right.sequence;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function buildTimelineDisplayModel({
+  timelineItems,
+  streamEvents,
+  draftAssistantMessages,
+}: {
+  timelineItems: PublicTimelineItem[];
+  streamEvents: PublicThreadStreamEvent[];
+  draftAssistantMessages: Record<string, string>;
+}): TimelineDisplayModel {
+  const sortedTimelineItems = timelineItems.toSorted(
+    (left, right) => left.sequence - right.sequence,
+  );
+  const rows: TimelineDisplayRow[] = [];
+  const restAssistantKeys = new Set<string>();
+  const restAssistantContents = new Set<string>();
+  const restDedupKeys = new Set<string>();
+
+  for (const item of sortedTimelineItems) {
+    restDedupKeys.add(`${item.kind}:${item.sequence}`);
+    restDedupKeys.add(`id:${item.timeline_item_id}`);
+
+    const content = timelineItemContent(item);
+    if (isAssistantTimelineItem(item)) {
+      for (const key of timelineAssistantKeys(item)) {
+        restAssistantKeys.add(key);
+      }
+      restAssistantContents.add(content);
+    }
+
+    rows.push({
+      id: `timeline:${item.timeline_item_id}`,
+      turnId: item.turn_id,
+      sequence: item.sequence,
+      occurredAt: item.occurred_at,
+      label: item.kind,
+      content,
+      density: classifyTimelineDensity(item.kind),
+      role: timelineRole(item),
+      timelineItemId: item.timeline_item_id,
+      isLive: false,
+    });
+  }
+
+  const sortedStreamEvents = streamEvents.toSorted((left, right) => left.sequence - right.sequence);
+  const assistantDeltaGroups = new Map<
+    string,
+    {
+      key: string;
+      turnId: string | null;
+      itemId: string | null;
+      firstSequence: number;
+      occurredAt: string | null;
+      content: string;
+      completedContent: string | null;
+      completedSequence: number | null;
+      completedAt: string | null;
+    }
+  >();
+
+  for (const event of sortedStreamEvents) {
+    if (!ASSISTANT_EVENT_TYPES.has(event.event_type)) {
+      continue;
+    }
+
+    const key = streamAssistantKey(event);
+    const existing = assistantDeltaGroups.get(key);
+    const group = existing ?? {
+      key,
+      turnId: payloadTurnId(event.payload),
+      itemId: asNonEmptyString(event.payload.item_id),
+      firstSequence: event.sequence,
+      occurredAt: event.occurred_at,
+      content: "",
+      completedContent: null,
+      completedSequence: null,
+      completedAt: null,
+    };
+
+    group.turnId = group.turnId ?? payloadTurnId(event.payload);
+    group.itemId = group.itemId ?? asNonEmptyString(event.payload.item_id);
+
+    if (event.event_type === "message.assistant.delta") {
+      const delta = asNonEmptyString(event.payload.delta);
+      if (delta) {
+        group.content = `${group.content}${delta}`;
+      }
+    }
+
+    if (event.event_type === "message.assistant.completed") {
+      group.completedContent = streamEventContent(event);
+      group.completedSequence = event.sequence;
+      group.completedAt = event.occurred_at;
+    }
+
+    assistantDeltaGroups.set(key, group);
+  }
+
+  for (const group of assistantDeltaGroups.values()) {
+    const content = group.completedContent ?? group.content;
+    if (!content) {
+      continue;
+    }
+
+    const keyConverged =
+      restAssistantKeys.has(group.key) ||
+      (group.itemId !== null && restAssistantKeys.has(group.itemId));
+    const contentConverged = group.completedContent !== null && restAssistantContents.has(content);
+    if (keyConverged || contentConverged) {
+      continue;
+    }
+
+    const isCompleted = group.completedContent !== null;
+    rows.push({
+      id: `assistant:${group.key}`,
+      turnId: group.turnId,
+      sequence: group.completedSequence ?? group.firstSequence,
+      occurredAt: group.completedAt ?? group.occurredAt,
+      label: isCompleted ? "message.assistant.completed" : "assistant streaming",
+      content: isCompleted ? content : `${content}...`,
+      density: "primary",
+      role: "assistant",
+      timelineItemId: null,
+      isLive: !isCompleted,
+    });
+  }
+
+  for (const [messageId, content] of Object.entries(draftAssistantMessages)) {
+    if (assistantDeltaGroups.has(messageId) || restAssistantKeys.has(messageId) || !content) {
+      continue;
+    }
+
+    rows.push({
+      id: `draft:${messageId}`,
+      turnId: null,
+      sequence: Number.MAX_SAFE_INTEGER,
+      occurredAt: null,
+      label: "assistant streaming",
+      content: `${content}...`,
+      density: "primary",
+      role: "assistant",
+      timelineItemId: null,
+      isLive: true,
+    });
+  }
+
+  for (const event of sortedStreamEvents) {
+    if (ASSISTANT_EVENT_TYPES.has(event.event_type)) {
+      continue;
+    }
+
+    if (
+      restDedupKeys.has(`id:${event.event_id}`) ||
+      restDedupKeys.has(`${event.event_type}:${event.sequence}`)
+    ) {
+      continue;
+    }
+
+    rows.push({
+      id: `stream:${event.event_id}`,
+      turnId: payloadTurnId(event.payload),
+      sequence: event.sequence,
+      occurredAt: event.occurred_at,
+      label: event.event_type,
+      content: streamEventContent(event),
+      density: classifyTimelineDensity(event.event_type),
+      role: eventRole(event),
+      timelineItemId: null,
+      isLive: false,
+    });
+  }
+
+  return {
+    groups: buildGroups(sortRows(rows)),
+  };
+}

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -274,6 +274,16 @@ describe("ChatView", () => {
               content: "Run git push",
             },
           },
+          {
+            event_id: "evt_stream_002",
+            thread_id: "thread_001",
+            event_type: "session.status_changed",
+            sequence: 3,
+            occurred_at: "2026-03-27T05:19:00Z",
+            payload: {
+              summary: "Tool output received",
+            },
+          },
         ]}
         threads={[
           {
@@ -324,6 +334,9 @@ describe("ChatView", () => {
     expect(markup).toContain("Please explain the diff.");
     expect(markup).toContain("Streaming update");
     expect(markup).toContain("approval.requested");
+    expect(markup).toContain("timeline-row-prominent");
+    expect(markup).toContain("session.status_changed");
+    expect(markup).toContain("timeline-row-compact");
     expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
     expect(markup).toContain('id="thread-composer-input"');
     expect(markup).not.toContain('id="thread-input"');

--- a/apps/frontend-bff/tests/timeline-display-model.test.ts
+++ b/apps/frontend-bff/tests/timeline-display-model.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import type { PublicThreadStreamEvent, PublicTimelineItem } from "../src/thread-types";
+import { buildTimelineDisplayModel, classifyTimelineDensity } from "../src/timeline-display-model";
+
+function timelineItem(overrides: Partial<PublicTimelineItem>): PublicTimelineItem {
+  return {
+    timeline_item_id: "timeline_001",
+    thread_id: "thread_001",
+    turn_id: null,
+    item_id: null,
+    sequence: 1,
+    occurred_at: "2026-03-27T05:20:00Z",
+    kind: "message.user",
+    payload: {
+      content: "Start",
+    },
+    ...overrides,
+  };
+}
+
+function streamEvent(overrides: Partial<PublicThreadStreamEvent>): PublicThreadStreamEvent {
+  return {
+    event_id: "stream_001",
+    thread_id: "thread_001",
+    event_type: "message.assistant.delta",
+    sequence: 1,
+    occurred_at: "2026-03-27T05:20:01Z",
+    payload: {
+      message_id: "message_001",
+      delta: "Hello",
+    },
+    ...overrides,
+  };
+}
+
+function rows(model: ReturnType<typeof buildTimelineDisplayModel>) {
+  return model.groups.flatMap((group) => group.rows);
+}
+
+describe("timeline display model", () => {
+  it("merges assistant deltas for the same assistant key into one live item in sequence order", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [],
+      streamEvents: [
+        streamEvent({
+          event_id: "delta_002",
+          sequence: 2,
+          payload: {
+            message_id: "message_001",
+            delta: "there",
+          },
+        }),
+        streamEvent({
+          event_id: "delta_001",
+          sequence: 1,
+          payload: {
+            message_id: "message_001",
+            delta: "Hi ",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    const modelRows = rows(model);
+    expect(modelRows).toHaveLength(1);
+    expect(modelRows[0]).toMatchObject({
+      label: "assistant streaming",
+      content: "Hi there...",
+      density: "primary",
+      role: "assistant",
+      isLive: true,
+    });
+  });
+
+  it("replaces a live assistant draft on completion and dedupes after REST convergence", () => {
+    const streamEvents: PublicThreadStreamEvent[] = [
+      streamEvent({
+        event_id: "delta_001",
+        sequence: 1,
+        payload: {
+          message_id: "message_001",
+          delta: "Partial",
+        },
+      }),
+      streamEvent({
+        event_id: "completed_001",
+        event_type: "message.assistant.completed",
+        sequence: 2,
+        payload: {
+          message_id: "message_001",
+          content: "Final answer.",
+        },
+      }),
+    ];
+
+    const beforeRest = buildTimelineDisplayModel({
+      timelineItems: [],
+      streamEvents,
+      draftAssistantMessages: {
+        message_001: "Partial",
+      },
+    });
+    expect(rows(beforeRest)).toHaveLength(1);
+    expect(rows(beforeRest)[0]).toMatchObject({
+      label: "message.assistant.completed",
+      content: "Final answer.",
+      isLive: false,
+    });
+
+    const afterRest = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "timeline_completed",
+          item_id: "item_assistant_001",
+          sequence: 2,
+          kind: "message.assistant.completed",
+          payload: {
+            message_id: "message_001",
+            content: "Final answer.",
+          },
+        }),
+      ],
+      streamEvents,
+      draftAssistantMessages: {
+        message_001: "Partial",
+      },
+    });
+
+    const convergedRows = rows(afterRest);
+    expect(convergedRows).toHaveLength(1);
+    expect(convergedRows[0]).toMatchObject({
+      id: "timeline:timeline_completed",
+      content: "Final answer.",
+    });
+  });
+
+  it("groups adjacent timeline rows by turn_id without grouping rows that lack turn_id", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "user_001",
+          turn_id: "turn_001",
+          sequence: 1,
+          kind: "message.user",
+          payload: {
+            content: "Explain this diff.",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "assistant_001",
+          turn_id: "turn_001",
+          sequence: 2,
+          kind: "message.assistant.completed",
+          payload: {
+            content: "The diff changes the UI.",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "status_001",
+          turn_id: null,
+          sequence: 3,
+          kind: "session.status_changed",
+          payload: {
+            summary: "idle",
+          },
+        }),
+      ],
+      streamEvents: [],
+      draftAssistantMessages: {},
+    });
+
+    expect(model.groups).toHaveLength(2);
+    expect(model.groups[0]?.turnId).toBe("turn_001");
+    expect(model.groups[0]?.rows.map((row) => row.id)).toEqual([
+      "timeline:user_001",
+      "timeline:assistant_001",
+    ]);
+    expect(model.groups[1]?.turnId).toBeNull();
+    expect(model.groups[1]?.rows).toHaveLength(1);
+  });
+
+  it("classifies primary messages, prominent approval/error/file rows, and compact operational rows", () => {
+    expect(classifyTimelineDensity("message.user")).toBe("primary");
+    expect(classifyTimelineDensity("message.assistant.completed")).toBe("primary");
+    expect(classifyTimelineDensity("approval.requested")).toBe("prominent");
+    expect(classifyTimelineDensity("error.raised")).toBe("prominent");
+    expect(classifyTimelineDensity("file.changed")).toBe("prominent");
+    expect(classifyTimelineDensity("session.status_changed")).toBe("compact");
+    expect(classifyTimelineDensity("tool.started")).toBe("compact");
+    expect(classifyTimelineDensity("command.output")).toBe("compact");
+  });
+
+  it("renders low-priority stream events as compact rows instead of separate raw event cards", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [],
+      streamEvents: [
+        streamEvent({
+          event_id: "status_001",
+          event_type: "session.status_changed",
+          sequence: 4,
+          payload: {
+            summary: "Running tool",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "stream:status_001",
+        label: "session.status_changed",
+        content: "Running tool",
+        density: "compact",
+      }),
+    ]);
+  });
+});

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-183-timeline-grouping](./archive/issue-183-timeline-grouping/README.md)
 - [issue-182-thread-view-composer](./archive/issue-182-thread-view-composer/README.md)
 - [issue-181-navigation-home-replacement](./archive/issue-181-navigation-home-replacement/README.md)
 - [issue-180-contract-audit](./archive/issue-180-contract-audit/README.md)

--- a/tasks/archive/issue-183-timeline-grouping/README.md
+++ b/tasks/archive/issue-183-timeline-grouping/README.md
@@ -1,0 +1,66 @@
+# Issue 183 Timeline Grouping
+
+## Purpose
+
+- Implement the v0.9 thread-view timeline grouping, density, and assistant delta merge slice for Issue #183.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/183
+
+## Source docs
+
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/notes/codex_webui_agent_ui_benchmark_note_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Replace all-card timeline rendering with grouped, readable thread chronology.
+- Merge assistant streaming deltas into one visible assistant item while output is active.
+- Define practical density tiers for user and assistant messages, approval or error items, file/tool/status rows, and low-priority logs.
+- Add compact log rows or collapsed handling so low-priority items do not crowd out primary thread content.
+- Preserve sticky composer and timeline scrolling behavior while streaming.
+
+## Exit criteria
+
+- Streaming no longer creates one visible card per assistant delta.
+- User and assistant turn grouping keeps the primary thread narrative readable.
+- Approval, error, file/tool/status, and low-priority log items render with appropriate density.
+- Sticky composer and timeline scrolling behavior remain compatible with the grouped timeline.
+- Focused frontend tests cover assistant delta merge, density tiers, and primary timeline readability behavior.
+
+## Work plan
+
+- Inspect current thread view, timeline, stream update, and tests in `apps/frontend-bff`.
+- Add or adjust a timeline view-model layer for grouping, assistant delta coalescing, and density classification.
+- Update the thread timeline rendering to use grouped message blocks and compact operational rows.
+- Add focused tests for streaming delta merge, compact rows, and stable scrolling/composer layout assumptions.
+- Run the frontend validation commands required for this slice.
+
+## Artifacts / evidence
+
+- Sprint validation: `npm run check` passed.
+- Sprint validation: `npm test -- --run tests/timeline-display-model.test.ts tests/chat-view.test.tsx` passed.
+- Sprint validation: `npm test -- --run tests/chat-page-client.test.tsx -t "keeps the final assistant message visible|renders the final assistant message from the stream"` passed.
+- Sprint validation: `npm run build` passed after evaluator requested the missing build evidence.
+- Pre-push validation: `npm run check` passed.
+- Pre-push validation: `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+- Pre-push validation: `npm test` passed with 11 files and 65 tests.
+- Pre-push validation: `npm run build` passed.
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-23T12-34-21Z-issue-183-close/events.ndjson`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-183-timeline-grouping`
+- Active worktree: `.worktrees/issue-183-timeline-grouping`
+- Notes: Implemented the Issue #183 timeline display slice with a single derived timeline display model, assistant delta coalescing, completed-stream dedupe, turn grouping, density classification, compact operational rows, and focused tests. Sprint evaluator approved the slice. Dedicated pre-push validation passed. Completion retrospective found no workflow updates or new skill candidates; Issue close still requires commit, PR, merge to `main`, parent checkout sync, worktree cleanup, and final GitHub tracking updates.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and handoff notes are updated.
+- Archive condition status: met for this local package.


### PR DESCRIPTION
## Summary

- add a derived timeline display model for thread view rendering
- merge assistant streaming deltas into one live assistant row and dedupe completed output after REST convergence
- group adjacent turn rows and render primary, prominent, and compact timeline densities
- archive the Issue #183 task package

## Validation

- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm test
- npm run build

Closes #183
