### PR TITLE
feat: add UX renewal validation gates

### DIFF
--- a/apps/frontend-bff/e2e/approval-flow.spec.ts
+++ b/apps/frontend-bff/e2e/approval-flow.spec.ts
@@ -14,7 +14,7 @@ async function runRequestDecisionFlow(
   await mockApprovalFlow(page);
 
   await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
-  await expect(page.getByRole("heading", { name: "Chat", exact: true })).toBeVisible();
+  await expect(page.locator("header.chat-topbar h1")).toHaveText("alpha");
   await expect(page.getByRole("heading", { name: "thread_001", exact: true })).toBeVisible();
   await expect(page.locator(".request-detail-card")).toBeVisible();
   await expect(page.getByText("Apply the prepared deployment plan.")).toBeVisible();
@@ -25,7 +25,7 @@ async function runRequestDecisionFlow(
   await expect(
     page.getByText(`${decision === "approved" ? "Approved" : "Denied"} req_001.`),
   ).toBeVisible();
-  await expect(page.getByText(`Latest request: ${decision}`)).toBeVisible();
+  await expect(page.getByText(`Decision: ${decision}`)).toBeVisible();
   await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
 }
 

--- a/apps/frontend-bff/e2e/background-priority.spec.ts
+++ b/apps/frontend-bff/e2e/background-priority.spec.ts
@@ -1,0 +1,294 @@
+import { expect, test } from "@playwright/test";
+
+import { stubEventSource } from "./helpers/browser-mocks";
+
+async function emitNotificationEvent(
+  page: Parameters<typeof test>[0]["page"],
+  payload: Record<string, unknown>,
+) {
+  await page.evaluate((message) => {
+    const windowWithMockSources = window as Window & {
+      __mockEventSourceInstances?: Array<{
+        url: string;
+        emit: (data: unknown) => void;
+      }>;
+    };
+
+    for (const instance of windowWithMockSources.__mockEventSourceInstances ?? []) {
+      if (instance.url === "/api/v1/notifications/stream") {
+        instance.emit(message);
+      }
+    }
+  }, payload);
+}
+
+async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page"]) {
+  const baseTimestamp = "2026-04-24T03:10:00Z";
+
+  const workspace = {
+    workspace_id: "ws_alpha",
+    workspace_name: "alpha",
+    created_at: "2026-04-24T03:00:00Z",
+    updated_at: baseTimestamp,
+    active_session_summary: {
+      session_id: "thread_001",
+      status: "running",
+      last_message_at: baseTimestamp,
+    },
+    pending_approval_count: 1,
+  };
+
+  const primaryThread = {
+    thread_id: "thread_001",
+    workspace_id: "ws_alpha",
+    native_status: {
+      thread_status: "running",
+      active_flags: [],
+      latest_turn_status: "completed",
+    },
+    updated_at: baseTimestamp,
+    current_activity: {
+      kind: "waiting_on_user_input",
+      label: "Waiting for your input",
+    },
+    badge: null,
+    blocked_cue: null,
+    resume_cue: {
+      reason_kind: "active_thread",
+      priority_band: "medium" as const,
+      label: "Active now",
+    },
+  };
+
+  const backgroundThread = {
+    thread_id: "thread_background",
+    workspace_id: "ws_alpha",
+    native_status: {
+      thread_status: "waiting_input",
+      active_flags: ["waiting_on_request"],
+      latest_turn_status: null,
+    },
+    updated_at: "2026-04-24T03:11:00Z",
+    current_activity: {
+      kind: "waiting_on_approval",
+      label: "Approval required",
+    },
+    badge: {
+      kind: "approval_required",
+      label: "Approval required",
+    },
+    blocked_cue: {
+      kind: "approval_required",
+      label: "Needs response",
+    },
+    resume_cue: {
+      reason_kind: "waiting_on_approval",
+      priority_band: "highest" as const,
+      label: "Resume here first",
+    },
+  };
+
+  const threadViewById = {
+    thread_001: {
+      thread: {
+        thread_id: "thread_001",
+        workspace_id: "ws_alpha",
+        native_status: primaryThread.native_status,
+        updated_at: primaryThread.updated_at,
+      },
+      current_activity: primaryThread.current_activity,
+      pending_request: null,
+      latest_resolved_request: null,
+      composer: {
+        accepting_user_input: true,
+        interrupt_available: false,
+        blocked_by_request: false,
+      },
+      timeline: {
+        items: [
+          {
+            timeline_item_id: "evt_001",
+            thread_id: "thread_001",
+            turn_id: null,
+            item_id: null,
+            sequence: 1,
+            occurred_at: baseTimestamp,
+            kind: "message.assistant.completed",
+            payload: {
+              summary: "assistant completed",
+              content: "Primary thread is idle.",
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      },
+    },
+    thread_background: {
+      thread: {
+        thread_id: "thread_background",
+        workspace_id: "ws_alpha",
+        native_status: backgroundThread.native_status,
+        updated_at: backgroundThread.updated_at,
+      },
+      current_activity: backgroundThread.current_activity,
+      pending_request: {
+        request_id: "req_background",
+        thread_id: "thread_background",
+        turn_id: "turn_background",
+        item_id: "item_background",
+        request_kind: "approval",
+        status: "pending" as const,
+        risk_category: "external_side_effect" as const,
+        summary: "Deploy background fix",
+        requested_at: backgroundThread.updated_at,
+      },
+      latest_resolved_request: null,
+      composer: {
+        accepting_user_input: false,
+        interrupt_available: false,
+        blocked_by_request: true,
+      },
+      timeline: {
+        items: [
+          {
+            timeline_item_id: "evt_100",
+            thread_id: "thread_background",
+            turn_id: null,
+            item_id: null,
+            sequence: 1,
+            occurred_at: backgroundThread.updated_at,
+            kind: "approval.requested",
+            payload: {
+              summary: "Deploy background fix",
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      },
+    },
+  };
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const { pathname } = url;
+
+    if (pathname === "/api/v1/workspaces" && request.method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [workspace],
+          next_cursor: null,
+          has_more: false,
+        }),
+      });
+    }
+
+    if (pathname === "/api/v1/workspaces/ws_alpha/threads" && request.method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [primaryThread, backgroundThread],
+          next_cursor: null,
+          has_more: false,
+        }),
+      });
+    }
+
+    if (
+      (pathname === "/api/v1/threads/thread_001/view" ||
+        pathname === "/api/v1/threads/thread_background/view") &&
+      request.method() === "GET"
+    ) {
+      const threadId = pathname.includes("thread_background") ? "thread_background" : "thread_001";
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(threadViewById[threadId]),
+      });
+    }
+
+    if (pathname === "/api/v1/requests/req_background" && request.method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          request_id: "req_background",
+          thread_id: "thread_background",
+          turn_id: "turn_background",
+          item_id: "item_background",
+          request_kind: "approval",
+          status: "pending",
+          risk_category: "external_side_effect",
+          summary: "Deploy background fix",
+          reason: "The background deployment needs approval.",
+          operation_summary: "Deploy the prepared fix to staging.",
+          requested_at: backgroundThread.updated_at,
+          responded_at: null,
+          decision: null,
+          decision_options: {
+            policy_scope_supported: false,
+            default_policy_scope: "once",
+          },
+          context: {
+            environment: "staging",
+          },
+        }),
+      });
+    }
+
+    return route.abort();
+  });
+}
+
+test("returns to a high-priority background thread from the lightweight notification path on desktop and mobile", async ({
+  page,
+}, testInfo) => {
+  const isDesktop = testInfo.project.name === "desktop-chromium";
+
+  await stubEventSource(page);
+  await mockBackgroundPriorityFlow(page);
+
+  await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
+  await expect(page).toHaveURL(/\/chat\?workspaceId=ws_alpha&threadId=thread_001$/);
+  await expect(page.getByRole("heading", { name: "thread_001", exact: true })).toBeVisible();
+  await expect(page.getByText("Primary thread is idle.")).toBeVisible();
+
+  if (!isDesktop) {
+    await expect(page.getByRole("button", { name: "Threads", exact: true })).toBeVisible();
+  }
+
+  await emitNotificationEvent(page, {
+    thread_id: "thread_background",
+    event_type: "approval.requested",
+    occurred_at: "2026-04-24T03:11:00Z",
+    high_priority: true,
+  });
+
+  await expect(page.locator(".status-message")).toContainText(
+    "High-priority background thread needs attention.",
+  );
+  await expect(page.locator(".background-priority-notice")).toContainText(
+    "Background thread needs attention",
+  );
+  await expect(page.locator(".background-priority-notice")).toContainText("Reason: Needs response");
+
+  await page.getByRole("button", { name: "Open thread", exact: true }).click();
+
+  await expect(page).toHaveURL(/\/chat\?workspaceId=ws_alpha&threadId=thread_background$/);
+  await expect(page.getByRole("heading", { name: "thread_background", exact: true })).toBeVisible();
+  await expect(page.locator(".request-detail-card.pending-request-card")).toBeVisible();
+  await expect(page.locator(".request-detail-card.pending-request-card")).toContainText(
+    "Deploy background fix",
+  );
+  await expect(page.locator(".request-detail-card.pending-request-card")).toContainText(
+    "The background deployment needs approval.",
+  );
+  await expect(page.getByRole("button", { name: "Approve request", exact: true })).toBeVisible();
+  await expect(page.locator(".background-priority-notice")).toHaveCount(0);
+  await expect(page).not.toHaveURL(/\/approvals(\/|$)/);
+});

