### PR TITLE
Cover UX recovery regressions

### DIFF
--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -961,6 +961,10 @@ describe("ChatPageClient", () => {
     expect(container.textContent).toContain("Run git push");
     expect(container.textContent).toContain("Codex requests permission to push changes to remote.");
     expect(container.textContent).toContain("Operation: git push origin main");
+    expect(container.textContent).not.toContain("Approvals");
+    expect(container.textContent).not.toContain("Home");
+    expect(container.textContent).not.toContain("ReasonReason");
+    expect(container.textContent).not.toContain("OperationOperation");
 
     const requestDetailButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Request detail",
@@ -1224,6 +1228,17 @@ describe("ChatPageClient", () => {
             kind: "waiting_on_approval",
             label: "Approval required",
           },
+          pending_request: {
+            request_id: "req_background",
+            thread_id: "thread_background",
+            turn_id: "turn_background",
+            item_id: "item_background",
+            request_kind: "approval",
+            status: "pending",
+            risk_category: "external_side_effect",
+            summary: "Run git push",
+            requested_at: "2026-03-27T05:25:00Z",
+          },
           composer: {
             accepting_user_input: false,
             interrupt_available: false,
@@ -1266,6 +1281,7 @@ describe("ChatPageClient", () => {
     expect(container.textContent).toContain("High-priority background thread needs attention.");
     expect(container.textContent).toContain("Background thread needs attention");
     expect(container.textContent).toContain("Reason: Needs response");
+    expect(container.textContent).not.toContain("Request detail");
 
     const openThreadButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Open thread",
@@ -1285,6 +1301,55 @@ describe("ChatPageClient", () => {
     ).toBeUndefined();
     expect(container.textContent).toContain("thread_background");
     expect(container.textContent).toContain("Approval required");
+    expect(container.textContent).toContain("Approve request");
+    expect(container.textContent).toContain("Deny request");
+  });
+
+  it("keeps opening recovery inside thread view without auto-opening detail", async () => {
+    const pendingThread = createDeferred<{
+      view: PublicThreadView;
+      pendingRequestDetail: PublicRequestDetail | null;
+    }>();
+
+    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
+      items: [buildThreadListItem()],
+      next_cursor: null,
+      has_more: false,
+    });
+    chatDataMocks.loadChatThreadBundle.mockReturnValue(pendingThread.promise);
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("Opening thread");
+    expect(container.textContent).toContain(
+      "Opening this thread and restoring its latest context.",
+    );
+    expect(container.textContent).toContain(
+      "Opening this thread and restoring its latest timeline",
+    );
+    expect(container.textContent).not.toContain("Request detail");
+    expect(container.textContent).not.toContain("Timeline item detail");
+    expect(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Threads",
+      ),
+    ).not.toBeUndefined();
+
+    await act(async () => {
+      pendingThread.resolve({
+        view: buildThreadView(),
+        pendingRequestDetail: null,
+      });
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("Investigate build");
+    expect(container.textContent).not.toContain(
+      "Opening this thread and restoring its latest timeline",
+    );
   });
 
   it("refreshes the selected thread for a high-priority current-thread notification without a background notice", async () => {

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-203-ux-regression-coverage](./archive/issue-203-ux-regression-coverage/README.md)
 - [issue-202-thread-surface-detail](./archive/issue-202-thread-surface-detail/README.md)
 - [issue-201-navigation-thread-identity](./archive/issue-201-navigation-thread-identity/README.md)
 - [issue-200-timeline-thread-view](./archive/issue-200-timeline-thread-view/README.md)

--- a/tasks/archive/issue-203-ux-regression-coverage/README.md
+++ b/tasks/archive/issue-203-ux-regression-coverage/README.md
@@ -1,0 +1,58 @@
+# Issue #203 UX Regression Coverage
+
+## Purpose
+
+- Add regression coverage for the reviewed UX refresh so remaining work is judged by behavior rather than visual intent alone.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/203
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `.tmp/codex_webui_v0_9_ux_improvement_plan.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Add focused regression tests for opening/recovery, request detail, background priority, and mobile-critical no-horizontal-scroll affordances where existing test infrastructure supports them.
+- Verify no Home dependency, no global approval inbox dependency, no per-delta assistant cards, and no detail auto-open behavior.
+- Keep this as validation coverage only; do not redesign UI in this package.
+
+## Exit criteria
+
+- The UX refresh has reproducible regression coverage for the core desktop and mobile-critical states reachable in component/client tests.
+- Validation explicitly covers opening/recovery and request/detail behavior.
+- Targeted frontend-bff validation passes.
+
+## Work plan
+
+- Inspect existing ChatView/ChatPageClient/timeline tests.
+- Add the smallest regression assertions that cover the issue acceptance criteria.
+- Run frontend-bff validation and record evidence.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-25T05-41-06Z-issues-198-205/events.ndjson`
+- Validation:
+  - `git diff --check`: passed.
+  - `npm run check`: passed, Biome checked 72 files with no fixes.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm test -- tests/chat-page-client.test.tsx`: passed.
+  - `npm test`: passed, 11 files / 70 tests.
+- Sprint evaluator: approved.
+- Dedicated pre-push validation: passed.
+
+## Status / handoff notes
+
+- Status: `locally complete; archived before PR follow-through`
+- Active branch: `issue-203-ux-regression-coverage`
+- Active worktree: `.worktrees/issue-203-ux-regression-coverage`
+- Notes: Added regression assertions for request/detail behavior from thread context, no Home or global approval inbox dependency, opening recovery remaining inside Thread View without auto-opened detail, and background high-priority notice remaining selection-driven with request actions reachable after opening the target thread.
+- Completion retrospective: package archive boundary only. Contract checks are satisfied for the local #203 slice by added ChatPageClient regression coverage, evaluator approval, and pre-push validation. Mobile coverage is component-level; viewport/visual evidence remains for #204/#205 polish slices.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary
- add ChatPageClient regression coverage for opening recovery staying inside Thread View
- assert request/detail behavior remains thread-context based without Home or global approval inbox dependency
- cover selection-driven background priority notice and request action reachability after opening target thread
- archive the issue #203 task package after evaluator and pre-push validation

Closes #203

## Validation
- `git diff --check`
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- tests/chat-page-client.test.tsx`
- `npm test`
