### PR TITLE
Show thread titles in navigation

### DIFF
--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -426,7 +426,7 @@ export function ChatView({
                         {thread.current_activity.label}
                       </span>
                     </div>
-                    <strong>{thread.thread_id}</strong>
+                    <strong>{thread.title}</strong>
                     {thread.badge ? (
                       <span className="workspace-meta">
                         {formatMachineLabel(thread.badge.label)}
@@ -440,6 +440,7 @@ export function ChatView({
                     <span className="workspace-meta">
                       Updated {formatTimestamp(thread.updated_at)}
                     </span>
+                    <span className="workspace-meta">Thread ref: {thread.thread_id}</span>
                     {thread.resume_cue ? (
                       <span className="workspace-meta">
                         {formatMachineLabel(thread.resume_cue.label)}

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -156,6 +156,10 @@ describe("ChatView", () => {
     expect(markup).toContain("Attention needed");
     expect(markup).toContain("Active");
     expect(markup).toContain("Recent");
+    expect(markup).toContain("Approval thread");
+    expect(markup).toContain("Active thread");
+    expect(markup).toContain("Recent thread");
+    expect(markup).toContain("Thread ref: thread_approval");
     expect(markup).toContain("Blocked: Needs response");
     expect(markup).toContain("Resume here first");
     expect(markup).toContain("Recently updated");

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-201-navigation-thread-identity](./archive/issue-201-navigation-thread-identity/README.md)
 - [issue-200-timeline-thread-view](./archive/issue-200-timeline-thread-view/README.md)
 - [issue-199-bff-title-helpers](./archive/issue-199-bff-title-helpers/README.md)
 - [issue-198-ux-source-boundaries](./archive/issue-198-ux-source-boundaries/README.md)

--- a/tasks/archive/issue-201-navigation-thread-identity/README.md
+++ b/tasks/archive/issue-201-navigation-thread-identity/README.md
@@ -1,0 +1,59 @@
+# Issue #201 Navigation Thread Identity
+
+## Purpose
+
+- Refresh Navigation and thread identity so users can discover, resume, and prioritize work without relying on Home or raw IDs.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/201
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `.tmp/codex_webui_v0_9_ux_improvement_plan.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Redesign thread rows around title, current activity summary, updated time, and badges within the existing Navigation component.
+- Keep workspace switching visible but secondary to current-workspace thread discovery.
+- Avoid raw thread IDs as the dominant thread-list label.
+
+## Exit criteria
+
+- Navigation is the primary return and discovery surface for the refreshed UX.
+- Raw thread IDs are no longer the dominant thread-list label.
+- Approval, error, failed, active, and recent signals remain distinguishable from the list.
+- Targeted frontend-bff validation passes.
+
+## Work plan
+
+- Inspect Navigation rendering and tests.
+- Patch thread row markup/copy with the smallest UI change.
+- Add or update tests for title-first thread identity and signal visibility.
+- Run frontend-bff validation and record evidence.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-25T05-41-06Z-issues-198-205/events.ndjson`
+- Validation:
+  - `git diff --check`: passed.
+  - `npm run check`: passed, Biome checked 72 files with no fixes.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm test -- tests/chat-view.test.tsx`: passed, 1 file / 6 tests.
+  - `npm test`: passed, 11 files / 69 tests.
+- Sprint evaluator: approved.
+- Dedicated pre-push validation: passed.
+
+## Status / handoff notes
+
+- Status: `locally complete; archived before PR follow-through`
+- Active branch: `issue-201-navigation-thread-identity`
+- Active worktree: `.worktrees/issue-201-navigation-thread-identity`
+- Notes: Navigation thread rows now use `thread.title` as the primary row identity and demote raw thread IDs to supporting `Thread ref` metadata while preserving attention, active, recent, blocked, resume, and updated signals.
+- Completion retrospective: package archive boundary only. Contract checks are satisfied for the local #201 slice by title-first Navigation row rendering, retained priority/cue signals, evaluator approval, and pre-push validation. No durable workflow or skill update is needed from this slice.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary
- render thread title as the primary Navigation row identity
- demote raw thread ID to supporting `Thread ref` metadata
- preserve attention, active, recent, blocked, resume, and updated row signals
- archive the issue #201 task package after evaluator and pre-push validation

Closes #201

## Validation
- `git diff --check`
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- tests/chat-view.test.tsx`
- `npm test`