--- a/apps/frontend-bff/e2e/chat-flow.spec.ts
+++ b/apps/frontend-bff/e2e/chat-flow.spec.ts
@@ -6,13 +6,6 @@ import {
   installChatFlowDebugCapture,
 } from "./helpers/chat-flow-debug";
 
-async function sectionByHeading(page: Page, heading: string) {
-  return page
-    .locator("section")
-    .filter({ has: page.getByRole("heading", { name: heading, exact: true }) })
-    .first();
-}
-
 async function locatorBox(locator: ReturnType<Page["locator"]>) {
   await expect(locator).toBeVisible();
 
@@ -22,18 +15,14 @@ async function locatorBox(locator: ReturnType<Page["locator"]>) {
   return box!;
 }
 
-async function sectionBox(page: Page, heading: string) {
-  return locatorBox(await sectionByHeading(page, heading));
-}
-
 async function timelineBox(page: Page) {
   return locatorBox(page.getByRole("region", { name: "Timeline", exact: true }));
 }
 
-async function threadCards(page: Page, currentThreadHeading: string) {
+async function threadCards(page: Page) {
   return {
-    startCard: await sectionBox(page, "Start or resume a thread"),
-    currentCard: await sectionBox(page, currentThreadHeading),
+    navigationCard: await locatorBox(page.locator("section.thread-navigation")),
+    currentCard: await locatorBox(page.locator("section.thread-view-card")),
     timelineCard: await timelineBox(page),
   };
 }
@@ -43,20 +32,38 @@ async function openMobileThreadNavigation(page: Page, isDesktop: boolean) {
     return;
   }
 
-  await page.getByRole("button", { name: "Threads", exact: true }).click();
-  await expect(
-    page.getByRole("heading", { name: "Start or resume a thread", exact: true }),
-  ).toBeVisible();
+  const threadsButton = page.getByRole("button", { name: "Threads", exact: true });
+  if (await threadsButton.isVisible()) {
+    await threadsButton.click();
+  }
+  await expect(page.locator("section.thread-navigation")).toBeVisible();
+}
+
+async function startThreadFromComposer(page: Page, isDesktop: boolean, firstInput: string) {
+  const inputScope = isDesktop ? page : page.locator("section.thread-view-card");
+  const firstInputField = inputScope.getByLabel("Ask Codex");
+  const startThreadButton = inputScope.getByRole("button", { name: "Start thread", exact: true });
+
+  await firstInputField.fill(firstInput);
+  await expect(startThreadButton).toBeEnabled();
+
+  if (isDesktop) {
+    await startThreadButton.click();
+    await expect(page.getByText("Started thread thread_001.")).toBeVisible();
+    return;
+  }
+
+  await startThreadButton.click({ force: true });
 }
 
 function expectDesktopThreadLayoutStable(
   baseline: Awaited<ReturnType<typeof threadCards>>,
   current: Awaited<ReturnType<typeof threadCards>>,
 ) {
-  expect(current.startCard.x).toBeCloseTo(baseline.startCard.x, 0);
+  expect(current.navigationCard.x).toBeCloseTo(baseline.navigationCard.x, 0);
   expect(current.currentCard.x).toBeCloseTo(baseline.currentCard.x, 0);
   expect(current.timelineCard.x).toBeCloseTo(baseline.timelineCard.x, 0);
-  expect(current.currentCard.x).toBeGreaterThan(current.startCard.x + 20);
+  expect(current.currentCard.x).toBeGreaterThan(current.navigationCard.x + 20);
   expect(current.timelineCard.x).toBeGreaterThan(current.currentCard.x);
   expect(current.timelineCard.x).toBeLessThan(current.currentCard.x + current.currentCard.width);
   expect(current.timelineCard.y).toBeGreaterThan(current.currentCard.y + 20);
@@ -74,10 +81,7 @@ async function expectThreadRunning(page: Page, isDesktop: boolean) {
   }
 
   await expect(
-    page
-      .locator("section.chat-panel.workspace-card")
-      .filter({ has: page.getByText("Current thread", { exact: true }) })
-      .getByText("Running", { exact: true }),
+    page.locator("section.thread-view-card").getByText("Running", { exact: true }).first(),
   ).toBeVisible();
 }
 
@@ -91,43 +95,46 @@ test("runs the main thread flow from Home through interrupt on desktop and mobil
     await stubEventSource(page);
     await mockChatFlow(page);
 
-    await page.goto("/");
-    await expect(page.getByRole("heading", { name: "Home", exact: true })).toBeVisible();
+    await page.goto("/chat");
+    await expect(
+      page.getByRole("heading", { name: "Thread workspace", exact: true }),
+    ).toBeVisible();
     await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
 
-    await page.getByLabel("Workspace name").fill("alpha");
+    await openMobileThreadNavigation(page, isDesktop);
+    await page.locator("details.workspace-switcher summary").click();
+    await page.locator("#workspace-name").fill("alpha");
     await expect(page.getByRole("button", { name: "Create workspace" })).toBeEnabled();
     await page.getByRole("button", { name: "Create workspace" }).click();
-    await expect(page.getByText('Workspace "alpha" created.')).toBeVisible();
-
-    await page.locator(".home-primary-actions").getByRole("link", { name: "Ask Codex" }).click();
-    await expect(page).toHaveURL(/\/chat\?workspaceId=ws_alpha/);
-    await expect(page.getByRole("heading", { name: "Chat", exact: true })).toBeVisible();
+    await expect(page.getByText("Created workspace alpha.")).toBeVisible();
+    await expect(page).toHaveURL(/\/chat\?workspaceId=ws_alpha$/);
+    await expect(page.locator("header.chat-topbar h1")).toHaveText("alpha");
     await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
 
     let baselineLayout: Awaited<ReturnType<typeof threadCards>> | undefined;
     if (isDesktop) {
-      baselineLayout = await threadCards(page, "Select a thread");
+      baselineLayout = await threadCards(page);
+      await expect(page.getByRole("heading", { name: "New thread", exact: true })).toBeVisible();
     } else {
       await openMobileThreadNavigation(page, isDesktop);
-      await expect(
-        page.getByRole("heading", { name: "Select a thread", exact: true }),
-      ).toBeVisible();
+      await expect(page.locator("section.thread-navigation")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "New thread", exact: true })).toBeVisible();
       await expect(page.getByRole("region", { name: "Timeline", exact: true })).toBeVisible();
+      await page.getByRole("button", { name: "Close threads", exact: true }).click();
     }
 
