### PR TITLE
[codex] Add actionable background priority thread notices

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -395,6 +395,20 @@ textarea {
   gap: 10px;
 }
 
+.background-priority-notice {
+  display: grid;
+  gap: 10px;
+  padding: 14px 16px;
+  border: 1px solid rgba(143, 91, 20, 0.2);
+  border-radius: 18px;
+  background: rgba(255, 248, 231, 0.92);
+  box-shadow: var(--shadow);
+}
+
+.background-priority-notice p {
+  margin: 0;
+}
+
 .chat-panel {
   display: grid;
   gap: 14px;

--- a/apps/frontend-bff/src/chat-page-client.tsx
+++ b/apps/frontend-bff/src/chat-page-client.tsx
@@ -102,6 +102,15 @@ function replaceChatUrl(workspaceId: string | null, threadId: string | null) {
   window.history.replaceState(null, "", nextUrl);
 }
 
+function derivePriorityReason(thread: PublicThreadListItem) {
+  return (
+    thread.blocked_cue?.label ??
+    thread.resume_cue?.label ??
+    thread.badge?.label ??
+    thread.current_activity.label
+  );
+}
+
 export function ChatPageClient() {
   const searchParams = useSearchParams();
   const initialWorkspaceId = searchParams.get("workspaceId");
@@ -119,6 +128,10 @@ export function ChatPageClient() {
   const [composerDraft, setComposerDraft] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [backgroundPriorityNotice, setBackgroundPriorityNotice] = useState<{
+    threadId: string;
+    reason: string;
+  } | null>(null);
   const [isLoadingThreads, setIsLoadingThreads] = useState(false);
   const [isLoadingWorkspaces, setIsLoadingWorkspaces] = useState(false);
   const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
@@ -214,7 +227,7 @@ export function ChatPageClient() {
     if (!workspaceId) {
       setThreads([]);
       setSelectedThreadId(null);
-      return;
+      return null;
     }
 
     const refreshId = threadListRefreshIdRef.current + 1;
@@ -241,10 +254,12 @@ export function ChatPageClient() {
       updateSelectedThreadId(nextSelectedThreadId, "refresh_threads", {
         refresh_id: refreshId,
       });
+      return response.items;
     } catch (error) {
       if (threadListRefreshIdRef.current === refreshId) {
         setErrorMessage(error instanceof Error ? error.message : "Failed to load threads.");
       }
+      return null;
     } finally {
       if (threadListRefreshIdRef.current === refreshId) {
         setIsLoadingThreads(false);
@@ -323,6 +338,7 @@ export function ChatPageClient() {
       setStreamEvents([]);
       streamEventsRef.current = [];
       setDraftAssistantMessages({});
+      setBackgroundPriorityNotice(null);
       setConnectionState("idle");
       return;
     }
@@ -501,11 +517,29 @@ export function ChatPageClient() {
 
       const currentThreadId = selectedThreadIdRef.current;
       if (currentThreadId && event.thread_id === currentThreadId) {
+        setBackgroundPriorityNotice(null);
         void refreshSelectedThreadAndList(currentThreadId);
         return;
       }
 
-      void refreshThreads(currentThreadId);
+      void refreshThreads(currentThreadId).then((refreshedThreads) => {
+        if (!event.high_priority) {
+          return;
+        }
+
+        const targetThread =
+          refreshedThreads?.find((thread) => thread.thread_id === event.thread_id) ?? null;
+
+        if (!targetThread) {
+          setBackgroundPriorityNotice(null);
+          return;
+        }
+
+        setBackgroundPriorityNotice({
+          threadId: targetThread.thread_id,
+          reason: derivePriorityReason(targetThread),
+        });
+      });
     };
 
     notifications.onerror = () => {
@@ -588,6 +622,7 @@ export function ChatPageClient() {
     setStreamEvents([]);
     streamEventsRef.current = [];
     setDraftAssistantMessages({});
+    setBackgroundPriorityNotice(null);
     setStatusMessage(null);
     setErrorMessage(null);
     replaceChatUrl(nextWorkspaceId, null);
@@ -613,6 +648,7 @@ export function ChatPageClient() {
       ]);
       setWorkspaceId(workspace.workspace_id);
       setThreads([]);
+      setBackgroundPriorityNotice(null);
       updateSelectedThreadId(null, "create_workspace_success", {
         workspace_id: workspace.workspace_id,
       });
@@ -673,8 +709,16 @@ export function ChatPageClient() {
     }
   }
 
+  function handleSelectThread(threadId: string, reason: string) {
+    setBackgroundPriorityNotice((currentNotice) =>
+      currentNotice?.threadId === threadId ? null : currentNotice,
+    );
+    updateSelectedThreadId(threadId, reason);
+  }
+
   return (
     <ChatView
+      backgroundPriorityNotice={backgroundPriorityNotice}
       connectionState={connectionState}
       draftAssistantMessages={draftAssistantMessages}
       errorMessage={errorMessage}
@@ -691,9 +735,12 @@ export function ChatPageClient() {
       onComposerDraftChange={setComposerDraft}
       onCreateWorkspace={() => void handleCreateWorkspace()}
       onDenyRequest={() => void handleRequestDecision("denied")}
+      onOpenBackgroundPriorityThread={(threadId) =>
+        handleSelectThread(threadId, "background_priority_notice")
+      }
       onInterruptThread={() => void handleInterruptThread()}
       onSelectWorkspace={(nextWorkspaceId) => void handleSelectWorkspace(nextWorkspaceId)}
-      onSelectThread={(threadId) => updateSelectedThreadId(threadId, "user_select_thread")}
+      onSelectThread={(threadId) => handleSelectThread(threadId, "user_select_thread")}
       onSubmitComposer={() => void handleSubmitComposer()}
       onWorkspaceNameChange={setWorkspaceName}
       selectedRequestDetail={selectedRequestDetail}

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -15,6 +15,10 @@ export interface ChatViewProps {
   workspaceId: string | null;
   workspaces: PublicWorkspaceSummary[];
   threads: PublicThreadListItem[];
+  backgroundPriorityNotice: {
+    threadId: string;
+    reason: string;
+  } | null;
   selectedThreadId: string | null;
   selectedThreadView: PublicThreadView | null;
   selectedRequestDetail: PublicRequestDetail | null;
@@ -39,6 +43,7 @@ export interface ChatViewProps {
   onCreateWorkspace: () => void;
   onSelectWorkspace: (workspaceId: string) => void;
   onSelectThread: (threadId: string) => void;
+  onOpenBackgroundPriorityThread: (threadId: string) => void;
   onInterruptThread: () => void;
   onApproveRequest: () => void;
   onDenyRequest: () => void;
@@ -181,6 +186,7 @@ export function ChatView({
   workspaceId,
   workspaces,
   threads,
+  backgroundPriorityNotice,
   selectedThreadId,
   selectedThreadView,
   selectedRequestDetail,
@@ -205,6 +211,7 @@ export function ChatView({
   onCreateWorkspace,
   onSelectWorkspace,
   onSelectThread,
+  onOpenBackgroundPriorityThread,
   onInterruptThread,
   onApproveRequest,
   onDenyRequest,
@@ -297,6 +304,28 @@ export function ChatView({
               </p>
             ) : null}
           </div>
+        ) : null}
+        {backgroundPriorityNotice ? (
+          <section aria-live="polite" className="background-priority-notice" role="status">
+            <div className="workspace-meta-row">
+              <strong>Background thread needs attention</strong>
+              <span className="status-badge warning">High priority</span>
+            </div>
+            <p>
+              <strong>{backgroundPriorityNotice.threadId}</strong>
+              {" needs attention now."}
+            </p>
+            <p className="workspace-meta">Reason: {backgroundPriorityNotice.reason}</p>
+            <div className="workspace-actions">
+              <button
+                className="primary-link action-button compact-button"
+                onClick={() => onOpenBackgroundPriorityThread(backgroundPriorityNotice.threadId)}
+                type="button"
+              >
+                Open thread
+              </button>
+            </div>
+          </section>
         ) : null}
 
         <section

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -1133,26 +1133,96 @@ describe("ChatPageClient", () => {
     );
   });
 
-  it("uses global notification events as refresh triggers and high-priority signals", async () => {
-    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
-      items: [
-        buildThreadListItem(),
-        buildThreadListItem({
-          thread_id: "thread_background",
-          resume_cue: {
-            reason_kind: "waiting_on_approval",
-            priority_band: "highest",
-            label: "Resume here first",
+  it("shows a targeted notice for a background high-priority thread and opens it on demand", async () => {
+    chatDataMocks.listWorkspaceThreads
+      .mockResolvedValueOnce({
+        items: [
+          buildThreadListItem(),
+          buildThreadListItem({
+            thread_id: "thread_background",
+            native_status: {
+              thread_status: "waiting_input",
+              active_flags: ["waiting_on_request"],
+              latest_turn_status: null,
+            },
+            current_activity: {
+              kind: "waiting_on_approval",
+              label: "Approval required",
+            },
+            blocked_cue: {
+              kind: "approval_required",
+              label: "Needs response",
+            },
+            resume_cue: {
+              reason_kind: "waiting_on_approval",
+              priority_band: "highest",
+              label: "Resume here first",
+            },
+          }),
+        ],
+        next_cursor: null,
+        has_more: false,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          buildThreadListItem(),
+          buildThreadListItem({
+            thread_id: "thread_background",
+            native_status: {
+              thread_status: "waiting_input",
+              active_flags: ["waiting_on_request"],
+              latest_turn_status: null,
+            },
+            current_activity: {
+              kind: "waiting_on_approval",
+              label: "Approval required",
+            },
+            blocked_cue: {
+              kind: "approval_required",
+              label: "Needs response",
+            },
+            resume_cue: {
+              reason_kind: "waiting_on_approval",
+              priority_band: "highest",
+              label: "Resume here first",
+            },
+          }),
+        ],
+        next_cursor: null,
+        has_more: false,
+      });
+    chatDataMocks.loadChatThreadBundle
+      .mockResolvedValueOnce({
+        view: buildThreadView(),
+        pendingRequestDetail: null,
+      })
+      .mockResolvedValueOnce({
+        view: buildThreadView({
+          thread: {
+            thread_id: "thread_background",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "waiting_input",
+              active_flags: ["waiting_on_request"],
+              latest_turn_status: null,
+            },
+            updated_at: "2026-03-27T05:25:00Z",
+          },
+          current_activity: {
+            kind: "waiting_on_approval",
+            label: "Approval required",
+          },
+          composer: {
+            accepting_user_input: false,
+            interrupt_available: false,
+            blocked_by_request: true,
+            input_unavailable_reason: null,
           },
         }),
-      ],
-      next_cursor: null,
-      has_more: false,
-    });
-    chatDataMocks.loadChatThreadBundle.mockResolvedValue({
-      view: buildThreadView(),
-      pendingRequestDetail: null,
-    });
+        pendingRequestDetail: buildPendingRequestDetail({
+          thread_id: "thread_background",
+        }),
+      });
 
     await act(async () => {
       root.render(<ChatPageClient />);
@@ -1180,8 +1250,167 @@ describe("ChatPageClient", () => {
 
     expect(chatDataMocks.listWorkspaceThreads).toHaveBeenCalledTimes(2);
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("thread_001");
     expect(container.textContent).toContain("High-priority background thread needs attention.");
-    expect(container.textContent).toContain("Resume here first");
+    expect(container.textContent).toContain("Background thread needs attention");
+    expect(container.textContent).toContain("Reason: Needs response");
+
+    const openThreadButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Open thread",
+    );
+    expect(openThreadButton).not.toBeUndefined();
+
+    await act(async () => {
+      openThreadButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushUi();
+
+    expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
+    expect(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Open thread",
+      ),
+    ).toBeUndefined();
+    expect(container.textContent).toContain("thread_background");
+    expect(container.textContent).toContain("Approval required");
+  });
+
+  it("refreshes the selected thread for a high-priority current-thread notification without a background notice", async () => {
+    chatDataMocks.listWorkspaceThreads
+      .mockResolvedValueOnce({
+        items: [buildThreadListItem()],
+        next_cursor: null,
+        has_more: false,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          buildThreadListItem({
+            updated_at: "2026-03-27T05:25:00Z",
+            current_activity: {
+              kind: "waiting_on_approval",
+              label: "Approval required",
+            },
+            blocked_cue: {
+              kind: "approval_required",
+              label: "Needs response",
+            },
+          }),
+        ],
+        next_cursor: null,
+        has_more: false,
+      });
+    chatDataMocks.loadChatThreadBundle
+      .mockResolvedValueOnce({
+        view: buildThreadView(),
+        pendingRequestDetail: null,
+      })
+      .mockResolvedValueOnce({
+        view: buildThreadView({
+          current_activity: {
+            kind: "waiting_on_approval",
+            label: "Approval required",
+          },
+          pending_request: {
+            request_id: "req_selected",
+            thread_id: "thread_001",
+            turn_id: "turn_001",
+            item_id: "item_001",
+            request_kind: "approval",
+            status: "pending",
+            risk_category: "external_side_effect",
+            summary: "Run git push",
+            requested_at: "2026-03-27T05:25:00Z",
+          },
+          composer: {
+            accepting_user_input: false,
+            interrupt_available: true,
+            blocked_by_request: true,
+            input_unavailable_reason: null,
+          },
+        }),
+        pendingRequestDetail: buildPendingRequestDetail(),
+      });
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    const notifications = MockEventSource.instances.find(
+      (instance) => instance.url === "/api/v1/notifications/stream",
+    );
+
+    await act(async () => {
+      notifications?.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            thread_id: "thread_001",
+            event_type: "approval.requested",
+            occurred_at: "2026-03-27T05:25:00Z",
+            high_priority: true,
+          }),
+        }),
+      );
+    });
+    await flushUi();
+
+    expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("Approval required");
+    expect(container.textContent).not.toContain("Background thread needs attention");
+    expect(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Open thread",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("keeps the generic high-priority status when the refreshed workspace list does not include the target thread", async () => {
+    chatDataMocks.listWorkspaceThreads
+      .mockResolvedValueOnce({
+        items: [buildThreadListItem()],
+        next_cursor: null,
+        has_more: false,
+      })
+      .mockResolvedValueOnce({
+        items: [buildThreadListItem()],
+        next_cursor: null,
+        has_more: false,
+      });
+    chatDataMocks.loadChatThreadBundle.mockResolvedValue({
+      view: buildThreadView(),
+      pendingRequestDetail: null,
+    });
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    const notifications = MockEventSource.instances.find(
+      (instance) => instance.url === "/api/v1/notifications/stream",
+    );
+
+    await act(async () => {
+      notifications?.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            thread_id: "thread_missing",
+            event_type: "approval.requested",
+            occurred_at: "2026-03-27T05:25:00Z",
+            high_priority: true,
+          }),
+        }),
+      );
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("High-priority background thread needs attention.");
+    expect(container.textContent).not.toContain("Background thread needs attention");
+    expect(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Open thread",
+      ),
+    ).toBeUndefined();
   });
 
   it("keeps the final assistant message visible after completion refresh", async () => {

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -24,6 +24,7 @@ describe("ChatView", () => {
   it("renders Navigation workspace switching, creation, and grouped thread cues", () => {
     const markup = renderToStaticMarkup(
       <ChatView
+        backgroundPriorityNotice={null}
         connectionState="idle"
         draftAssistantMessages={{}}
         errorMessage={null}
@@ -41,6 +42,7 @@ describe("ChatView", () => {
         onCreateWorkspace={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
+        onOpenBackgroundPriorityThread={() => {}}
         onComposerDraftChange={() => {}}
         onSelectThread={() => {}}
         onSelectWorkspace={() => {}}
@@ -164,6 +166,7 @@ describe("ChatView", () => {
   it("renders thread context, pending request controls, and timeline state", () => {
     const markup = renderToStaticMarkup(
       <ChatView
+        backgroundPriorityNotice={null}
         connectionState="live"
         draftAssistantMessages={{
           draft_001: "Streaming update",
@@ -183,6 +186,7 @@ describe("ChatView", () => {
         onSubmitComposer={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
+        onOpenBackgroundPriorityThread={() => {}}
         onComposerDraftChange={() => {}}
         onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
@@ -346,6 +350,7 @@ describe("ChatView", () => {
   it("renders transient feedback above the chat panels", () => {
     const markup = renderToStaticMarkup(
       <ChatView
+        backgroundPriorityNotice={null}
         connectionState="live"
         draftAssistantMessages={{}}
         errorMessage="Failed to interrupt the thread."
@@ -363,6 +368,7 @@ describe("ChatView", () => {
         onSubmitComposer={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
+        onOpenBackgroundPriorityThread={() => {}}
         onComposerDraftChange={() => {}}
         onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
@@ -390,6 +396,7 @@ describe("ChatView", () => {
   it("renders latest resolved request recovery affordance without response controls", () => {
     const markup = renderToStaticMarkup(
       <ChatView
+        backgroundPriorityNotice={null}
         connectionState="idle"
         draftAssistantMessages={{}}
         errorMessage={null}
@@ -407,6 +414,7 @@ describe("ChatView", () => {
         onSubmitComposer={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
+        onOpenBackgroundPriorityThread={() => {}}
         onComposerDraftChange={() => {}}
         onSelectWorkspace={() => {}}
         onSelectThread={() => {}}
@@ -487,9 +495,57 @@ describe("ChatView", () => {
     expect(markup).not.toContain("Deny request");
   });
 
+  it("renders a targeted background-priority notice with a direct thread action", () => {
+    const markup = renderToStaticMarkup(
+      <ChatView
+        backgroundPriorityNotice={{
+          threadId: "thread_background",
+          reason: "Needs response",
+        }}
+        connectionState="live"
+        draftAssistantMessages={{}}
+        errorMessage={null}
+        isCreatingThread={false}
+        isCreatingWorkspace={false}
+        isInterruptingThread={false}
+        isLoadingThread={false}
+        isLoadingThreads={false}
+        isLoadingWorkspaces={false}
+        isRespondingToRequest={false}
+        isSendingMessage={false}
+        composerDraft=""
+        onCreateWorkspace={() => {}}
+        onApproveRequest={() => {}}
+        onSubmitComposer={() => {}}
+        onDenyRequest={() => {}}
+        onInterruptThread={() => {}}
+        onOpenBackgroundPriorityThread={() => {}}
+        onComposerDraftChange={() => {}}
+        onSelectWorkspace={() => {}}
+        onSelectThread={() => {}}
+        onWorkspaceNameChange={() => {}}
+        selectedRequestDetail={null}
+        selectedThreadId="thread_001"
+        selectedThreadView={null}
+        statusMessage="High-priority background thread needs attention."
+        streamEvents={[]}
+        threads={[]}
+        workspaceId="ws_alpha"
+        workspaceName=""
+        workspaces={[]}
+      />,
+    );
+
+    expect(markup).toContain("Background thread needs attention");
+    expect(markup).toContain("thread_background");
+    expect(markup).toContain("Reason: Needs response");
+    expect(markup).toContain("Open thread");
+  });
+
   it("renders recovery input-unavailable reason as the single disabled composer state", () => {
     const markup = renderToStaticMarkup(
       <ChatView
+        backgroundPriorityNotice={null}
         connectionState="idle"
         draftAssistantMessages={{}}
         errorMessage={null}
@@ -507,6 +563,7 @@ describe("ChatView", () => {
         onSubmitComposer={() => {}}
         onDenyRequest={() => {}}
         onInterruptThread={() => {}}
+        onOpenBackgroundPriorityThread={() => {}}
         onComposerDraftChange={() => {}}
         onSelectWorkspace={() => {}}
         onSelectThread={() => {}}

--- a/tasks/archive/issue-185-reconnect-recovery/README.md
+++ b/tasks/archive/issue-185-reconnect-recovery/README.md
@@ -1,0 +1,54 @@
+# Issue #185 Reconnect Recovery
+
+## Purpose
+
+- Implement the reconnect recovery and background priority notification slice for Issue #185.
+
+## Primary issue
+
+- Issue: `#185` https://github.com/tsukushibito/codex-webui/issues/185
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+
+## Scope for this package
+
+- Implement thread-scoped reconnect recovery and sequence-gap reacquisition in the browser/BFF flow.
+- Surface background `waitingOnApproval`, `systemError`, and failed-turn states through navigation emphasis or lightweight notifications.
+- Absorb open-required and runtime-error recovery into the thread-view flow without reviving a separate recovery screen.
+
+## Exit criteria
+
+- Sequence gaps and reconnect paths trigger documented REST reacquisition that restores thread-view consistency.
+- Background high-priority thread state changes are visibly emphasized in the UI.
+- Open-required and runtime-error recovery paths keep the user inside the thread-first flow.
+- Local implementation passes the sprint gate and the dedicated pre-push validation gate before archive-oriented handoff.
+
+## Work plan
+
+- Audit the current thread stream, timeline, and notification handling to define one bounded implementation slice.
+- Implement the required BFF and UI changes with focused tests.
+- Run sprint evaluation, then the dedicated pre-push validation gate.
+- Archive the package only after the slice is validated and ready for merge/completion tracking.
+
+## Artifacts / evidence
+
+- Validation evidence captured from `apps/frontend-bff`:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `npm test`
+  - `npm run build`
+- Package lifecycle notes in this README
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: `Implemented actionable background high-priority thread notices in /chat, kept thread selection stable on notification arrival, and added focused Chat UI tests. Sprint evaluator approved the bounded slice. The dedicated pre-push validation gate passed with check, tsc, test, and build in apps/frontend-bff.`
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the pre-push validation gate passes, and the handoff notes are updated.


### PR DESCRIPTION
## Summary
- add an actionable background-priority notice in `/chat` for high-priority notifications targeting a non-selected thread
- keep selected-thread notifications in the current thread flow without auto-switching or auto-opening detail
- cover the new notice behavior with chat page and chat view tests, and archive the local task package for Issue #185

## Root cause
The renewed thread-first UI only exposed a generic high-priority status message when `/api/v1/notifications/stream` reported attention-needed background activity. That made the affected thread hard to identify or open directly from `/chat`, even though Issue #185 requires background high-priority threads to be hard to miss without leaving thread context.

## Validation
- `cd apps/frontend-bff && npm run check`
- `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `cd apps/frontend-bff && npm test`
- `cd apps/frontend-bff && npm run build`

Closes #185
