### PR TITLE
feat(ui): collapse timeline noise

### DIFF
--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -712,7 +712,7 @@ export function ChatView({
                             </span>
                           </div>
                           <p>{row.content}</p>
-                          {row.timelineItemId ? (
+                          {row.showDetailButton && row.timelineItemId ? (
                             <button
                               className="secondary-link action-button inline-detail-button"
                               onClick={() =>

--- a/apps/frontend-bff/src/timeline-display-model.ts
+++ b/apps/frontend-bff/src/timeline-display-model.ts
@@ -15,6 +15,7 @@ export interface TimelineDisplayRow {
   role: TimelineRowRole;
   timelineItemId: string | null;
   isLive: boolean;
+  showDetailButton: boolean;
 }
 
 export interface TimelineDisplayGroup {
@@ -28,6 +29,22 @@ export interface TimelineDisplayModel {
 }
 
 const ASSISTANT_EVENT_TYPES = new Set(["message.assistant.delta", "message.assistant.completed"]);
+const GENERIC_STATUS_CONTENT = new Set([
+  "session.status_changed",
+  "status changed",
+  "thread status changed",
+  "status update",
+  "created",
+  "running",
+  "waiting input",
+  "waiting approval",
+  "completed",
+  "stopped",
+  "idle",
+  "open",
+  "stopping",
+  "closed",
+]);
 
 function asNonEmptyString(value: unknown) {
   return typeof value === "string" && value.length > 0 ? value : null;
@@ -82,11 +99,35 @@ function payloadText(payload: Record<string, unknown>) {
   );
 }
 
+function normalizedStatusValue(value: unknown) {
+  return asNonEmptyString(value)?.replaceAll("_", " ") ?? null;
+}
+
+function statusChangedContent(payload: Record<string, unknown>) {
+  return (
+    payloadText(payload) ??
+    normalizedStatusValue(payload.status) ??
+    normalizedStatusValue(payload.to_status)
+  );
+}
+
+function assistantDeltaText(payload: Record<string, unknown>) {
+  return asNonEmptyString(payload.delta) ?? asNonEmptyString(payload.content);
+}
+
 function timelineItemContent(item: PublicTimelineItem) {
+  if (item.kind === "session.status_changed") {
+    return statusChangedContent(item.payload) ?? item.kind;
+  }
+
   return payloadText(item.payload) ?? item.kind;
 }
 
 function streamEventContent(event: PublicThreadStreamEvent) {
+  if (event.event_type === "session.status_changed") {
+    return statusChangedContent(event.payload) ?? event.event_type;
+  }
+
   return payloadText(event.payload) ?? event.event_type;
 }
 
@@ -116,6 +157,61 @@ function isAssistantTimelineItem(item: PublicTimelineItem) {
 
 function isUserTimelineItem(item: PublicTimelineItem) {
   return item.kind.startsWith("message.user");
+}
+
+function assistantTimelineKey(item: PublicTimelineItem) {
+  return (
+    asNonEmptyString(item.payload.message_id) ??
+    item.item_id ??
+    asNonEmptyString(item.payload.item_id)
+  );
+}
+
+function normalizeContent(value: string | null | undefined) {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function shouldHideRow(kind: string, content: string, payload: Record<string, unknown>) {
+  if (kind === "session.status_changed") {
+    const normalizedContent = normalizeContent(content);
+    const normalizedStatus = normalizeContent(normalizedStatusValue(payload.status));
+    const normalizedToStatus = normalizeContent(normalizedStatusValue(payload.to_status));
+
+    if (
+      normalizedContent.length === 0 ||
+      GENERIC_STATUS_CONTENT.has(normalizedContent) ||
+      (normalizedStatus.length > 0 &&
+        GENERIC_STATUS_CONTENT.has(normalizedStatus) &&
+        normalizedContent === normalizedStatus) ||
+      (normalizedToStatus.length > 0 &&
+        GENERIC_STATUS_CONTENT.has(normalizedToStatus) &&
+        normalizedContent === normalizedToStatus)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function shouldShowDetailButton(
+  kind: string,
+  role: TimelineRowRole,
+  timelineItemId: string | null,
+) {
+  if (!timelineItemId) {
+    return false;
+  }
+
+  if (role !== "event") {
+    return false;
+  }
+
+  if (kind === "session.status_changed") {
+    return false;
+  }
+
+  return true;
 }
 
 export function classifyTimelineDensity(kind: string): TimelineRowDensity {
@@ -197,8 +293,40 @@ export function buildTimelineDisplayModel({
   );
   const rows: TimelineDisplayRow[] = [];
   const restAssistantKeys = new Set<string>();
+  const restCompletedAssistantKeys = new Set<string>();
   const restAssistantContents = new Set<string>();
   const restDedupKeys = new Set<string>();
+  const assistantTimelineGroupAliases = new Map<
+    string,
+    {
+      key: string;
+      turnId: string | null;
+      firstSequence: number;
+      occurredAt: string | null;
+      content: string;
+      completedContent: string | null;
+      completedSequence: number | null;
+      completedAt: string | null;
+      timelineItemId: string | null;
+    }
+  >();
+  const assistantTimelineGroups = new Map<
+    string,
+    {
+      key: string;
+      turnId: string | null;
+      firstSequence: number;
+      occurredAt: string | null;
+      content: string;
+      completedContent: string | null;
+      completedSequence: number | null;
+      completedAt: string | null;
+      timelineItemId: string | null;
+    }
+  >();
+  let previousAssistantGroupKey: string | null = null;
+  let previousAssistantGroupAnonymous = false;
+  let previousAssistantGroupCompleted = false;
 
   for (const item of sortedTimelineItems) {
     restDedupKeys.add(`${item.kind}:${item.sequence}`);
@@ -209,9 +337,69 @@ export function buildTimelineDisplayModel({
       for (const key of timelineAssistantKeys(item)) {
         restAssistantKeys.add(key);
       }
-      restAssistantContents.add(content);
+      const explicitKey = assistantTimelineKey(item);
+      const key: string =
+        explicitKey ??
+        (previousAssistantGroupAnonymous &&
+        previousAssistantGroupKey !== null &&
+        !previousAssistantGroupCompleted
+          ? previousAssistantGroupKey
+          : item.timeline_item_id);
+      const existing = assistantTimelineGroups.get(key);
+      const group = existing ?? {
+        key,
+        turnId: item.turn_id,
+        firstSequence: item.sequence,
+        occurredAt: item.occurred_at,
+        content: "",
+        completedContent: null,
+        completedSequence: null,
+        completedAt: null,
+        timelineItemId: item.timeline_item_id,
+      };
+
+      group.turnId = group.turnId ?? item.turn_id;
+      group.timelineItemId = item.timeline_item_id;
+
+      if (item.kind === "message.assistant.delta") {
+        const delta = assistantDeltaText(item.payload);
+        if (delta) {
+          group.content = `${group.content}${delta}`;
+        }
+      }
+
+      if (item.kind === "message.assistant.completed") {
+        restCompletedAssistantKeys.add(key);
+        for (const assistantKey of timelineAssistantKeys(item)) {
+          restCompletedAssistantKeys.add(assistantKey);
+        }
+        group.completedContent = content;
+        group.completedSequence = item.sequence;
+        group.completedAt = item.occurred_at;
+        group.timelineItemId = item.timeline_item_id;
+        restAssistantContents.add(content);
+      }
+
+      assistantTimelineGroups.set(key, group);
+      assistantTimelineGroupAliases.set(key, group);
+      for (const assistantKey of timelineAssistantKeys(item)) {
+        assistantTimelineGroupAliases.set(assistantKey, group);
+      }
+      previousAssistantGroupKey = key;
+      previousAssistantGroupAnonymous = explicitKey === null;
+      previousAssistantGroupCompleted = item.kind === "message.assistant.completed";
+      continue;
     }
 
+    previousAssistantGroupKey = null;
+    previousAssistantGroupAnonymous = false;
+    previousAssistantGroupCompleted = false;
+
+    if (shouldHideRow(item.kind, content, item.payload)) {
+      continue;
+    }
+
+    const role = timelineRole(item);
     rows.push({
       id: `timeline:${item.timeline_item_id}`,
       turnId: item.turn_id,
@@ -220,9 +408,10 @@ export function buildTimelineDisplayModel({
       label: timelineDisplayLabel(item.kind),
       content,
       density: classifyTimelineDensity(item.kind),
-      role: timelineRole(item),
+      role,
       timelineItemId: item.timeline_item_id,
       isLive: false,
+      showDetailButton: shouldShowDetailButton(item.kind, role, item.timeline_item_id),
     });
   }
 
@@ -286,9 +475,26 @@ export function buildTimelineDisplayModel({
       continue;
     }
 
+    const restGroup =
+      assistantTimelineGroupAliases.get(group.key) ??
+      (group.itemId ? assistantTimelineGroupAliases.get(group.itemId) : undefined);
+    if (restGroup && group.completedContent === null && restGroup.completedContent === null) {
+      restGroup.turnId = restGroup.turnId ?? group.turnId;
+      continue;
+    }
+
+    if (restGroup && group.completedContent !== null && restGroup.completedContent === null) {
+      restGroup.turnId = restGroup.turnId ?? group.turnId;
+      restGroup.completedContent = group.completedContent;
+      restGroup.completedSequence = group.completedSequence;
+      restGroup.completedAt = group.completedAt;
+      restAssistantContents.add(group.completedContent);
+      continue;
+    }
+
     const keyConverged =
-      restAssistantKeys.has(group.key) ||
-      (group.itemId !== null && restAssistantKeys.has(group.itemId));
+      restCompletedAssistantKeys.has(group.key) ||
+      (group.itemId !== null && restCompletedAssistantKeys.has(group.itemId));
     const contentConverged = group.completedContent !== null && restAssistantContents.has(content);
     if (keyConverged || contentConverged) {
       continue;
@@ -306,6 +512,29 @@ export function buildTimelineDisplayModel({
       role: "assistant",
       timelineItemId: null,
       isLive: !isCompleted,
+      showDetailButton: false,
+    });
+  }
+
+  for (const group of assistantTimelineGroups.values()) {
+    const content = group.completedContent ?? group.content;
+    if (!content) {
+      continue;
+    }
+
+    const isCompleted = group.completedContent !== null;
+    rows.push({
+      id: `timeline-assistant:${group.key}`,
+      turnId: group.turnId,
+      sequence: group.completedSequence ?? group.firstSequence,
+      occurredAt: group.completedAt ?? group.occurredAt,
+      label: timelineDisplayLabel("message.assistant.completed", !isCompleted),
+      content: isCompleted ? content : `${content}...`,
+      density: "primary",
+      role: "assistant",
+      timelineItemId: group.timelineItemId,
+      isLive: !isCompleted,
+      showDetailButton: false,
     });
   }
 
@@ -325,6 +554,7 @@ export function buildTimelineDisplayModel({
       role: "assistant",
       timelineItemId: null,
       isLive: true,
+      showDetailButton: false,
     });
   }
 
@@ -340,17 +570,24 @@ export function buildTimelineDisplayModel({
       continue;
     }
 
+    const content = streamEventContent(event);
+    if (shouldHideRow(event.event_type, content, event.payload)) {
+      continue;
+    }
+
+    const role = eventRole(event);
     rows.push({
       id: `stream:${event.event_id}`,
       turnId: payloadTurnId(event.payload),
       sequence: event.sequence,
       occurredAt: event.occurred_at,
       label: timelineDisplayLabel(event.event_type),
-      content: streamEventContent(event),
+      content,
       density: classifyTimelineDensity(event.event_type),
-      role: eventRole(event),
+      role,
       timelineItemId: null,
       isLive: false,
+      showDetailButton: false,
     });
   }
 

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -271,6 +271,18 @@ describe("ChatView", () => {
                   content: "Please explain the diff.",
                 },
               },
+              {
+                timeline_item_id: "evt_file_001",
+                thread_id: "thread_001",
+                turn_id: "turn_001",
+                item_id: "item_file_001",
+                sequence: 2,
+                occurred_at: "2026-03-27T05:15:00Z",
+                kind: "file.changed",
+                payload: {
+                  summary: "Updated apps/frontend-bff/src/chat-view.tsx",
+                },
+              },
             ],
             next_cursor: null,
             has_more: false,
@@ -282,7 +294,7 @@ describe("ChatView", () => {
             event_id: "evt_stream_001",
             thread_id: "thread_001",
             event_type: "approval.requested",
-            sequence: 2,
+            sequence: 3,
             occurred_at: "2026-03-27T05:18:00Z",
             payload: {
               summary: "Run git push",
@@ -293,7 +305,7 @@ describe("ChatView", () => {
             event_id: "evt_stream_002",
             thread_id: "thread_001",
             event_type: "session.status_changed",
-            sequence: 3,
+            sequence: 4,
             occurred_at: "2026-03-27T05:19:00Z",
             payload: {
               summary: "Tool output received",
@@ -351,11 +363,13 @@ describe("ChatView", () => {
     expect(markup).toContain("Operation: git push origin main");
     expect(markup).toContain("Interrupt thread");
     expect(markup).toContain("Please explain the diff.");
+    expect(markup).toContain("Updated apps/frontend-bff/src/chat-view.tsx");
     expect(markup).toContain("Streaming update");
     expect(markup).toContain("Request needs attention");
     expect(markup).toContain("timeline-row-prominent");
     expect(markup).toContain("Status update");
     expect(markup).toContain("timeline-row-compact");
+    expect(markup.match(/Timeline item detail/g) ?? []).toHaveLength(1);
     expect(markup).not.toContain("approval.requested");
     expect(markup).not.toContain("session.status_changed");
     expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);

--- a/apps/frontend-bff/tests/timeline-display-model.test.ts
+++ b/apps/frontend-bff/tests/timeline-display-model.test.ts
@@ -130,9 +130,192 @@ describe("timeline display model", () => {
     const convergedRows = rows(afterRest);
     expect(convergedRows).toHaveLength(1);
     expect(convergedRows[0]).toMatchObject({
-      id: "timeline:timeline_completed",
+      id: "timeline-assistant:message_001",
       content: "Final answer.",
     });
+  });
+
+  it("prefers stream completion while REST has only stored assistant deltas", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "assistant_delta_001",
+          item_id: "item_assistant_001",
+          sequence: 1,
+          kind: "message.assistant.delta",
+          payload: {
+            message_id: "message_001",
+            delta: "Partial",
+          },
+        }),
+      ],
+      streamEvents: [
+        streamEvent({
+          event_id: "completed_001",
+          event_type: "message.assistant.completed",
+          sequence: 2,
+          payload: {
+            message_id: "message_001",
+            item_id: "item_assistant_001",
+            content: "Final answer.",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "timeline-assistant:message_001",
+        content: "Final answer.",
+        isLive: false,
+      }),
+    ]);
+  });
+
+  it("suppresses matching live stream deltas when REST assistant deltas already exist", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "assistant_delta_001",
+          item_id: "item_assistant_001",
+          sequence: 1,
+          kind: "message.assistant.delta",
+          payload: {
+            message_id: "message_001",
+            delta: "Partial",
+          },
+        }),
+      ],
+      streamEvents: [
+        streamEvent({
+          event_id: "delta_002",
+          event_type: "message.assistant.delta",
+          sequence: 2,
+          payload: {
+            message_id: "message_001",
+            item_id: "item_assistant_001",
+            delta: "Partial",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "timeline-assistant:message_001",
+        content: "Partial...",
+        isLive: true,
+        showDetailButton: false,
+      }),
+    ]);
+  });
+
+  it("collapses stored assistant deltas and completion into one logical assistant row", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "assistant_delta_001",
+          item_id: "item_assistant_001",
+          turn_id: "turn_001",
+          sequence: 2,
+          kind: "message.assistant.delta",
+          payload: {
+            message_id: "message_001",
+            delta: "Hi ",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "assistant_delta_002",
+          item_id: "item_assistant_001",
+          turn_id: "turn_001",
+          sequence: 3,
+          kind: "message.assistant.delta",
+          payload: {
+            message_id: "message_001",
+            delta: "there",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "assistant_completed_001",
+          item_id: "item_assistant_001",
+          turn_id: "turn_001",
+          sequence: 4,
+          kind: "message.assistant.completed",
+          payload: {
+            message_id: "message_001",
+            content: "Hi there",
+          },
+        }),
+      ],
+      streamEvents: [],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "timeline-assistant:message_001",
+        label: "Codex",
+        content: "Hi there",
+        role: "assistant",
+        isLive: false,
+        showDetailButton: false,
+      }),
+    ]);
+  });
+
+  it("collapses mapped public REST assistant rows without message_id or item_id into one final row", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "assistant_delta_001",
+          item_id: null,
+          turn_id: null,
+          sequence: 2,
+          kind: "message.assistant.delta",
+          payload: {
+            summary: "assistant streaming",
+            content: "Hi ",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "assistant_delta_002",
+          item_id: null,
+          turn_id: null,
+          sequence: 3,
+          kind: "message.assistant.delta",
+          payload: {
+            summary: "assistant streaming",
+            content: "there",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "assistant_completed_001",
+          item_id: null,
+          turn_id: null,
+          sequence: 4,
+          kind: "message.assistant.completed",
+          payload: {
+            summary: "assistant completed",
+            content: "Hi there",
+          },
+        }),
+      ],
+      streamEvents: [],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "timeline-assistant:assistant_delta_001",
+        label: "Codex",
+        content: "Hi there",
+        role: "assistant",
+        isLive: false,
+        showDetailButton: false,
+      }),
+    ]);
   });
 
   it("groups adjacent timeline rows by turn_id without grouping rows that lack turn_id", () => {
@@ -170,14 +353,12 @@ describe("timeline display model", () => {
       draftAssistantMessages: {},
     });
 
-    expect(model.groups).toHaveLength(2);
+    expect(model.groups).toHaveLength(1);
     expect(model.groups[0]?.turnId).toBe("turn_001");
     expect(model.groups[0]?.rows.map((row) => row.id)).toEqual([
       "timeline:user_001",
-      "timeline:assistant_001",
+      "timeline-assistant:assistant_001",
     ]);
-    expect(model.groups[1]?.turnId).toBeNull();
-    expect(model.groups[1]?.rows).toHaveLength(1);
   });
 
   it("classifies primary messages, prominent approval/error/file rows, and compact operational rows", () => {
@@ -191,7 +372,7 @@ describe("timeline display model", () => {
     expect(classifyTimelineDensity("command.output")).toBe("compact");
   });
 
-  it("renders low-priority stream events as compact rows instead of separate raw event cards", () => {
+  it("hides generic status transitions from the rendered timeline", () => {
     const model = buildTimelineDisplayModel({
       timelineItems: [],
       streamEvents: [
@@ -199,6 +380,178 @@ describe("timeline display model", () => {
           event_id: "status_001",
           event_type: "session.status_changed",
           sequence: 4,
+          payload: {
+            summary: "thread status changed",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([]);
+  });
+
+  it("keeps failed status evidence visible as a compact row without detail action", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [],
+      streamEvents: [
+        streamEvent({
+          event_id: "status_failed_001",
+          event_type: "session.status_changed",
+          sequence: 4,
+          payload: {
+            summary: "failed",
+            status: "failed",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "stream:status_failed_001",
+        label: "Status update",
+        content: "failed",
+        density: "compact",
+        role: "event",
+        showDetailButton: false,
+      }),
+    ]);
+  });
+
+  it("keeps recovery pending status evidence visible as a compact row without detail action", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [],
+      streamEvents: [
+        streamEvent({
+          event_id: "status_recovery_001",
+          event_type: "session.status_changed",
+          sequence: 5,
+          payload: {
+            summary: "recovery pending",
+            status: "recovery_pending",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "stream:status_recovery_001",
+        label: "Status update",
+        content: "recovery pending",
+        density: "compact",
+        role: "event",
+        showDetailButton: false,
+      }),
+    ]);
+  });
+
+  it("keeps canonical to_status failed evidence visible without summary or status", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [],
+      streamEvents: [
+        streamEvent({
+          event_id: "status_to_failed_001",
+          event_type: "session.status_changed",
+          sequence: 6,
+          payload: {
+            from_status: "running",
+            to_status: "failed",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "stream:status_to_failed_001",
+        label: "Status update",
+        content: "failed",
+        density: "compact",
+        role: "event",
+        showDetailButton: false,
+      }),
+    ]);
+  });
+
+  it("keeps canonical to_status recovery pending evidence visible without summary or status", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [],
+      streamEvents: [
+        streamEvent({
+          event_id: "status_to_recovery_001",
+          event_type: "session.status_changed",
+          sequence: 7,
+          payload: {
+            from_status: "failed",
+            to_status: "recovery_pending",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([
+      expect.objectContaining({
+        id: "stream:status_to_recovery_001",
+        label: "Status update",
+        content: "recovery pending",
+        density: "compact",
+        role: "event",
+        showDetailButton: false,
+      }),
+    ]);
+  });
+
+  it("hides routine canonical to_status transitions without summary or status", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [],
+      streamEvents: [
+        streamEvent({
+          event_id: "status_to_waiting_001",
+          event_type: "session.status_changed",
+          sequence: 8,
+          payload: {
+            from_status: "running",
+            to_status: "waiting_input",
+          },
+        }),
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(rows(model)).toEqual([]);
+  });
+
+  it("keeps meaningful operational rows visible while hiding low-value detail actions", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "user_001",
+          sequence: 1,
+          kind: "message.user",
+          payload: {
+            content: "Run the checks.",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "file_001",
+          sequence: 2,
+          kind: "file.changed",
+          payload: {
+            summary: "Updated src/app.ts",
+          },
+        }),
+      ],
+      streamEvents: [
+        streamEvent({
+          event_id: "status_001",
+          event_type: "session.status_changed",
+          sequence: 3,
           payload: {
             summary: "Running tool",
           },
@@ -209,10 +562,21 @@ describe("timeline display model", () => {
 
     expect(rows(model)).toEqual([
       expect.objectContaining({
+        id: "timeline:user_001",
+        label: "You",
+        showDetailButton: false,
+      }),
+      expect.objectContaining({
+        id: "timeline:file_001",
+        label: "File update",
+        showDetailButton: true,
+      }),
+      expect.objectContaining({
         id: "stream:status_001",
         label: "Status update",
         content: "Running tool",
         density: "compact",
+        showDetailButton: false,
       }),
     ]);
   });

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,10 +69,11 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- [issue-216-timeline-chronology](./issue-216-timeline-chronology/README.md)
+- `None`
 
 ## Archived Task Packages
 
+- [issue-216-timeline-chronology](./archive/issue-216-timeline-chronology/README.md)
 - [issue-215-first-input-composer](./archive/issue-215-first-input-composer/README.md)
 - [issue-205-mobile-responsive-polish](./archive/issue-205-mobile-responsive-polish/README.md)
 - [issue-204-desktop-shell-polish](./archive/issue-204-desktop-shell-polish/README.md)

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- `None`
+- [issue-216-timeline-chronology](./issue-216-timeline-chronology/README.md)
 
 ## Archived Task Packages
 

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-216-timeline-chronology](./issue-216-timeline-chronology/README.md)
 - [issue-215-first-input-composer](./issue-215-first-input-composer/README.md)
 - [issue-182-thread-view-composer](./issue-182-thread-view-composer/README.md)
 - [issue-178-benchmark-agent-uis](./issue-178-benchmark-agent-uis/README.md)

--- a/tasks/archive/issue-216-timeline-chronology/README.md
+++ b/tasks/archive/issue-216-timeline-chronology/README.md
@@ -38,15 +38,30 @@
 
 ## Artifacts / evidence
 
-- Planned: focused frontend test and validation command output in handoff notes.
-- Planned if visually material: `artifacts/visual-inspection/issue-216-timeline-chronology/`
+- Sprint validation:
+  - `npm test -- --run tests/timeline-display-model.test.ts tests/chat-view.test.tsx`: passed, 22 tests
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - `npm run check`: passed
+- Dedicated pre-push validation:
+  - `npm run check`: passed
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - focused Vitest: 2 files passed, 22 tests passed
+  - full `npm test`: 11 files passed, 82 tests passed
 
 ## Status / handoff notes
 
-- Status: `started`
+- Status: `locally complete`
 - Active branch: `issue-216-timeline-chronology`
 - Active worktree: `.worktrees/issue-216-timeline-chronology`
-- Notes: Package created from #216 before implementation.
+- Notes: Implemented timeline display-model normalization for assistant delta/completion collapse, REST/stream convergence, routine status suppression, failure/recovery preservation, and detail-button gating. Evaluator approved after regressions covered public REST assistant shape, live REST/SSE overlap, and canonical `to_status` failure/recovery payloads.
+- Completion retrospective:
+  - Completion boundary: package archive after local completion and pre-push validation.
+  - Contract check: Issue #216 acceptance criteria are satisfied locally; Issue close still requires PR merge to `main`, parent checkout sync, worktree cleanup, and GitHub tracking update.
+  - What worked: evaluator passes caught important real-shape convergence gaps that synthetic tests initially missed.
+  - Workflow problems: the sprint required several rejection cycles because early tests used idealized assistant identifiers rather than the mapped public REST shape.
+  - Improvements to adopt: timeline display-model tests should include public-mapped REST fixtures whenever behavior depends on payload identity.
+  - Skill candidates or skill updates: consider adding evaluator prompt guidance for UI model changes to inspect public mapping shape before approval.
+  - Follow-up updates: none required before archive; publish-oriented GitHub handoff remains required.
 
 ## Archive conditions
 

--- a/tasks/issue-216-timeline-chronology/README.md
+++ b/tasks/issue-216-timeline-chronology/README.md
@@ -1,0 +1,53 @@
+# Issue 216 Timeline Chronology
+
+## Purpose
+
+- Execute Issue #216 by making the selected-thread timeline read as a useful work chronology rather than raw event plumbing.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/216
+
+## Source docs
+
+- `docs/notes/codex_webui_current_ui_gap_analysis_note_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Collapse stored and live assistant deltas into logical assistant rows where available.
+- Demote routine status transitions that do not add user-facing value.
+- Introduce role-specific timeline rendering for high-value user, assistant, command/tool, approval, resolution, error, and recovery content where the current model exposes enough data.
+- Remove repeated generic `Timeline item detail` buttons from low-value rows.
+
+## Exit criteria
+
+- Selected-thread timelines foreground useful user/Codex work content over status noise.
+- Assistant streaming and completion do not produce duplicate or per-delta cards.
+- Routine implementation events are hidden, compact, or folded into meaningful row metadata.
+- Focused frontend validation passes for the changed timeline display model and rendering.
+
+## Work plan
+
+- Inspect current `timeline-display-model.ts`, `chat-view.tsx`, and focused tests.
+- Define the smallest timeline display model change that collapses low-value assistant deltas/status noise without broadening into artifact inspection.
+- Update timeline rendering to avoid generic detail buttons on low-value rows.
+- Add focused tests for assistant delta/status collapse and preserved high-value rows.
+- Run targeted validation and capture visual evidence if the UI structure changes materially.
+
+## Artifacts / evidence
+
+- Planned: focused frontend test and validation command output in handoff notes.
+- Planned if visually material: `artifacts/visual-inspection/issue-216-timeline-chronology/`
+
+## Status / handoff notes
+
+- Status: `started`
+- Active branch: `issue-216-timeline-chronology`
+- Active worktree: `.worktrees/issue-216-timeline-chronology`
+- Notes: Package created from #216 before implementation.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary

- Collapse assistant deltas/completions into one logical assistant timeline row, including public REST mapped rows without message IDs.
- Preserve stream completion during REST convergence and suppress overlapping live delta duplicates.
- Hide routine status plumbing while preserving failed/recovery status evidence.
- Gate generic timeline detail buttons to inspection-worthy rows.

Closes #216

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- --run tests/timeline-display-model.test.ts tests/chat-view.test.tsx`
- `npm test`

Pre-push validation passed with the same focused and full frontend test gates.