-    await page.getByLabel("First input").fill("Fix build error");
-    await expect(page.getByRole("button", { name: "Start new thread" })).toBeEnabled();
-    await page.getByRole("button", { name: "Start new thread" }).click();
-    await expect(page.getByText("Started thread thread_001.")).toBeVisible();
+    await startThreadFromComposer(page, isDesktop, "Fix build error");
+    if (isDesktop) {
+      await expect(page.getByText("Started thread thread_001.")).toBeVisible();
+    }
     await expect(page.getByRole("heading", { name: "thread_001", exact: true })).toBeVisible();
     await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
     if (isDesktop) {
-      expectDesktopThreadLayoutStable(baselineLayout!, await threadCards(page, "thread_001"));
+      expectDesktopThreadLayoutStable(baselineLayout!, await threadCards(page));
     }
 
-    const sendReplyButton = page.getByRole("button", { name: "Send reply" });
-    await page.getByLabel("Send follow-up input").fill("Please explain the diff.");
+    const sendReplyButton = page.getByRole("button", { name: "Send input", exact: true });
+    await page.getByLabel("Send input").fill("Please explain the diff.");
     await expect(sendReplyButton).toBeEnabled();
     await sendReplyButton.click();
     await expect(page.getByText("Input accepted. Waiting for thread updates.")).toBeVisible();
