### PR TITLE
Use user-facing timeline labels

### DIFF
--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -249,7 +249,7 @@ export function ChatView({
   const composerGuidance = !workspaceId
     ? "Select or create a workspace from Navigation before starting work."
     : isOpeningSelectedThread
-      ? "Opening the selected thread before accepting input."
+      ? "Opening this thread and restoring its latest context."
       : unavailableReason;
   const selectedTimelineItem =
     detailSelection?.kind === "timeline_item_detail"
@@ -615,7 +615,11 @@ export function ChatView({
             </header>
 
             {isLoadingThread ? (
-              <p className="workspace-status">Refreshing thread detail...</p>
+              <p className="workspace-status">
+                {selectedThreadId
+                  ? "Opening this thread and restoring its latest timeline..."
+                  : "Preparing thread view..."}
+              </p>
             ) : null}
 
             <div className="chat-message-list">

--- a/apps/frontend-bff/src/timeline-display-model.ts
+++ b/apps/frontend-bff/src/timeline-display-model.ts
@@ -33,6 +33,46 @@ function asNonEmptyString(value: unknown) {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function timelineDisplayLabel(kind: string, isLive = false) {
+  if (kind.startsWith("message.user")) {
+    return "You";
+  }
+
+  if (kind.startsWith("message.assistant")) {
+    return isLive ? "Codex is responding" : "Codex";
+  }
+
+  if (kind.includes("approval") || kind.includes("request")) {
+    if (kind.includes("resolved") || kind.includes("responded")) {
+      return "Request resolved";
+    }
+
+    return "Request needs attention";
+  }
+
+  if (kind.includes("error")) {
+    return "System error";
+  }
+
+  if (kind.includes("failed")) {
+    return "Turn failed";
+  }
+
+  if (kind.includes("file")) {
+    return "File update";
+  }
+
+  if (kind.includes("status")) {
+    return "Status update";
+  }
+
+  if (kind.includes("tool") || kind.includes("command")) {
+    return "Tool activity";
+  }
+
+  return "Thread update";
+}
+
 function payloadText(payload: Record<string, unknown>) {
   return (
     asNonEmptyString(payload.content) ??
@@ -177,7 +217,7 @@ export function buildTimelineDisplayModel({
       turnId: item.turn_id,
       sequence: item.sequence,
       occurredAt: item.occurred_at,
-      label: item.kind,
+      label: timelineDisplayLabel(item.kind),
       content,
       density: classifyTimelineDensity(item.kind),
       role: timelineRole(item),
@@ -260,7 +300,7 @@ export function buildTimelineDisplayModel({
       turnId: group.turnId,
       sequence: group.completedSequence ?? group.firstSequence,
       occurredAt: group.completedAt ?? group.occurredAt,
-      label: isCompleted ? "message.assistant.completed" : "assistant streaming",
+      label: timelineDisplayLabel("message.assistant.completed", !isCompleted),
       content: isCompleted ? content : `${content}...`,
       density: "primary",
       role: "assistant",
@@ -279,7 +319,7 @@ export function buildTimelineDisplayModel({
       turnId: null,
       sequence: Number.MAX_SAFE_INTEGER,
       occurredAt: null,
-      label: "assistant streaming",
+      label: timelineDisplayLabel("message.assistant.delta", true),
       content: `${content}...`,
       density: "primary",
       role: "assistant",
@@ -305,7 +345,7 @@ export function buildTimelineDisplayModel({
       turnId: payloadTurnId(event.payload),
       sequence: event.sequence,
       occurredAt: event.occurred_at,
-      label: event.event_type,
+      label: timelineDisplayLabel(event.event_type),
       content: streamEventContent(event),
       density: classifyTimelineDensity(event.event_type),
       role: eventRole(event),

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -342,10 +342,12 @@ describe("ChatView", () => {
     expect(markup).toContain("Interrupt thread");
     expect(markup).toContain("Please explain the diff.");
     expect(markup).toContain("Streaming update");
-    expect(markup).toContain("approval.requested");
+    expect(markup).toContain("Request needs attention");
     expect(markup).toContain("timeline-row-prominent");
-    expect(markup).toContain("session.status_changed");
+    expect(markup).toContain("Status update");
     expect(markup).toContain("timeline-row-compact");
+    expect(markup).not.toContain("approval.requested");
+    expect(markup).not.toContain("session.status_changed");
     expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
     expect(markup).toContain('id="thread-composer-input"');
     expect(markup).not.toContain('id="thread-input"');

--- a/apps/frontend-bff/tests/timeline-display-model.test.ts
+++ b/apps/frontend-bff/tests/timeline-display-model.test.ts
@@ -65,7 +65,7 @@ describe("timeline display model", () => {
     const modelRows = rows(model);
     expect(modelRows).toHaveLength(1);
     expect(modelRows[0]).toMatchObject({
-      label: "assistant streaming",
+      label: "Codex is responding",
       content: "Hi there...",
       density: "primary",
       role: "assistant",
@@ -103,7 +103,7 @@ describe("timeline display model", () => {
     });
     expect(rows(beforeRest)).toHaveLength(1);
     expect(rows(beforeRest)[0]).toMatchObject({
-      label: "message.assistant.completed",
+      label: "Codex",
       content: "Final answer.",
       isLive: false,
     });
@@ -210,10 +210,48 @@ describe("timeline display model", () => {
     expect(rows(model)).toEqual([
       expect.objectContaining({
         id: "stream:status_001",
-        label: "session.status_changed",
+        label: "Status update",
         content: "Running tool",
         density: "compact",
       }),
+    ]);
+  });
+
+  it("uses user-facing labels instead of raw event or item kinds in primary timeline rows", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "user_001",
+          kind: "message.user",
+          payload: {
+            content: "Run the checks.",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "request_001",
+          sequence: 2,
+          kind: "approval.requested",
+          payload: {
+            summary: "Approve git push",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "failure_001",
+          sequence: 3,
+          kind: "turn.failed",
+          payload: {
+            summary: "Command failed",
+          },
+        }),
+      ],
+      streamEvents: [],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model).map((row) => row.label)).toEqual([
+      "You",
+      "Request needs attention",
+      "Turn failed",
     ]);
   });
 });

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-200-timeline-thread-view](./archive/issue-200-timeline-thread-view/README.md)
 - [issue-199-bff-title-helpers](./archive/issue-199-bff-title-helpers/README.md)
 - [issue-198-ux-source-boundaries](./archive/issue-198-ux-source-boundaries/README.md)
 - [issue-183-timeline-grouping](./archive/issue-183-timeline-grouping/README.md)

--- a/tasks/archive/issue-200-timeline-thread-view/README.md
+++ b/tasks/archive/issue-200-timeline-thread-view/README.md
@@ -1,0 +1,61 @@
+# Issue #200 Timeline Thread View
+
+## Purpose
+
+- Refresh timeline rendering and opening/recovery states so the browser reads as a user-facing thread chronology rather than a raw event viewer.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/200
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `.tmp/codex_webui_v0_9_ux_improvement_plan.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Merge assistant deltas into stable visible assistant messages where the existing display model has enough information.
+- Remove raw event labels and raw IDs from primary timeline presentation.
+- Treat not-loaded, opening, retry, and temporary unavailable states inside `thread_view`.
+- Keep recovery and background-priority behavior selection-driven rather than auto-opening detail.
+- Align current activity copy with user-facing work summaries and recovery actions.
+
+## Exit criteria
+
+- Timeline reads as thread chronology rather than raw event log.
+- Opening and recovery states stay in `thread_view` and do not become standalone primary screens.
+- Assistant streaming converges without duplicate or per-delta card rendering.
+- Targeted frontend-bff validation passes.
+
+## Work plan
+
+- Inspect `chat-view`, timeline display model, tests, and UI layout spec.
+- Patch the smallest UI/model surface needed for Issue #200.
+- Add or update focused tests for timeline grouping and opening/recovery display behavior.
+- Run frontend-bff validation and record evidence.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-25T05-41-06Z-issues-198-205/events.ndjson`
+- Sprint and pre-push validation from `apps/frontend-bff`:
+  - `git diff --check`: passed in the pre-push gate.
+  - `npm run check`: passed, Biome checked 72 files with no fixes.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm test -- tests/timeline-display-model.test.ts tests/chat-view.test.tsx`: passed, 2 files / 12 tests.
+  - `npm test`: passed, 11 files / 69 tests.
+- Sprint evaluator: approved.
+- Dedicated pre-push validation: passed.
+
+## Status / handoff notes
+
+- Status: `locally complete; archived before PR follow-through`
+- Active branch: `issue-200-timeline-thread-view`
+- Active worktree: `.worktrees/issue-200-timeline-thread-view`
+- Notes: Timeline display rows now use user-facing labels instead of raw event or item kind labels. Assistant streaming merge/completion/REST convergence behavior remains covered. Selected-thread opening/loading copy stays inside Thread View and describes restoring timeline context rather than exposing internal recovery states.
+- Completion retrospective: package archive boundary only. Contract checks are satisfied for the local #200 slice by user-facing timeline labels, preserved assistant convergence tests, opening-state copy inside Thread View, evaluator approval, and pre-push validation. No durable workflow or skill update is needed from this slice.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary
- use user-facing timeline row labels instead of raw event/item kind labels
- keep assistant streaming merge, completion replacement, and REST convergence coverage intact
- keep selected-thread opening/recovery copy inside Thread View
- archive the issue #200 task package after evaluator and pre-push validation

Closes #200

## Validation
- `git diff --check`
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- tests/timeline-display-model.test.ts tests/chat-view.test.tsx`
- `npm test`
