### PR TITLE
Strengthen thread surface context

### DIFF
--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -182,6 +182,32 @@ function composerUnavailableReason(threadView: PublicThreadView | null) {
   return null;
 }
 
+function currentActivitySummary(
+  threadView: PublicThreadView | null,
+  isOpeningSelectedThread: boolean,
+) {
+  if (!threadView) {
+    return isOpeningSelectedThread
+      ? "Opening this thread and restoring its latest context."
+      : "First input will create a new thread in this workspace.";
+  }
+
+  switch (threadView.current_activity.kind) {
+    case "waiting_on_approval":
+      return "Codex is paused until you approve or deny the request below.";
+    case "running":
+      return "Codex is working in this thread; watch the timeline for progress.";
+    case "waiting_on_user_input":
+      return "This thread is ready for your next input.";
+    case "system_error":
+      return "A system error needs review before this thread can continue.";
+    case "latest_turn_failed":
+      return "The latest turn failed; review the timeline or detail before retrying.";
+    default:
+      return formatMachineLabel(threadView.current_activity.kind);
+  }
+}
+
 export function ChatView({
   workspaceId,
   workspaces,
@@ -468,7 +494,7 @@ export function ChatView({
               ) : null}
             </div>
             <h2>
-              {selectedThreadView?.thread.thread_id ??
+              {selectedThreadView?.thread.title ??
                 (isOpeningSelectedThread
                   ? "Opening thread"
                   : workspaceId
@@ -477,7 +503,9 @@ export function ChatView({
             </h2>
             <p className="workspace-meta">
               {selectedThreadView
-                ? `Updated ${formatTimestamp(selectedThreadView.thread.updated_at)}`
+                ? `Workspace ${selectedThreadView.thread.workspace_id} - Updated ${formatTimestamp(
+                    selectedThreadView.thread.updated_at,
+                  )}`
                 : isOpeningSelectedThread
                   ? `Loading ${selectedThreadId}.`
                   : workspaceId
@@ -519,13 +547,9 @@ export function ChatView({
               </span>
             </div>
             <p className="workspace-meta">
-              {selectedThreadView
-                ? formatMachineLabel(selectedThreadView.current_activity.kind)
-                : isOpeningSelectedThread
-                  ? "Thread details are loading."
-                  : workspaceId
-                    ? "First input will create a new thread in this workspace."
-                    : "Choose a workspace to enable the composer."}
+              {workspaceId
+                ? currentActivitySummary(selectedThreadView, isOpeningSelectedThread)
+                : "Choose a workspace to enable the composer."}
             </p>
           </div>
 
@@ -540,6 +564,11 @@ export function ChatView({
               <p>{selectedThreadView.pending_request.summary}</p>
               {selectedRequestDetail ? (
                 <p className="workspace-meta">{selectedRequestDetail.reason}</p>
+              ) : null}
+              {selectedRequestDetail?.operation_summary ? (
+                <p className="workspace-meta">
+                  Operation: {selectedRequestDetail.operation_summary}
+                </p>
               ) : null}
               <p className="workspace-meta">
                 Requested {formatTimestamp(selectedThreadView.pending_request.requested_at)}

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -960,7 +960,7 @@ describe("ChatPageClient", () => {
 
     expect(container.textContent).toContain("Run git push");
     expect(container.textContent).toContain("Codex requests permission to push changes to remote.");
-    expect(container.textContent).not.toContain("Operation: git push origin main");
+    expect(container.textContent).toContain("Operation: git push origin main");
 
     const requestDetailButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Request detail",

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -339,10 +339,13 @@ describe("ChatView", () => {
       />,
     );
 
-    expect(markup).toContain("thread_001");
+    expect(markup).toContain("Approval thread");
+    expect(markup).toContain("Workspace ws_alpha");
     expect(markup).toContain("Approval required");
+    expect(markup).toContain("Codex is paused until you approve or deny the request below.");
     expect(markup).toContain("Approve request");
     expect(markup).toContain("Input is paused while this thread waits for your approval response.");
+    expect(markup).toContain("Operation: git push origin main");
     expect(markup).toContain("Interrupt thread");
     expect(markup).toContain("Please explain the diff.");
     expect(markup).toContain("Streaming update");

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-202-thread-surface-detail](./archive/issue-202-thread-surface-detail/README.md)
 - [issue-201-navigation-thread-identity](./archive/issue-201-navigation-thread-identity/README.md)
 - [issue-200-timeline-thread-view](./archive/issue-200-timeline-thread-view/README.md)
 - [issue-199-bff-title-helpers](./archive/issue-199-bff-title-helpers/README.md)

--- a/tasks/archive/issue-202-thread-surface-detail/README.md
+++ b/tasks/archive/issue-202-thread-surface-detail/README.md
@@ -1,0 +1,61 @@
+# Issue #202 Thread Surface Detail
+
+## Purpose
+
+- Strengthen the main thread surface so current activity, request summary, detail inspection, and composer priority work coherently in thread context.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/202
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `.tmp/codex_webui_v0_9_ux_improvement_plan.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Redesign the thread header around selected-thread title and workspace context.
+- Rework current activity copy into user-facing summaries.
+- Strengthen pending-request and resolved-request cards using guaranteed minimum confirmation information.
+- Keep detail surface selection-driven for request and timeline detail.
+
+## Exit criteria
+
+- The selected thread is the main subject of the center pane.
+- Approval can be noticed, inspected, and answered from thread context.
+- Detail surface remains useful for inspection without becoming the only place where important states are discoverable.
+- Targeted frontend-bff validation passes.
+
+## Work plan
+
+- Inspect ChatView thread header, current activity, request cards, and tests.
+- Patch the smallest UI surface needed for Issue #202.
+- Add or update focused tests for selected-thread title, user-facing activity, and request card/detail affordances.
+- Run frontend-bff validation and record evidence.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-25T05-41-06Z-issues-198-205/events.ndjson`
+- Validation:
+  - `git diff --check`: passed.
+  - `npm run check`: passed, Biome checked 72 files with no fixes.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm test -- tests/chat-view.test.tsx tests/chat-page-client.test.tsx`: passed, 2 files / 20 tests.
+  - `npm test`: passed, 11 files / 69 tests.
+- Sprint evaluator: approved.
+- Dedicated pre-push validation: passed.
+
+## Status / handoff notes
+
+- Status: `locally complete; archived before PR follow-through`
+- Active branch: `issue-202-thread-surface-detail`
+- Active worktree: `.worktrees/issue-202-thread-surface-detail`
+- Notes: Thread View now uses the selected thread title as the center-pane subject, keeps workspace/update context visible, maps current activity into user-facing recovery/action summaries, and surfaces request operation summary on the pending request card when request detail is available. Request detail remains selection-driven.
+- Completion retrospective: package archive boundary only. Contract checks are satisfied for the local #202 slice by title-centered header, activity summaries, strengthened request card, unchanged selection-driven detail behavior, evaluator approval, and pre-push validation. No durable workflow or skill update is needed from this slice.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary
- use selected thread title as the Thread View subject with workspace/update context
- map current activity to user-facing summaries
- surface request operation summary in the pending request card while keeping detail selection-driven
- archive the issue #202 task package after evaluator and pre-push validation

Closes #202

## Validation
- `git diff --check`
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- tests/chat-view.test.tsx tests/chat-page-client.test.tsx`
- `npm test`