@@ -135,13 +142,13 @@ test("runs the main thread flow from Home through interrupt on desktop and mobil
     await expect(page.getByRole("button", { name: "Interrupt thread" })).toBeEnabled();
     await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
     if (isDesktop) {
-      expectDesktopThreadLayoutStable(baselineLayout!, await threadCards(page, "thread_001"));
+      expectDesktopThreadLayoutStable(baselineLayout!, await threadCards(page));
     }
 
     await page.getByRole("button", { name: "Interrupt thread" }).click();
     await expect(page.getByText("Interrupt requested.")).toBeVisible();
     await expect(page.getByText("Thread interrupted.")).toBeVisible();
-    await page.getByLabel("Send follow-up input").fill("Resume after interrupt.");
+    await page.getByLabel("Send input").fill("Resume after interrupt.");
     await expect(sendReplyButton).toBeEnabled();
     await sendReplyButton.click();
     await expect(
@@ -149,7 +156,7 @@ test("runs the main thread flow from Home through interrupt on desktop and mobil
     ).toBeVisible();
     await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
     if (isDesktop) {
-      expectDesktopThreadLayoutStable(baselineLayout!, await threadCards(page, "thread_001"));
+      expectDesktopThreadLayoutStable(baselineLayout!, await threadCards(page));
     }
   } finally {
     await attachChatFlowDebugArtifacts(testInfo, debugSink, "chat-flow");

--- a/apps/frontend-bff/e2e/helpers/browser-mocks.ts
+++ b/apps/frontend-bff/e2e/helpers/browser-mocks.ts
@@ -205,6 +205,14 @@ export async function mockChatFlow(page: Page) {
       });
     }
 
