### PR TITLE
feat(ui): improve Navigation return surface

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -473,6 +473,40 @@ textarea {
   padding-right: 4px;
 }
 
+.thread-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.thread-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(35, 24, 15, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--text-main);
+  padding: 8px 10px;
+  font-size: 0.84rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.thread-filter-chip.active {
+  border-color: rgba(184, 77, 36, 0.4);
+  background: rgba(243, 223, 209, 0.72);
+  color: var(--accent-strong);
+}
+
+.thread-filter-count {
+  min-width: 1.4rem;
+  border-radius: 999px;
+  background: rgba(35, 24, 15, 0.07);
+  padding: 2px 7px;
+  text-align: center;
+}
+
 .navigation-ask-codex {
   width: 100%;
 }
@@ -538,6 +572,50 @@ textarea {
   text-align: left;
   cursor: pointer;
   overflow-wrap: anywhere;
+}
+
+.thread-summary-header {
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.thread-summary-title-block {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.thread-summary-title-block strong {
+  font-size: 0.98rem;
+  line-height: 1.2;
+}
+
+.thread-summary-statuses,
+.thread-summary-cues {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.thread-summary-statuses {
+  justify-content: flex-end;
+}
+
+.thread-summary-activity,
+.thread-summary-notice {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.thread-summary-activity {
+  color: var(--text-main);
+  font-size: 0.92rem;
+}
+
+.thread-summary-notice {
+  color: var(--warning);
+  font-size: 0.88rem;
+  font-weight: 600;
 }
 
 .thread-summary-card.active {
@@ -1050,6 +1128,11 @@ textarea {
     line-height: 1.2;
     text-align: center;
   }
+
+  .thread-filter-chip {
+    justify-content: space-between;
+    width: calc(50% - 4px);
+  }
 }
 
 @media (min-width: 720px) {
@@ -1147,6 +1230,10 @@ textarea {
     border-color: rgba(35, 24, 15, 0.1);
     background: rgba(255, 255, 255, 0.64);
     padding: 11px 12px;
+  }
+
+  .thread-summary-title-block strong {
+    font-size: 0.94rem;
   }
 
   .thread-summary-card.active {

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -97,38 +97,67 @@ function formatMachineLabel(value: string | null | undefined) {
   return value ? value.replaceAll("_", " ") : "Not available";
 }
 
-function hasAttentionCue(thread: PublicThreadListItem) {
-  return (
-    thread.blocked_cue !== null ||
-    thread.resume_cue?.priority_band === "highest" ||
-    thread.current_activity.kind === "waiting_on_approval" ||
-    thread.current_activity.kind === "system_error" ||
-    thread.current_activity.kind === "latest_turn_failed"
-  );
-}
-
 function isActiveThread(thread: PublicThreadListItem) {
   return thread.current_activity.kind === "running";
 }
 
-function groupThreads(threads: PublicThreadListItem[]) {
-  const attentionNeeded = threads.filter(hasAttentionCue);
-  const active = threads.filter(
-    (thread) =>
-      isActiveThread(thread) &&
-      !attentionNeeded.some((item) => item.thread_id === thread.thread_id),
+function isWaitingApprovalThread(thread: PublicThreadListItem) {
+  return (
+    thread.current_activity.kind === "waiting_on_approval" ||
+    thread.blocked_cue?.kind === "approval_required" ||
+    thread.badge?.kind === "approval"
   );
-  const recent = threads.filter(
-    (thread) =>
-      !attentionNeeded.some((item) => item.thread_id === thread.thread_id) &&
-      !active.some((item) => item.thread_id === thread.thread_id),
-  );
+}
 
-  return [
-    { label: "Attention needed", threads: attentionNeeded },
-    { label: "Active", threads: active },
-    { label: "Recent", threads: recent },
-  ].filter((group) => group.threads.length > 0);
+function isErrorOrFailedThread(thread: PublicThreadListItem) {
+  return (
+    thread.current_activity.kind === "system_error" ||
+    thread.current_activity.kind === "latest_turn_failed" ||
+    thread.native_status.latest_turn_status === "failed"
+  );
+}
+
+function isRecentThread(thread: PublicThreadListItem) {
+  return (
+    !isActiveThread(thread) && !isWaitingApprovalThread(thread) && !isErrorOrFailedThread(thread)
+  );
+}
+
+type ThreadFilterId = "all" | "active" | "waiting_approval" | "errors_failed" | "recent";
+
+function filterThreads(threads: PublicThreadListItem[], filterId: ThreadFilterId) {
+  switch (filterId) {
+    case "active":
+      return threads.filter(isActiveThread);
+    case "waiting_approval":
+      return threads.filter(isWaitingApprovalThread);
+    case "errors_failed":
+      return threads.filter(isErrorOrFailedThread);
+    case "recent":
+      return threads.filter(isRecentThread);
+    default:
+      return threads;
+  }
+}
+
+function summarizeThreadActivity(thread: PublicThreadListItem) {
+  if (thread.blocked_cue) {
+    return thread.blocked_cue.label;
+  }
+
+  if (thread.badge) {
+    return thread.badge.label;
+  }
+
+  if (thread.resume_cue) {
+    return thread.resume_cue.label;
+  }
+
+  return thread.current_activity.label;
+}
+
+function threadCueLabel(thread: PublicThreadListItem) {
+  return thread.blocked_cue?.label ?? thread.resume_cue?.label ?? thread.badge?.label ?? null;
 }
 
 function workspaceSummary(workspace: PublicWorkspaceSummary) {
@@ -246,9 +275,25 @@ export function ChatView({
 }: ChatViewProps) {
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
+  const [selectedFilterId, setSelectedFilterId] = useState<ThreadFilterId>("all");
   const selectedWorkspace =
     workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
-  const threadGroups = groupThreads(threads);
+  const visibleThreads = filterThreads(threads, selectedFilterId);
+  const threadFilters: Array<{ id: ThreadFilterId; label: string; count: number }> = [
+    { id: "all", label: "All", count: threads.length },
+    { id: "active", label: "Active", count: threads.filter(isActiveThread).length },
+    {
+      id: "waiting_approval",
+      label: "Waiting approval",
+      count: threads.filter(isWaitingApprovalThread).length,
+    },
+    {
+      id: "errors_failed",
+      label: "Errors / Failed",
+      count: threads.filter(isErrorOrFailedThread).length,
+    },
+    { id: "recent", label: "Recent", count: threads.filter(isRecentThread).length },
+  ];
   const hasSelectedThread = selectedThreadId !== null;
   const isOpeningSelectedThread = hasSelectedThread && !selectedThreadView;
   const isStartingThread = !hasSelectedThread;
@@ -295,6 +340,10 @@ export function ChatView({
     setIsNavigationOpen(false);
     setDetailSelection(null);
   }, [selectedThreadId]);
+
+  useEffect(() => {
+    setSelectedFilterId("all");
+  }, [workspaceId]);
 
   function selectThread(threadId: string) {
     onSelectThread(threadId);
@@ -453,50 +502,82 @@ export function ChatView({
               <p className="empty-state">No threads yet. Use Ask Codex in Thread View.</p>
             ) : null}
 
-            {threadGroups.map((group) => (
-              <section className="thread-list-group" key={group.label}>
-                <h3>{group.label}</h3>
-                {group.threads.map((thread) => (
+            {workspaceId && threads.length > 0 ? (
+              <div className="thread-filter-bar" role="tablist" aria-label="Thread filters">
+                {threadFilters.map((filter) => (
                   <button
                     className={
-                      selectedThreadId === thread.thread_id
-                        ? "thread-summary-card active"
-                        : "thread-summary-card"
+                      selectedFilterId === filter.id
+                        ? "thread-filter-chip active"
+                        : "thread-filter-chip"
                     }
-                    key={thread.thread_id}
-                    onClick={() => selectThread(thread.thread_id)}
+                    key={filter.id}
+                    onClick={() => setSelectedFilterId(filter.id)}
+                    role="tab"
+                    aria-selected={selectedFilterId === filter.id}
                     type="button"
                   >
-                    <div className="workspace-meta-row">
-                      <p className="eyebrow">Thread</p>
+                    <span>{filter.label}</span>
+                    <span className="thread-filter-count">{filter.count}</span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+
+            {workspaceId &&
+            !isLoadingThreads &&
+            threads.length > 0 &&
+            visibleThreads.length === 0 ? (
+              <p className="empty-state">No threads match this filter.</p>
+            ) : null}
+
+            {visibleThreads.map((thread) => {
+              const isSelected = selectedThreadId === thread.thread_id;
+              const rowCueLabel = threadCueLabel(thread);
+              const hasBackgroundNotice =
+                backgroundPriorityNotice?.threadId === thread.thread_id && !isSelected;
+
+              return (
+                <button
+                  className={isSelected ? "thread-summary-card active" : "thread-summary-card"}
+                  key={thread.thread_id}
+                  onClick={() => selectThread(thread.thread_id)}
+                  type="button"
+                >
+                  <div className="workspace-meta-row thread-summary-header">
+                    <div className="thread-summary-title-block">
+                      <strong>{thread.title}</strong>
+                      <span className="workspace-meta">
+                        Updated {formatTimestamp(thread.updated_at)}
+                      </span>
+                    </div>
+                    <div className="thread-summary-statuses">
+                      {isSelected ? <span className="status-badge">Selected</span> : null}
                       <span className={threadBadgeClass(thread)}>
                         {thread.current_activity.label}
                       </span>
                     </div>
-                    <strong>{thread.title}</strong>
-                    {thread.badge ? (
-                      <span className="workspace-meta">
-                        {formatMachineLabel(thread.badge.label)}
-                      </span>
+                  </div>
+                  <p className="thread-summary-activity">{summarizeThreadActivity(thread)}</p>
+                  <div className="thread-summary-cues">
+                    {rowCueLabel ? (
+                      <span className="status-badge">{formatMachineLabel(rowCueLabel)}</span>
                     ) : null}
-                    {thread.blocked_cue ? (
-                      <span className="workspace-meta">
-                        Blocked: {formatMachineLabel(thread.blocked_cue.label)}
-                      </span>
+                    {hasBackgroundNotice ? (
+                      <span className="status-badge warning">Needs attention now</span>
                     ) : null}
-                    <span className="workspace-meta">
-                      Updated {formatTimestamp(thread.updated_at)}
-                    </span>
-                    <span className="workspace-meta">Thread ref: {thread.thread_id}</span>
-                    {thread.resume_cue ? (
-                      <span className="workspace-meta">
-                        {formatMachineLabel(thread.resume_cue.label)}
-                      </span>
+                    {thread.badge && rowCueLabel !== thread.badge.label ? (
+                      <span className="status-badge">{formatMachineLabel(thread.badge.label)}</span>
                     ) : null}
-                  </button>
-                ))}
-              </section>
-            ))}
+                  </div>
+                  {hasBackgroundNotice ? (
+                    <p className="thread-summary-notice">
+                      Background notice: {backgroundPriorityNotice?.reason}
+                    </p>
+                  ) : null}
+                </button>
+              );
+            })}
           </div>
         </section>
 

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -396,7 +396,8 @@ describe("ChatPageClient", () => {
     });
     await flushUi();
 
-    expect(container.textContent).toContain("thread_001");
+    expect(container.textContent).toContain("Investigate build");
+    expect(container.textContent).toContain("Selected");
     expect(container.textContent).toContain("Waiting for your input");
     expect(MockEventSource.instances[0]?.url).toBe("/api/v1/threads/thread_001/stream");
 
@@ -1443,10 +1444,13 @@ describe("ChatPageClient", () => {
 
     expect(chatDataMocks.listWorkspaceThreads).toHaveBeenCalledTimes(2);
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(1);
-    expect(container.textContent).toContain("thread_001");
+    expect(container.textContent).toContain("Investigate build");
+    expect(container.textContent).toContain("Selected");
     expect(container.textContent).toContain("High-priority background thread needs attention.");
     expect(container.textContent).toContain("Background thread needs attention");
     expect(container.textContent).toContain("Reason: Needs response");
+    expect(container.textContent).toContain("Needs attention now");
+    expect(container.textContent).toContain("Background notice: Needs response");
     expect(container.textContent).not.toContain("Request detail");
 
     const openThreadButton = Array.from(container.querySelectorAll("button")).find(
@@ -1465,7 +1469,7 @@ describe("ChatPageClient", () => {
         (button) => button.textContent === "Open thread",
       ),
     ).toBeUndefined();
-    expect(container.textContent).toContain("thread_background");
+    expect(container.textContent).toContain("Background work");
     expect(container.textContent).toContain("Approval required");
     expect(container.textContent).toContain("Approve request");
     expect(container.textContent).toContain("Deny request");

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -1,6 +1,10 @@
+// @vitest-environment jsdom
+
 import type React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChatView } from "../src/chat-view";
 
@@ -21,6 +25,25 @@ vi.mock("next/link", () => ({
 }));
 
 describe("ChatView", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   it("renders Navigation workspace switching, creation, and grouped thread cues", () => {
     const markup = renderToStaticMarkup(
       <ChatView
@@ -116,11 +139,7 @@ describe("ChatView", () => {
             },
             badge: null,
             blocked_cue: null,
-            resume_cue: {
-              reason_kind: "recent",
-              priority_band: "medium",
-              label: "Recently updated",
-            },
+            resume_cue: null,
           },
         ]}
         workspaceId="ws_alpha"
@@ -155,21 +174,268 @@ describe("ChatView", () => {
     expect(markup).toContain("Create workspace");
     expect(markup).toContain(">Ask Codex<");
     expect(markup).toContain("1 approval");
-    expect(markup).toContain("Attention needed");
+    expect(markup).toContain("All");
     expect(markup).toContain("Active");
+    expect(markup).toContain("Waiting approval");
+    expect(markup).toContain("Errors / Failed");
     expect(markup).toContain("Recent");
     expect(markup).toContain("Approval thread");
     expect(markup).toContain("Active thread");
     expect(markup).toContain("Recent thread");
-    expect(markup).toContain("Thread ref: thread_approval");
-    expect(markup).toContain("Blocked: Needs response");
-    expect(markup).toContain("Resume here first");
-    expect(markup).toContain("Recently updated");
+    expect(markup).toContain("Selected");
+    expect(markup).toContain("Needs response");
+    expect(markup).toContain("Waiting for your input");
     expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
     expect(markup).toContain('id="thread-composer-input"');
     expect(markup).not.toContain('id="thread-input"');
     expect(markup).not.toContain('id="message-input"');
     expect(markup).not.toContain("Home");
+    expect(markup).not.toContain("Thread ref:");
+  });
+
+  it("filters visible rows without changing thread selection behavior", async () => {
+    const onSelectThread = vi.fn();
+    const onSelectWorkspace = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={{
+            threadId: "thread_waiting",
+            reason: "Needs response",
+          }}
+          connectionState="idle"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={onSelectThread}
+          onSelectWorkspace={onSelectWorkspace}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_active"
+          selectedThreadView={null}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[
+            {
+              thread_id: "thread_waiting",
+              title: "Approval thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: ["waiting_on_request"],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+              current_activity: {
+                kind: "waiting_on_approval",
+                label: "Approval required",
+              },
+              badge: {
+                kind: "approval",
+                label: "Waiting approval",
+              },
+              blocked_cue: {
+                kind: "approval_required",
+                label: "Needs response",
+              },
+              resume_cue: {
+                reason_kind: "waiting_on_approval",
+                priority_band: "highest",
+                label: "Resume here first",
+              },
+            },
+            {
+              thread_id: "thread_active",
+              title: "Active thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:20:00Z",
+              current_activity: {
+                kind: "running",
+                label: "Running",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+            {
+              thread_id: "thread_failed",
+              title: "Failed thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "idle",
+                active_flags: [],
+                latest_turn_status: "failed",
+              },
+              updated_at: "2026-03-27T05:19:00Z",
+              current_activity: {
+                kind: "latest_turn_failed",
+                label: "Latest turn failed",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+            {
+              thread_id: "thread_recent",
+              title: "Recent thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "waiting_input",
+                active_flags: [],
+                latest_turn_status: null,
+              },
+              updated_at: "2026-03-27T05:18:00Z",
+              current_activity: {
+                kind: "waiting_on_user_input",
+                label: "Waiting for your input",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+          ]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[]}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Approval thread");
+    expect(container.textContent).toContain("Active thread");
+    expect(container.textContent).toContain("Failed thread");
+    expect(container.textContent).toContain("Recent thread");
+    expect(container.textContent).toContain("Background notice: Needs response");
+
+    const filterButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Waiting approval"),
+    );
+    expect(filterButton).not.toBeUndefined();
+
+    await act(async () => {
+      filterButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Approval thread");
+    expect(container.textContent).not.toContain("Active thread");
+    expect(container.textContent).not.toContain("Failed thread");
+    expect(container.textContent).not.toContain("Recent thread");
+    expect(onSelectThread).not.toHaveBeenCalled();
+    expect(onSelectWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("treats a normal waiting-input thread with no resume cue as Recent", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={null}
+          connectionState="idle"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId={null}
+          selectedThreadView={null}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[
+            {
+              thread_id: "thread_running",
+              title: "Running thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+              current_activity: {
+                kind: "running",
+                label: "Running",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+            {
+              thread_id: "thread_recent",
+              title: "Mapped idle thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "waiting_input",
+                active_flags: [],
+                latest_turn_status: null,
+              },
+              updated_at: "2026-03-27T05:21:00Z",
+              current_activity: {
+                kind: "waiting_on_user_input",
+                label: "Waiting for your input",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+          ]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[]}
+        />,
+      );
+    });
+
+    const recentFilterButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Recent1"),
+    );
+    expect(recentFilterButton).not.toBeUndefined();
+
+    await act(async () => {
+      recentFilterButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Mapped idle thread");
+    expect(container.textContent).toContain("Waiting for your input");
+    expect(container.textContent).not.toContain("Running thread");
   });
 
   it("renders thread context, pending request controls, and timeline state", () => {

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,10 +69,11 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- [issue-217-navigation-return-surface](./issue-217-navigation-return-surface/README.md)
+- `None`
 
 ## Archived Task Packages
 
+- [issue-217-navigation-return-surface](./archive/issue-217-navigation-return-surface/README.md)
 - [issue-216-timeline-chronology](./archive/issue-216-timeline-chronology/README.md)
 - [issue-215-first-input-composer](./archive/issue-215-first-input-composer/README.md)
 - [issue-205-mobile-responsive-polish](./archive/issue-205-mobile-responsive-polish/README.md)

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- `None`
+- [issue-217-navigation-return-surface](./issue-217-navigation-return-surface/README.md)
 
 ## Archived Task Packages
 

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-217-navigation-return-surface](./issue-217-navigation-return-surface/README.md)
 - [issue-216-timeline-chronology](./issue-216-timeline-chronology/README.md)
 - [issue-215-first-input-composer](./issue-215-first-input-composer/README.md)
 - [issue-182-thread-view-composer](./issue-182-thread-view-composer/README.md)

--- a/tasks/archive/issue-217-navigation-return-surface/README.md
+++ b/tasks/archive/issue-217-navigation-return-surface/README.md
@@ -38,15 +38,30 @@
 
 ## Artifacts / evidence
 
-- Planned: focused frontend test and validation command output in handoff notes.
-- Planned if visually material: `artifacts/visual-inspection/issue-217-navigation-return-surface/`
+- Sprint validation:
+  - `npm run check`: passed
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - `npm test -- tests/chat-view.test.tsx tests/chat-page-client.test.tsx`: passed, 25 tests
+- Dedicated pre-push validation:
+  - `npm run check`: passed
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - focused Vitest: 2 files passed, 25 tests passed
+  - full `npm test`: 11 files passed, 84 tests passed
 
 ## Status / handoff notes
 
-- Status: `started`
+- Status: `locally complete`
 - Active branch: `issue-217-navigation-return-surface`
 - Active worktree: `.worktrees/issue-217-navigation-return-surface`
-- Notes: Package created from #217 before implementation.
+- Notes: Implemented client-local Navigation filters/counts, title-first thread rows, selected/background notice cues, compact status/cue display, and removal of dominant raw thread refs. Evaluator approved after `Recent` was corrected to use current API list ordering and existing state cues instead of a synthetic resume-cue value.
+- Completion retrospective:
+  - Completion boundary: package archive after local completion and pre-push validation.
+  - Contract check: Issue #217 acceptance criteria are satisfied locally; Issue close still requires PR merge to `main`, parent checkout sync, worktree cleanup, and GitHub tracking update.
+  - What worked: evaluator caught a production-data mismatch in the initial `Recent` filter before publication.
+  - Workflow problems: early tests used a synthetic `recent` resume cue that current BFF mapping does not emit.
+  - Improvements to adopt: filter/cue tests should include mapped-production-like fixtures for values derived from BFF mappers.
+  - Skill candidates or skill updates: none required.
+  - Follow-up updates: none required before archive; publish-oriented GitHub handoff remains required.
 
 ## Archive conditions
 

--- a/tasks/issue-217-navigation-return-surface/README.md
+++ b/tasks/issue-217-navigation-return-surface/README.md
@@ -1,0 +1,53 @@
+# Issue 217 Navigation Return Surface
+
+## Purpose
+
+- Execute Issue #217 by making Navigation useful for identifying, resuming, and prioritizing threads without opening each thread.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/217
+
+## Source docs
+
+- `docs/notes/codex_webui_current_ui_gap_analysis_note_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Improve Navigation thread rows around title, relative time, activity summary, compact status badge, and selected state.
+- Add or refine filters/counts for all, active, waiting approval, errors, and recent where current data supports it.
+- Add unread/new-activity cues for background thread changes without automatic context switching.
+- Keep workspace switching compact and secondary to current-workspace thread discovery.
+
+## Exit criteria
+
+- Users can identify what each thread is and why it matters from Navigation alone.
+- Background updates are noticeable without automatic context switching.
+- Raw thread refs are not the dominant row content.
+- Focused frontend validation passes for the changed Navigation behavior.
+
+## Work plan
+
+- Inspect current Navigation rendering in `chat-view.tsx` and available thread list fields.
+- Implement a bounded Navigation row/readability slice without changing backend contracts.
+- Add supported filter/count or cue behavior from existing data only.
+- Add focused tests for row content, selected/background cues, and counts.
+- Run targeted frontend validation.
+
+## Artifacts / evidence
+
+- Planned: focused frontend test and validation command output in handoff notes.
+- Planned if visually material: `artifacts/visual-inspection/issue-217-navigation-return-surface/`
+
+## Status / handoff notes
+
+- Status: `started`
+- Active branch: `issue-217-navigation-return-surface`
+- Active worktree: `.worktrees/issue-217-navigation-return-surface`
+- Notes: Package created from #217 before implementation.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary

- Add client-local Navigation filters/counts for All, Active, Waiting approval, Errors / Failed, and Recent using existing thread fields.
- Make thread rows title-first with updated time, activity summary, selected state, and compact cues.
- Surface background priority notices as row-level attention cues without auto-switching thread context.
- Remove dominant raw thread refs from Navigation rows.

Closes #217

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- tests/chat-view.test.tsx tests/chat-page-client.test.tsx`
- `npm test`

Pre-push validation passed with focused Navigation tests and full frontend Vitest suite.