### PR TITLE
Expose public thread titles in frontend BFF

### DIFF
--- a/apps/frontend-bff/src/chat-data.ts
+++ b/apps/frontend-bff/src/chat-data.ts
@@ -28,7 +28,7 @@ async function readJson<T>(response: Response) {
 }
 
 export async function listWorkspaceThreads(workspaceId: string, fetchImpl: FetchLike = fetch) {
-  const response = await fetchImpl(`/api/v1/workspaces/${workspaceId}/threads?sort=-updated_at`, {
+  const response = await fetchImpl(`/api/v1/workspaces/${workspaceId}/threads?sort=recommended`, {
     cache: "no-store",
     headers: {
       accept: "application/json",

--- a/apps/frontend-bff/src/handlers.ts
+++ b/apps/frontend-bff/src/handlers.ts
@@ -353,7 +353,7 @@ export async function getHome(_request: Request) {
     const threadResults = await Promise.all(
       workspaceResult.body.items.map((workspace) =>
         runtimeClient.requestJson<ListResponse<RuntimeThreadSummary>>(
-          `/api/v1/workspaces/${workspace.workspace_id}/threads?sort=-updated_at`,
+          `/api/v1/workspaces/${workspace.workspace_id}/threads?sort=recommended`,
         ),
       ),
     );

--- a/apps/frontend-bff/src/mappings.ts
+++ b/apps/frontend-bff/src/mappings.ts
@@ -188,6 +188,7 @@ export function mapThread(thread: RuntimeThreadSummary) {
   return {
     thread_id: thread.thread_id,
     workspace_id: thread.workspace_id,
+    title: thread.title,
     native_status: thread.native_status,
     updated_at: thread.updated_at,
   };

--- a/apps/frontend-bff/src/thread-types.ts
+++ b/apps/frontend-bff/src/thread-types.ts
@@ -1,6 +1,7 @@
 export interface PublicThread {
   thread_id: string;
   workspace_id: string;
+  title: string;
   native_status: {
     thread_status: string;
     active_flags: string[];

--- a/apps/frontend-bff/tests/chat-data.test.ts
+++ b/apps/frontend-bff/tests/chat-data.test.ts
@@ -27,6 +27,7 @@ describe("chat data access", () => {
           {
             thread_id: "thread_001",
             workspace_id: "ws_alpha",
+            title: "Investigate build",
             native_status: {
               thread_status: "running",
               active_flags: [],
@@ -49,7 +50,7 @@ describe("chat data access", () => {
 
     const result = await listWorkspaceThreads("ws_alpha", fetchMock);
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/v1/workspaces/ws_alpha/threads?sort=-updated_at", {
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/workspaces/ws_alpha/threads?sort=recommended", {
       cache: "no-store",
       headers: {
         accept: "application/json",
@@ -72,6 +73,7 @@ describe("chat data access", () => {
             thread: {
               thread_id: "thread_002",
               workspace_id: "ws_alpha",
+              title: "Investigate build",
               native_status: {
                 thread_status: "running",
                 active_flags: [],
@@ -94,6 +96,7 @@ describe("chat data access", () => {
             thread: {
               thread_id: "thread_002",
               workspace_id: "ws_alpha",
+              title: "Investigate build",
               native_status: {
                 thread_status: "running",
                 active_flags: [],
@@ -131,6 +134,7 @@ describe("chat data access", () => {
           thread: {
             thread_id: "thread_001",
             workspace_id: "ws_alpha",
+            title: "Investigate build",
             native_status: {
               thread_status: "running",
               active_flags: ["waiting_on_request"],
@@ -267,6 +271,7 @@ describe("chat data access", () => {
           thread: {
             thread_id: "thread_001",
             workspace_id: "ws_alpha",
+            title: "Investigate build",
             native_status: {
               thread_status: "running",
               active_flags: [],
@@ -280,6 +285,7 @@ describe("chat data access", () => {
         jsonResponse({
           thread_id: "thread_001",
           workspace_id: "ws_alpha",
+          title: "Investigate build",
           native_status: {
             thread_status: "idle",
             active_flags: [],

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -66,6 +66,7 @@ function buildThreadListItem(overrides: Partial<PublicThreadListItem> = {}): Pub
   return {
     thread_id: "thread_001",
     workspace_id: "ws_alpha",
+    title: "Investigate build",
     native_status: {
       thread_status: "running",
       active_flags: ["waiting_on_request"],
@@ -100,6 +101,7 @@ function buildThreadView(overrides: Partial<PublicThreadView> = {}): PublicThrea
     thread: {
       thread_id: "thread_001",
       workspace_id: "ws_alpha",
+      title: "Investigate build",
       native_status: {
         thread_status: "running",
         active_flags: ["waiting_on_request"],
@@ -191,6 +193,7 @@ function buildAcceptedInputResponse(
     thread: {
       thread_id: "thread_001",
       workspace_id: "ws_alpha",
+      title: "Investigate build",
       native_status: {
         thread_status: "running",
         active_flags: ["waiting_on_request"],
@@ -312,6 +315,7 @@ describe("ChatPageClient", () => {
           thread: {
             thread_id: "thread_001",
             workspace_id: "ws_alpha",
+            title: "Investigate build",
             native_status: {
               thread_status: "waiting_input",
               active_flags: [],
@@ -441,6 +445,7 @@ describe("ChatPageClient", () => {
       thread: {
         thread_id: "thread_new",
         workspace_id: "ws_alpha",
+        title: "Start a new thread",
         native_status: {
           thread_status: "running",
           active_flags: ["turn_active"],
@@ -482,6 +487,7 @@ describe("ChatPageClient", () => {
       thread: {
         thread_id: "thread_new",
         workspace_id: "ws_alpha",
+        title: "Start a new thread",
         native_status: {
           thread_status: "waiting_input",
           active_flags: [],
@@ -523,6 +529,7 @@ describe("ChatPageClient", () => {
       thread: {
         thread_id: "thread_new",
         workspace_id: "ws_alpha",
+        title: "Start a new thread",
         native_status: {
           thread_status: "running",
           active_flags: ["turn_active"],
@@ -608,6 +615,7 @@ describe("ChatPageClient", () => {
         thread: {
           thread_id: "thread_new",
           workspace_id: "ws_alpha",
+          title: "Start a new thread",
           native_status: {
             thread_status: "running",
             active_flags: ["turn_active"],
@@ -637,6 +645,7 @@ describe("ChatPageClient", () => {
         thread: {
           thread_id: "thread_new",
           workspace_id: "ws_alpha",
+          title: "Start a new thread",
           native_status: {
             thread_status: "running",
             active_flags: ["turn_active"],
@@ -776,6 +785,7 @@ describe("ChatPageClient", () => {
         thread: {
           thread_id: "thread_created",
           workspace_id: "ws_created",
+          title: "Created workspace thread",
           native_status: {
             thread_status: "running",
             active_flags: ["turn_active"],
@@ -790,6 +800,7 @@ describe("ChatPageClient", () => {
         thread: {
           thread_id: "thread_created",
           workspace_id: "ws_created",
+          title: "Created workspace thread",
           native_status: {
             thread_status: "running",
             active_flags: ["turn_active"],
@@ -1201,6 +1212,7 @@ describe("ChatPageClient", () => {
           thread: {
             thread_id: "thread_background",
             workspace_id: "ws_alpha",
+            title: "Background work",
             native_status: {
               thread_status: "waiting_input",
               active_flags: ["waiting_on_request"],
@@ -1590,6 +1602,7 @@ describe("ChatPageClient", () => {
       thread: {
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "running",
           active_flags: [],
@@ -1612,6 +1625,7 @@ describe("ChatPageClient", () => {
       thread: {
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "waiting_input",
           active_flags: [],
@@ -1685,6 +1699,7 @@ describe("ChatPageClient", () => {
       thread: {
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "waiting_input",
           active_flags: [],
@@ -1707,6 +1722,7 @@ describe("ChatPageClient", () => {
       thread: {
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "running",
           active_flags: [],
@@ -1748,6 +1764,7 @@ describe("ChatPageClient", () => {
       thread: {
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "waiting_input",
           active_flags: [],

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -55,6 +55,7 @@ describe("ChatView", () => {
         threads={[
           {
             thread_id: "thread_approval",
+            title: "Approval thread",
             workspace_id: "ws_alpha",
             native_status: {
               thread_status: "running",
@@ -82,6 +83,7 @@ describe("ChatView", () => {
           },
           {
             thread_id: "thread_active",
+            title: "Active thread",
             workspace_id: "ws_alpha",
             native_status: {
               thread_status: "running",
@@ -99,6 +101,7 @@ describe("ChatView", () => {
           },
           {
             thread_id: "thread_recent",
+            title: "Recent thread",
             workspace_id: "ws_alpha",
             native_status: {
               thread_status: "waiting_input",
@@ -215,6 +218,7 @@ describe("ChatView", () => {
         selectedThreadView={{
           thread: {
             thread_id: "thread_001",
+            title: "Approval thread",
             workspace_id: "ws_alpha",
             native_status: {
               thread_status: "running",
@@ -292,6 +296,7 @@ describe("ChatView", () => {
         threads={[
           {
             thread_id: "thread_001",
+            title: "Approval thread",
             workspace_id: "ws_alpha",
             native_status: {
               thread_status: "running",
@@ -443,6 +448,7 @@ describe("ChatView", () => {
         selectedThreadView={{
           thread: {
             thread_id: "thread_001",
+            title: "Resolved request thread",
             workspace_id: "ws_alpha",
             native_status: {
               thread_status: "waiting_input",
@@ -573,6 +579,7 @@ describe("ChatView", () => {
         selectedThreadView={{
           thread: {
             thread_id: "thread_001",
+            title: "Failed thread",
             workspace_id: "ws_alpha",
             native_status: {
               thread_status: "idle",

--- a/apps/frontend-bff/tests/home-page-client.test.tsx
+++ b/apps/frontend-bff/tests/home-page-client.test.tsx
@@ -105,6 +105,7 @@ describe("HomePageClient", () => {
         resume_candidates: [
           {
             thread_id: "thread_approval",
+            title: "Approval thread",
             workspace_id: "ws_alpha",
             native_status: {
               thread_status: "running",
@@ -185,6 +186,7 @@ describe("HomePageClient", () => {
         resume_candidates: [
           {
             thread_id: "thread_beta",
+            title: "Beta failed thread",
             workspace_id: "ws_beta",
             native_status: {
               thread_status: "idle",

--- a/apps/frontend-bff/tests/home-view.test.tsx
+++ b/apps/frontend-bff/tests/home-view.test.tsx
@@ -51,6 +51,7 @@ describe("HomeView", () => {
           resume_candidates: [
             {
               thread_id: "thread_approval",
+              title: "Approval thread",
               workspace_id: "ws_alpha",
               native_status: {
                 thread_status: "running",
@@ -78,6 +79,7 @@ describe("HomeView", () => {
             },
             {
               thread_id: "thread_failed",
+              title: "Failed thread",
               workspace_id: "ws_beta",
               native_status: {
                 thread_status: "idle",

--- a/apps/frontend-bff/tests/routes.test.ts
+++ b/apps/frontend-bff/tests/routes.test.ts
@@ -230,7 +230,7 @@ describe("frontend-bff route handlers", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "http://127.0.0.1:3001/api/v1/workspaces/ws_alpha/threads?sort=-updated_at",
+      "http://127.0.0.1:3001/api/v1/workspaces/ws_alpha/threads?sort=recommended",
       expect.objectContaining({
         cache: "no-store",
       }),
@@ -255,6 +255,7 @@ describe("frontend-bff route handlers", () => {
         {
           thread_id: "thread_approval",
           workspace_id: "ws_alpha",
+          title: "Needs approval",
           native_status: {
             thread_status: "running",
             active_flags: ["waiting_on_request"],
@@ -282,6 +283,7 @@ describe("frontend-bff route handlers", () => {
         {
           thread_id: "thread_failed",
           workspace_id: "ws_alpha",
+          title: "Failed turn",
           native_status: {
             thread_status: "idle",
             active_flags: [],
@@ -309,6 +311,7 @@ describe("frontend-bff route handlers", () => {
         {
           thread_id: "thread_active",
           workspace_id: "ws_alpha",
+          title: "Still running",
           native_status: {
             thread_status: "running",
             active_flags: [],
@@ -421,6 +424,7 @@ describe("frontend-bff route handlers", () => {
         {
           thread_id: "thread_001",
           workspace_id: "ws_alpha",
+          title: "Investigate build",
           native_status: {
             thread_status: "running",
             active_flags: ["waiting_on_request"],
@@ -488,6 +492,7 @@ describe("frontend-bff route handlers", () => {
     expect(await response.json()).toEqual({
       thread_id: "thread_001",
       workspace_id: "ws_alpha",
+      title: "Investigate build",
       native_status: {
         thread_status: "idle",
         active_flags: [],
@@ -555,6 +560,7 @@ describe("frontend-bff route handlers", () => {
       thread: {
         thread_id: "thread_002",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "running",
           active_flags: [],
@@ -631,6 +637,7 @@ describe("frontend-bff route handlers", () => {
       thread: {
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "running",
           active_flags: [],
@@ -683,6 +690,7 @@ describe("frontend-bff route handlers", () => {
     expect(await response.json()).toEqual({
       thread_id: "thread_001",
       workspace_id: "ws_alpha",
+      title: "Investigate build",
       native_status: {
         thread_status: "idle",
         active_flags: [],
@@ -764,6 +772,7 @@ describe("frontend-bff route handlers", () => {
       thread: {
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "running",
           active_flags: [],
@@ -927,6 +936,7 @@ describe("frontend-bff route handlers", () => {
       thread: {
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
+        title: "Investigate build",
         native_status: {
           thread_status: "idle",
           active_flags: [],

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-199-bff-title-helpers](./archive/issue-199-bff-title-helpers/README.md)
 - [issue-198-ux-source-boundaries](./archive/issue-198-ux-source-boundaries/README.md)
 - [issue-183-timeline-grouping](./archive/issue-183-timeline-grouping/README.md)
 - [issue-182-thread-view-composer](./archive/issue-182-thread-view-composer/README.md)

--- a/tasks/archive/issue-199-bff-title-helpers/README.md
+++ b/tasks/archive/issue-199-bff-title-helpers/README.md
@@ -1,0 +1,63 @@
+# Issue #199 BFF Title Helpers
+
+## Purpose
+
+- Expose the minimum public BFF title and helper fields needed by the UX refresh without inventing a new canonical resource model.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/199
+
+## Source docs
+
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/notes/codex_webui_ux_refresh_execution_order_synthesis_note_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Align `frontend-bff` public thread, thread-list, and thread-view shaping with the maintained `title` contract.
+- Expose the minimum helper material needed for Navigation row summaries and request/detail affordances.
+- Keep request/detail shaping aligned with the maintained P0 minimum confirmation information.
+- Preserve recovery-safe handling for pending and just-resolved request detail reachability.
+
+## Exit criteria
+
+- Public BFF thread shapes expose `title` consistently for thread list rows and thread header data.
+- Public BFF thread-list behavior is aligned with the maintained `recommended` default sort contract where this slice touches it.
+- Request helper mapping still exposes P0 confirmation fields and just-resolved reachability material without requiring richer file/diff detail.
+- Targeted `frontend-bff` validation passes.
+
+## Work plan
+
+- Inspect current `frontend-bff` runtime/public types, mapping functions, handlers, and tests.
+- Patch the smallest BFF surface needed for Issue #199.
+- Add or update focused tests for title/helper shaping and recommended sort behavior.
+- Run targeted app validation from `apps/frontend-bff`.
+- Record evidence and handoff notes before pre-push validation.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-25T05-41-06Z-issues-198-205/events.ndjson`
+- Sprint validation evidence from `apps/frontend-bff`:
+  - `npm run check`: passed, Biome checked 72 files with no fixes.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm test -- tests/routes.test.ts tests/chat-data.test.ts`: passed, 2 files / 23 tests.
+  - `npm test`: passed, 11 files / 68 tests.
+- Sprint evaluator: approved.
+- Dedicated pre-push validation: passed with the same command set.
+
+## Status / handoff notes
+
+- Status: `locally complete; archived before PR follow-through`
+- Active branch: `issue-199-bff-title-helpers`
+- Active worktree: `.worktrees/issue-199-bff-title-helpers`
+- Notes: `PublicThread.title` now flows through the shared BFF mapper for thread list rows, thread snapshots, thread view payloads, accepted-input results, interrupt results, and request-response thread payloads. Home workspace thread fan-out and chat workspace-thread discovery now request `sort=recommended` instead of `sort=-updated_at`.
+- Validation: `npm run check`; `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`; `npm test -- tests/routes.test.ts tests/chat-data.test.ts`; `npm test`.
+- Completion retrospective: package archive boundary only. Contract checks are satisfied for the local #199 slice by mapper/type changes, recommended-sort callsite updates, unchanged request-helper scope, evaluator approval, and pre-push validation. The earlier handoff stalled on mechanical typed fixtures after `PublicThread.title` became required; closing completed subagents promptly and rerunning the gate kept the recovery bounded. No repo skill or maintained docs update is needed from this slice.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary
- expose `title` on public BFF thread shapes through the shared mapper
- request `sort=recommended` for touched home/chat thread-list discovery paths
- archive the issue #199 task package after evaluator and pre-push validation

Closes #199

## Validation
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- tests/routes.test.ts tests/chat-data.test.ts`
- `npm test`
- archive-inclusive validator gate: `git diff --check`, same frontend-bff command set