+    if (pathname === "/api/v1/workspaces" && request.method() === "GET") {
+      return json(route, {
+        items: workspaceCreated ? [workspace] : [],
+        next_cursor: null,
+        has_more: false,
+      });
+    }
+
     if (pathname === "/api/v1/workspaces" && request.method() === "POST") {
       workspaceCreated = true;
       return json(route, workspace, 201);
@@ -561,6 +569,27 @@ export async function mockApprovalFlow(page: Page) {
                     priority_band: "medium" as const,
                     label: "Active now",
                   },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      });
+    }
+
+    if (pathname === "/api/v1/workspaces" && request.method() === "GET") {
+      return json(route, {
+        items: [
+          {
+            workspace_id: "ws_alpha",
+            workspace_name: "alpha",
+            created_at: "2026-04-05T02:20:00Z",
+            updated_at: resolution === "pending" ? requestedAt : resolvedAt,
+            active_session_summary: {
+              session_id: "thread_001",
+              status: resolution === "pending" ? "waiting_approval" : "running",
+              last_message_at: resolution === "pending" ? null : resolvedAt,
+            },
+            pending_approval_count: resolution === "pending" ? 1 : 0,
           },
         ],
         next_cursor: null,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Codex WebUI LLM Wiki Index
 
-Last updated: 2026-04-23
+Last updated: 2026-04-24
 
 ## Purpose
 
@@ -22,6 +22,7 @@ Read this file first when you need to locate maintained knowledge across source-
 - [docs/specs/codex_webui_public_api_v0_9.md](./specs/codex_webui_public_api_v0_9.md): maintained public API contract
 - [docs/specs/codex_webui_ui_layout_spec_v0_9.md](./specs/codex_webui_ui_layout_spec_v0_9.md): maintained thread-first desktop/mobile UI layout and interaction structure
 - [docs/validation/app_server_behavior_validation_plan_checklist.md](./validation/app_server_behavior_validation_plan_checklist.md): app-server behavior validation plan
+- [docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md](./validation/codex_webui_ux_renewal_validation_gates_v0_1.md): maintained UX renewal browser, regression, desktop-inspection, and mobile-reachability validation gates
 
 ## Maintained note pages
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,6 +1,6 @@
 # Codex WebUI LLM Wiki Log
 
-Last updated: 2026-04-23
+Last updated: 2026-04-24
 
 ## Purpose
 
@@ -28,6 +28,35 @@ After the heading, keep the body concise:
 - short note on what changed or remains deferred
 
 ## Entries
+
+## [2026-04-24] ingest | Issue #186 UX renewal validation gates
+
+Source:
+
+- approved sprint slice for Issue #186
+- `tasks/issue-186-validation-gates/README.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/e2e/chat-flow.spec.ts`
+- `apps/frontend-bff/e2e/approval-flow.spec.ts`
+- `apps/frontend-bff/tests/chat-page-client.test.tsx`
+- `apps/frontend-bff/tests/home-page-client.test.tsx`
+
+Updated:
+
+- `docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md`
+- `docs/index.md`
+- `docs/log.md`
+- `tasks/issue-186-validation-gates/README.md`
+
+Notes:
+
+- added a maintained validation source for UX renewal E2E gates, UX regression gates, desktop visual inspection expectations, mobile reachability checks, and a gate-to-evidence coverage map
+- kept roadmap, requirements, and UI/spec documents as the normative source instead of duplicating behavior contracts into the validation page
+- linked the maintained validation page into wiki navigation so later sessions can find the current browser and inspection gates directly
 
 ## [2026-04-23] ingest | Issue #180 contract audit
 

--- a/docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md
+++ b/docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md
@@ -1,0 +1,137 @@
+# Codex WebUI UX renewal validation gates v0.1
+
+## 1. Purpose
+
+This document defines the maintained validation gates for the v0.9 UX renewal.
+
+It is the source of truth for:
+
+- browser E2E gates that must pass before the UX renewal is judged complete
+- UX regression gates that protect the thread-first model from legacy surface regressions
+- desktop visual inspection expectations
+- mobile reachability checks
+- the current coverage map from maintained gates to automated and manual evidence
+
+This document does not replace the roadmap, requirements, or UI specification. It points validation back to those maintained sources.
+
+## 2. Governing sources
+
+Use these maintained documents as the normative source for what the UX renewal must satisfy:
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`, especially section `5.4 Phase 5: v0.9 validation, convergence, and MVP judgment`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+
+When this validation document and a normative source appear to disagree, treat this document as the execution and evidence layer and defer product behavior to the normative source.
+
+## 3. Gate families
+
+### 3.1 UX renewal E2E gates
+
+The browser suite must prove the thread-first v0.9 flow across desktop and mobile for:
+
+1. first-input thread start from workspace context
+2. existing-thread continuation
+3. pending request response inside thread context
+4. interrupt and return to normal sendability
+5. reconnect or stream reacquisition convergence
+6. background high-priority return using a lightweight notification path
+
+### 3.2 UX regression gates
+
+Validation must reject regressions that reintroduce legacy surface assumptions. At minimum, the browser and component/test evidence must continue to prove:
+
+- no required primary Home screen dependency for thread start, thread return, or approval response
+- no dedicated standalone approval screen or approval inbox as the required intervention path
+- no event-driven auto-open detail behavior for approval or background-priority events
+- pending request response remains thread-scoped
+- desktop and mobile both preserve a reachable return-to-thread path
+
+### 3.3 Desktop visual inspection gates
+
+Manual desktop inspection must confirm:
+
+- the desktop layout preserves the normative `[ Navigation ] [ Thread View ]` composition
+- thread context remains readable without route changes to legacy primary screens
+- high-priority background promotion is noticeable through lightweight UI such as the banner/notice, badges, or navigation summaries
+- the selected thread can be opened from the lightweight notification path and the user stays in `thread_view`
+- detail remains selection-driven rather than auto-opened by events
+- no horizontal overflow appears in the validated desktop flows
+
+### 3.4 Mobile reachability gates
+
+Manual and automated mobile validation must confirm:
+
+- the single-column `thread_view` remains usable at the mobile project width
+- navigation is reachable through the mobile thread drawer toggle
+- first-input start, thread continuation, request response, interrupt, and background return remain reachable without desktop-only assumptions
+- the background high-priority notice is visible in thread context without first opening Navigation
+- returning to the target thread from the notice does not require a standalone approval route or a dedicated approval page
+- no horizontal overflow appears in the validated mobile flows
+
+## 4. Required automated gates
+
+The current required automated gate set for `apps/frontend-bff` is:
+
+```bash
+npm run check
+node ./node_modules/typescript/bin/tsc --noEmit --pretty false
+npm test -- tests/chat-page-client.test.tsx tests/home-page-client.test.tsx
+npm run test:e2e -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts e2e/background-priority.spec.ts --project=desktop-chromium --reporter=line
+npm run test:e2e -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts e2e/background-priority.spec.ts --project=mobile-chromium --reporter=line
+```
+
+These commands are the bounded validation slice for the UX renewal gates in this work package. Broader build or redesign validation is out of scope for this document version.
+
+## 5. Coverage map
+
+| Gate | Normative source anchor | Current automated evidence | Current manual evidence |
+| --- | --- | --- | --- |
+| First-input thread start in workspace context | roadmap `5.4` item 4; UI layout spec section `13.4`; requirements thread-first/mobile start rules | `apps/frontend-bff/e2e/chat-flow.spec.ts`; `apps/frontend-bff/tests/chat-page-client.test.tsx` | desktop and mobile visual pass during targeted browser inspection |
+| Existing-thread continuation and normal composer flow | roadmap `5.4` item 4; UI layout spec section `13.3` and `13.4` | `apps/frontend-bff/e2e/chat-flow.spec.ts`; `apps/frontend-bff/tests/chat-page-client.test.tsx` | desktop and mobile visual pass during targeted browser inspection |
+| Pending request response inside thread context | roadmap `5.4` item 4; UI layout spec section `13.5`; requirements request-response rules | `apps/frontend-bff/e2e/approval-flow.spec.ts`; `apps/frontend-bff/tests/chat-page-client.test.tsx` | desktop and mobile request card/readability inspection |
+| Background high-priority return via lightweight notification | roadmap `5.3` items 7 and acceptance bullets; roadmap `5.4` item 6; UI layout spec sections `12` and `13.7` | `apps/frontend-bff/e2e/background-priority.spec.ts`; `apps/frontend-bff/tests/chat-page-client.test.tsx`; `apps/frontend-bff/tests/home-page-client.test.tsx` | desktop and mobile notice visibility plus return-path inspection |
+| No standalone approval screen required for background return | UI layout spec sections `3.3`, `5.5`, `12.3`, `13.5`, `13.11` | `apps/frontend-bff/e2e/background-priority.spec.ts`; `apps/frontend-bff/tests/routes.test.ts` retired approvals-route quarantine; `apps/frontend-bff/tests/chat-page-client.test.tsx` | browser review confirms the return path stays on `/chat` thread context |
+| Reconnect and state reacquisition convergence | roadmap `5.4` item 3 and item 4; UI layout spec section `13.9` | `apps/frontend-bff/tests/chat-page-client.test.tsx`; `apps/frontend-bff/tests/chat-send-recovery.test.ts` | deferred manual reconnect drill in a full-stack session when pre-push validation runs |
+| Desktop detail remains selection-driven | UI layout spec sections `11.3`, `11.4`, `13.6`, `13.7` | `apps/frontend-bff/tests/chat-page-client.test.tsx`; `apps/frontend-bff/tests/chat-view.test.tsx` | desktop visual inspection of request/background flows |
+| Mobile reachability for notification return and request response | roadmap `5.4` item 5; requirements mobile acceptance rules; UI layout spec sections `4.6`, `6`, `13.10` | `apps/frontend-bff/e2e/approval-flow.spec.ts`; `apps/frontend-bff/e2e/background-priority.spec.ts` | mobile visual inspection at Playwright mobile project width |
+
+## 6. Desktop visual inspection checklist
+
+Run desktop inspection against `desktop-chromium` using the validated thread-first flows.
+
+Confirm all of the following:
+
+1. Navigation remains visible as the left discovery surface.
+2. Thread View remains the primary center surface.
+3. Background high-priority promotion appears as a lightweight notice or equivalent signal without route replacement.
+4. Opening the promoted thread keeps the reviewer on `/chat` and lands on the target thread header and pending request state.
+5. No standalone approval route, approval inbox, or auto-open detail surface is required to complete the return.
+6. No horizontal overflow appears before or after the background return.
+
+## 7. Mobile inspection checklist
+
+Run mobile inspection against `mobile-chromium` using the validated thread-first flows.
+
+Confirm all of the following:
+
+1. The thread-first surface remains single-column and readable.
+2. The background high-priority notice is visible from thread context without opening the thread drawer first.
+3. The lightweight notice can open the target thread directly.
+4. The target thread shows pending request context in `thread_view` after the return.
+5. The flow remains on `/chat` and does not depend on a standalone approval route.
+6. No horizontal overflow appears in the validated flow.
+
+## 8. Current evidence status
+
+Current automated evidence for this document version is expected from:
+
+- `apps/frontend-bff/e2e/chat-flow.spec.ts`
+- `apps/frontend-bff/e2e/approval-flow.spec.ts`
+- `apps/frontend-bff/e2e/background-priority.spec.ts`
+- `apps/frontend-bff/tests/chat-page-client.test.tsx`
+- `apps/frontend-bff/tests/home-page-client.test.tsx`
+
+Current manual evidence remains targeted visual/browser inspection for desktop and mobile layouts. Record execution-specific command results and inspection notes in the active task package and artifacts, not by rewriting this maintained document.

--- a/tasks/archive/issue-186-validation-gates/README.md
+++ b/tasks/archive/issue-186-validation-gates/README.md
@@ -1,0 +1,78 @@
+# Issue 186 Validation Gates
+
+## Purpose
+
+- Define the maintained E2E and UX regression validation gates that prove the UX renewal is complete by behavior, not only by route or component presence.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/186
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`, section 5.4
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `tasks/archive/issue-168-legacy-surface-validation/README.md`
+
+## Scope for this package
+
+- Publish maintained validation docs for the UX renewal E2E flows and regression gates.
+- Align Playwright and supporting validation coverage with the maintained gate definitions where the current suite is incomplete or ambiguous.
+- Capture the evidence and handoff notes needed to close Issue #186 once the work reaches `main`.
+
+## Exit criteria
+
+- Maintained validation source-of-truth documents define the UX renewal E2E scenarios, regression checks, and desktop visual inspection expectations.
+- Repo validation coverage clearly maps to the maintained gate definitions for workspace selection, new-thread start, existing-thread continuation, approval response, streaming, reconnect convergence, and background priority return.
+- The package records the evidence and completion notes needed for pre-push validation, merge follow-through, and Issue close.
+
+## Work plan
+
+- Audit existing validation docs and Playwright coverage against Issue #186 scope.
+- Add or update maintained validation docs under `docs/validation/` for UX renewal E2E and regression gates.
+- Add or update focused tests and helpers under `apps/frontend-bff/` only where the maintained gates reveal concrete gaps.
+- Run local validation, then prepare for the dedicated pre-push validation gate.
+
+## Artifacts / evidence
+
+- Evidence:
+  - maintained validation source: `docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md`
+  - targeted browser coverage: `apps/frontend-bff/e2e/background-priority.spec.ts`
+  - local validation command summaries:
+    - `npm run check` passed
+    - `node ./node_modules/next/dist/bin/next typegen` passed
+    - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed
+    - `npm test -- tests/chat-page-client.test.tsx tests/home-page-client.test.tsx` passed with 17 tests
+    - `npm run test:e2e -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts e2e/background-priority.spec.ts --project=desktop-chromium --reporter=line` passed with 4 tests
+    - `npm run test:e2e -- e2e/chat-flow.spec.ts e2e/approval-flow.spec.ts e2e/background-priority.spec.ts --project=mobile-chromium --reporter=line` passed with 4 tests
+  - `artifacts/issue-186-validation-gates/` remains available for follow-up evidence capture if pre-push validation requests it
+
+## Status / handoff notes
+
+- Status: `locally complete; ready to archive after pre-push validation`
+- Active branch: `issue-186-validation-gates`
+- Active worktree: `.worktrees/issue-186-validation-gates`
+- Notes:
+  - Package created from the orchestration run for Issue #186 closure.
+  - Maintained UX renewal validation gates doc and focused background-priority Playwright coverage added in the active worktree.
+  - Scoped local validation is complete; dedicated pre-push validation is still required before archive, merge, or Issue close.
+  - `tsc --noEmit` required `next typegen` first because `tsconfig.json` includes `.next/types/**/*.ts`.
+  - No active PR yet.
+  - Completion retrospective:
+    - Completion boundary: package archive after sprint approval and dedicated pre-push validation.
+    - Contract check:
+      - Maintained validation source-of-truth document: Satisfied by `docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md`.
+      - Targeted automated validation coverage: Satisfied by `apps/frontend-bff/e2e/background-priority.spec.ts` plus aligned `chat-flow.spec.ts` and `approval-flow.spec.ts`.
+      - Local validation evidence: Satisfied by Biome, `tsc`, focused Vitest, and desktop/mobile Playwright runs recorded above.
+      - Issue close readiness: Not applicable at package-archive boundary; PR, merge-to-main, cleanup, and GitHub completion tracking remain pending.
+    - What worked: keeping the sprint scoped to one maintained validation doc plus one new E2E gate made the missing coverage easy to isolate.
+    - Workflow problems: worker result reporting was lost once, so the orchestrator had to recover from worktree state and rerun validation manually.
+    - Improvements to adopt: pre-push and sprint prompts for frontend E2E slices should explicitly mention that mobile/desktop locator drift may require aligning older specs before the new test can validate cleanly.
+    - Skill candidates or skill updates: consider tightening sprint worker prompts to require a final written validation summary before agent shutdown.
+    - Follow-up updates: archive this package, commit/push/open PR, merge to `main`, sync parent checkout, remove worktree, set Project item to `Done`, and close Issue #186.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate has passed, and the handoff notes are updated.


### PR DESCRIPTION
## Summary
- add a maintained UX renewal validation gates document and link it from docs navigation
- add focused Playwright coverage for background high-priority thread return and align existing chat/approval E2E coverage with the current UI
- archive the Issue #186 work package with validation evidence and retrospective notes

Closes #186