### PR TITLE
feat(ui): improve thread feedback recovery

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -637,12 +637,44 @@ textarea {
   overflow-wrap: anywhere;
 }
 
+.thread-feedback-card {
+  display: grid;
+  gap: 12px;
+  border: 1px solid rgba(35, 24, 15, 0.08);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 14px;
+}
+
+.thread-feedback-card .workspace-status {
+  margin: 0;
+}
+
+.thread-feedback-actions {
+  margin-top: 0;
+}
+
 .thread-view-scroll-region {
   display: grid;
   gap: 14px;
   min-height: 0;
   overflow: auto;
   padding-bottom: 12px;
+}
+
+.latest-activity-cta {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid rgba(35, 24, 15, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 252, 245, 0.96);
+  box-shadow: 0 10px 24px rgba(42, 25, 9, 0.1);
+  padding: 10px 12px;
 }
 
 .timeline-section {
@@ -1051,6 +1083,7 @@ textarea {
   }
 
   .current-activity-card,
+  .thread-feedback-card,
   .request-detail-card,
   .chat-composer {
     border-radius: 16px;
@@ -1084,6 +1117,12 @@ textarea {
 
   .thread-interrupt-actions {
     margin-top: 8px;
+  }
+
+  .latest-activity-cta {
+    align-items: stretch;
+    border-radius: 16px;
+    padding: 10px;
   }
 
   .timeline-section {

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { PublicWorkspaceSummary } from "./chat-data";
 import type {
@@ -178,6 +178,21 @@ type ThreadDetailSelection =
   | { kind: "request_detail" }
   | { kind: "timeline_item_detail"; timelineItemId: string };
 
+type ThreadFeedbackAction =
+  | { kind: "refresh"; label: string }
+  | { kind: "focus_composer"; label: string }
+  | { kind: "interrupt"; label: string }
+  | { kind: "approve"; label: string }
+  | { kind: "deny"; label: string }
+  | { kind: "request_detail"; label: string };
+
+type ThreadFeedbackDescriptor = {
+  badgeTone: "default" | "success" | "warning";
+  title: string;
+  summary: string;
+  actions: ThreadFeedbackAction[];
+};
+
 function timelineItemLabel(item: PublicTimelineItem) {
   return String(item.payload.content ?? item.payload.summary ?? item.kind);
 }
@@ -238,6 +253,210 @@ function currentActivitySummary(
   }
 }
 
+function threadFeedbackBadgeClass(descriptor: ThreadFeedbackDescriptor) {
+  if (descriptor.badgeTone === "success") {
+    return "status-badge success";
+  }
+
+  if (descriptor.badgeTone === "warning") {
+    return "status-badge warning";
+  }
+
+  return "status-badge";
+}
+
+function buildThreadFeedbackDescriptor({
+  composerAcceptingInput,
+  connectionState,
+  hasSelectedThread,
+  isOpeningSelectedThread,
+  isRequestDetailAvailable,
+  isRespondingToRequest,
+  isSendingMessage,
+  isStartingThread,
+  isInterruptingThread,
+  selectedThreadView,
+  workspaceId,
+}: {
+  composerAcceptingInput: boolean;
+  connectionState: "idle" | "live" | "reconnecting";
+  hasSelectedThread: boolean;
+  isOpeningSelectedThread: boolean;
+  isRequestDetailAvailable: boolean;
+  isRespondingToRequest: boolean;
+  isSendingMessage: boolean;
+  isStartingThread: boolean;
+  isInterruptingThread: boolean;
+  selectedThreadView: PublicThreadView | null;
+  workspaceId: string | null;
+}): ThreadFeedbackDescriptor {
+  if (!workspaceId) {
+    return {
+      badgeTone: "default",
+      title: "Workspace required",
+      summary: "Select or create a workspace before Thread View can start or resume work.",
+      actions: [],
+    };
+  }
+
+  if (isSendingMessage) {
+    return {
+      badgeTone: "success",
+      title: isStartingThread ? "Submitting first input" : "Submitting follow-up input",
+      summary: isStartingThread
+        ? "Input is accepted locally while Thread View waits for the new thread to open."
+        : "Input is accepted locally while Thread View waits for the next thread update.",
+      actions: [],
+    };
+  }
+
+  if (isOpeningSelectedThread) {
+    return {
+      badgeTone: "default",
+      title: "Opening thread",
+      summary:
+        "Restoring timeline context, request state, and the live connection for this thread.",
+      actions: hasSelectedThread ? [{ kind: "refresh", label: "Reopen thread" }] : [],
+    };
+  }
+
+  if (!selectedThreadView) {
+    return {
+      badgeTone: "success",
+      title: "Ready for first input",
+      summary: "The next composer submission will create a new thread in this workspace.",
+      actions: [{ kind: "focus_composer", label: "Focus composer" }],
+    };
+  }
+
+  if (selectedThreadView.pending_request || selectedThreadView.composer.blocked_by_request) {
+    return {
+      badgeTone: "warning",
+      title: "Approval required",
+      summary: "Codex is blocked until you approve or deny the pending request in this thread.",
+      actions: [
+        { kind: "approve", label: isRespondingToRequest ? "Submitting..." : "Approve request" },
+        { kind: "deny", label: "Deny request" },
+        ...(isRequestDetailAvailable
+          ? [{ kind: "request_detail", label: "Request detail" } as const]
+          : []),
+      ],
+    };
+  }
+
+  if (connectionState === "reconnecting") {
+    return {
+      badgeTone: "warning",
+      title: "Reconnecting live updates",
+      summary:
+        "Live delivery dropped. Thread View is reacquiring the latest activity for this thread.",
+      actions: [
+        { kind: "refresh", label: "Refresh thread" },
+        ...(selectedThreadView.composer.interrupt_available
+          ? [
+              {
+                kind: "interrupt",
+                label: isInterruptingThread ? "Interrupting..." : "Interrupt thread",
+              } as const,
+            ]
+          : []),
+      ],
+    };
+  }
+
+  if (connectionState === "idle" && selectedThreadView.current_activity.kind === "running") {
+    return {
+      badgeTone: "default",
+      title: "Connecting live updates",
+      summary: "The thread is active while Thread View waits for the live stream to open.",
+      actions: [
+        { kind: "refresh", label: "Refresh thread" },
+        ...(selectedThreadView.composer.interrupt_available
+          ? [
+              {
+                kind: "interrupt",
+                label: isInterruptingThread ? "Interrupting..." : "Interrupt thread",
+              } as const,
+            ]
+          : []),
+      ],
+    };
+  }
+
+  if (selectedThreadView.current_activity.kind === "running") {
+    return {
+      badgeTone: "success",
+      title: "Codex is running",
+      summary: "Thread View is waiting for more live activity, a request, or the turn to finish.",
+      actions: selectedThreadView.composer.interrupt_available
+        ? [
+            {
+              kind: "interrupt",
+              label: isInterruptingThread ? "Interrupting..." : "Interrupt thread",
+            },
+          ]
+        : [],
+    };
+  }
+
+  if (
+    selectedThreadView.current_activity.kind === "system_error" ||
+    selectedThreadView.current_activity.kind === "latest_turn_failed" ||
+    selectedThreadView.composer.input_unavailable_reason
+  ) {
+    return {
+      badgeTone: "warning",
+      title:
+        selectedThreadView.current_activity.kind === "system_error"
+          ? "System error"
+          : selectedThreadView.current_activity.kind === "latest_turn_failed"
+            ? "Latest turn failed"
+            : "Recovery required",
+      summary:
+        selectedThreadView.current_activity.kind === "system_error"
+          ? "This thread needs recovery before Codex can continue."
+          : selectedThreadView.current_activity.kind === "latest_turn_failed"
+            ? "The latest turn failed. Refresh the thread or reopen detail before continuing."
+            : `Input is unavailable while ${formatMachineLabel(
+                selectedThreadView.composer.input_unavailable_reason,
+              )}.`,
+      actions: [
+        { kind: "refresh", label: "Refresh thread" },
+        ...(composerAcceptingInput
+          ? [{ kind: "focus_composer", label: "Focus composer" } as const]
+          : []),
+        ...(selectedThreadView.composer.interrupt_available
+          ? [
+              {
+                kind: "interrupt",
+                label: isInterruptingThread ? "Interrupting..." : "Interrupt thread",
+              } as const,
+            ]
+          : []),
+        ...(isRequestDetailAvailable
+          ? [{ kind: "request_detail", label: "Request detail" } as const]
+          : []),
+      ],
+    };
+  }
+
+  if (selectedThreadView.current_activity.kind === "waiting_on_user_input") {
+    return {
+      badgeTone: "success",
+      title: "Ready for your next input",
+      summary: "Codex is idle and the composer below is available for the next instruction.",
+      actions: [{ kind: "focus_composer", label: "Focus composer" }],
+    };
+  }
+
+  return {
+    badgeTone: "default",
+    title: selectedThreadView.current_activity.label,
+    summary: currentActivitySummary(selectedThreadView, false),
+    actions: hasSelectedThread ? [{ kind: "refresh", label: "Refresh thread" }] : [],
+  };
+}
+
 export function ChatView({
   workspaceId,
   workspaces,
@@ -276,6 +495,11 @@ export function ChatView({
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
   const [selectedFilterId, setSelectedFilterId] = useState<ThreadFilterId>("all");
+  const [followLatestActivity, setFollowLatestActivity] = useState(true);
+  const [hasSuppressedActivity, setHasSuppressedActivity] = useState(false);
+  const composerRef = useRef<HTMLTextAreaElement | null>(null);
+  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
+  const latestActivitySignatureRef = useRef<string | null>(null);
   const selectedWorkspace =
     workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
   const visibleThreads = filterThreads(threads, selectedFilterId);
@@ -335,6 +559,35 @@ export function ChatView({
     streamEvents,
     draftAssistantMessages,
   });
+  const latestTimelineGroup = timelineModel.groups[timelineModel.groups.length - 1] ?? null;
+  const latestTimelineRow = latestTimelineGroup?.rows[latestTimelineGroup.rows.length - 1] ?? null;
+  const latestActivitySignature = selectedThreadId
+    ? JSON.stringify({
+        connectionState,
+        currentActivity: selectedThreadView?.current_activity.kind ?? null,
+        latestResolvedRequest: selectedThreadView?.latest_resolved_request?.request_id ?? null,
+        latestRowContent: latestTimelineRow?.content ?? null,
+        latestRowId: latestTimelineRow?.id ?? null,
+        latestRowIsLive: latestTimelineRow?.isLive ?? null,
+        latestRowSequence: latestTimelineRow?.sequence ?? null,
+        pendingRequest: selectedThreadView?.pending_request?.request_id ?? null,
+        selectedThreadId,
+        statusMessage,
+      })
+    : null;
+  const threadFeedback = buildThreadFeedbackDescriptor({
+    composerAcceptingInput: isThreadAcceptingInput,
+    connectionState,
+    hasSelectedThread,
+    isOpeningSelectedThread,
+    isRequestDetailAvailable: selectedRequestDetail !== null,
+    isRespondingToRequest,
+    isSendingMessage: isSubmittingComposer,
+    isStartingThread,
+    isInterruptingThread,
+    selectedThreadView,
+    workspaceId,
+  });
 
   useEffect(() => {
     setIsNavigationOpen(false);
@@ -345,6 +598,35 @@ export function ChatView({
     setSelectedFilterId("all");
   }, [workspaceId]);
 
+  useEffect(() => {
+    latestActivitySignatureRef.current = null;
+    setFollowLatestActivity(true);
+    setHasSuppressedActivity(false);
+  }, [selectedThreadId]);
+
+  useEffect(() => {
+    if (!selectedThreadId || latestActivitySignature === null) {
+      latestActivitySignatureRef.current = latestActivitySignature;
+      return;
+    }
+
+    const previousSignature = latestActivitySignatureRef.current;
+    latestActivitySignatureRef.current = latestActivitySignature;
+
+    if (followLatestActivity) {
+      const scrollRegion = scrollRegionRef.current;
+      if (scrollRegion) {
+        scrollRegion.scrollTop = scrollRegion.scrollHeight;
+      }
+      setHasSuppressedActivity(false);
+      return;
+    }
+
+    if (previousSignature !== null && previousSignature !== latestActivitySignature) {
+      setHasSuppressedActivity(true);
+    }
+  }, [followLatestActivity, latestActivitySignature, selectedThreadId]);
+
   function selectThread(threadId: string) {
     onSelectThread(threadId);
     setIsNavigationOpen(false);
@@ -353,6 +635,110 @@ export function ChatView({
   function askCodex() {
     onAskCodex();
     setIsNavigationOpen(false);
+  }
+
+  function handleScrollRegionScroll() {
+    const scrollRegion = scrollRegionRef.current;
+    if (!scrollRegion) {
+      return;
+    }
+
+    const distanceFromBottom =
+      scrollRegion.scrollHeight - scrollRegion.scrollTop - scrollRegion.clientHeight;
+    const isNearBottom = distanceFromBottom <= 48;
+
+    setFollowLatestActivity(isNearBottom);
+    if (isNearBottom) {
+      setHasSuppressedActivity(false);
+    }
+  }
+
+  function focusComposer() {
+    composerRef.current?.focus();
+  }
+
+  function jumpToLatestActivity() {
+    const scrollRegion = scrollRegionRef.current;
+    if (scrollRegion) {
+      scrollRegion.scrollTop = scrollRegion.scrollHeight;
+    }
+    setFollowLatestActivity(true);
+    setHasSuppressedActivity(false);
+  }
+
+  function renderThreadFeedbackAction(action: ThreadFeedbackAction) {
+    switch (action.kind) {
+      case "refresh":
+        return workspaceId ? (
+          <Link
+            className="secondary-link action-button compact-button"
+            href={threadChatHref(workspaceId, selectedThreadId ?? undefined)}
+            key={action.label}
+          >
+            {action.label}
+          </Link>
+        ) : null;
+      case "focus_composer":
+        return (
+          <button
+            className="secondary-link action-button compact-button"
+            key={action.label}
+            onClick={focusComposer}
+            type="button"
+          >
+            {action.label}
+          </button>
+        );
+      case "interrupt":
+        return (
+          <button
+            className="secondary-link action-button compact-button"
+            disabled={isInterruptingThread}
+            key={action.label}
+            onClick={onInterruptThread}
+            type="button"
+          >
+            {action.label}
+          </button>
+        );
+      case "approve":
+        return (
+          <button
+            className="primary-link action-button compact-button"
+            disabled={isRespondingToRequest || selectedRequestDetail?.status !== "pending"}
+            key={action.label}
+            onClick={onApproveRequest}
+            type="button"
+          >
+            {action.label}
+          </button>
+        );
+      case "deny":
+        return (
+          <button
+            className="secondary-link action-button compact-button"
+            disabled={isRespondingToRequest || selectedRequestDetail?.status !== "pending"}
+            key={action.label}
+            onClick={onDenyRequest}
+            type="button"
+          >
+            {action.label}
+          </button>
+        );
+      case "request_detail":
+        return (
+          <button
+            className="secondary-link action-button compact-button"
+            key={action.label}
+            onClick={() => setDetailSelection({ kind: "request_detail" })}
+            type="button"
+          >
+            {action.label}
+          </button>
+        );
+      default:
+        return null;
+    }
   }
 
   return (
@@ -657,10 +1043,41 @@ export function ChatView({
                   : "Choose a workspace to enable the composer."}
               </p>
             </div>
+
+            <div className="thread-feedback-card">
+              <div className="workspace-meta-row">
+                <strong>Thread feedback</strong>
+                <span className={threadFeedbackBadgeClass(threadFeedback)}>
+                  {threadFeedback.title}
+                </span>
+              </div>
+              <p className="workspace-status">{threadFeedback.summary}</p>
+              {threadFeedback.actions.length > 0 ? (
+                <div className="workspace-actions thread-feedback-actions">
+                  {threadFeedback.actions.map((action) => renderThreadFeedbackAction(action))}
+                </div>
+              ) : null}
+            </div>
           </div>
 
           <div className="thread-view-body">
-            <div className="thread-view-scroll-region">
+            <div
+              className="thread-view-scroll-region"
+              onScroll={handleScrollRegionScroll}
+              ref={scrollRegionRef}
+            >
+              {hasSuppressedActivity ? (
+                <div className="latest-activity-cta">
+                  <span className="workspace-meta">New activity is available below.</span>
+                  <button
+                    className="secondary-link action-button compact-button"
+                    onClick={jumpToLatestActivity}
+                    type="button"
+                  >
+                    Jump to latest activity
+                  </button>
+                </div>
+              ) : null}
               {selectedThreadView?.pending_request ? (
                 <div className="request-detail-card pending-request-card">
                   <div className="workspace-meta-row">
@@ -830,6 +1247,7 @@ export function ChatView({
                   name="thread-composer-input"
                   onChange={(event) => onComposerDraftChange(event.target.value)}
                   placeholder={composerPlaceholder}
+                  ref={composerRef}
                   rows={4}
                   value={composerDraft}
                 />

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -435,6 +435,10 @@ describe("ChatPageClient", () => {
     expect((textarea as HTMLTextAreaElement).value).toBe("");
     expect(container.textContent).toContain("Running");
     expect(container.textContent).toContain("Continue with the fix.");
+    expect(container.textContent).toContain("Connecting live updates");
+    expect(container.textContent).toContain(
+      "The thread is active while Thread View waits for the live stream to open.",
+    );
   });
 
   it("clears the selected thread from Navigation and starts a workspace-scoped thread", async () => {
@@ -490,6 +494,8 @@ describe("ChatPageClient", () => {
     expect(container.textContent).toContain(
       "First input will create a new thread in this workspace.",
     );
+    expect(container.textContent).toContain("Ready for first input");
+    expect(container.textContent).toContain("Focus composer");
     expect(container.querySelectorAll("textarea")).toHaveLength(1);
     expect(chatDataMocks.sendThreadInput).not.toHaveBeenCalled();
 
@@ -1252,6 +1258,45 @@ describe("ChatPageClient", () => {
 
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
     expect(container.textContent).toContain("Request pending. Respond from the current thread.");
+  });
+
+  it("shows reconnecting feedback when the thread stream drops", async () => {
+    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
+      items: [buildThreadListItem()],
+      next_cursor: null,
+      has_more: false,
+    });
+    chatDataMocks.loadChatThreadBundle.mockResolvedValue({
+      view: buildThreadView({
+        current_activity: {
+          kind: "running",
+          label: "Running",
+        },
+        composer: {
+          accepting_user_input: false,
+          interrupt_available: true,
+          blocked_by_request: false,
+          input_unavailable_reason: null,
+        },
+      }),
+      pendingRequestDetail: null,
+    });
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    await act(async () => {
+      MockEventSource.instances[0]?.onerror?.(new Event("error"));
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("Reconnecting live updates");
+    expect(container.textContent).toContain(
+      "Live delivery dropped. Thread View is reacquiring the latest activity for this thread.",
+    );
+    expect(container.textContent).toContain("Refresh thread");
   });
 
   it("marks stream sequence gaps as inconsistent and reacquires selected thread state", async () => {

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -624,6 +624,10 @@ describe("ChatView", () => {
     expect(markup).toContain("Workspace alpha");
     expect(markup).toContain("Approval required");
     expect(markup).toContain("Codex is paused until you approve or deny the request below.");
+    expect(markup).toContain("Thread feedback");
+    expect(markup).toContain(
+      "Codex is blocked until you approve or deny the pending request in this thread.",
+    );
     expect(markup).toContain("Approve request");
     expect(markup).toContain("Input is paused while this thread waits for your approval response.");
     expect(markup).toContain("Operation: git push origin main");
@@ -843,6 +847,81 @@ describe("ChatView", () => {
     expect(markup).toContain("Open thread");
   });
 
+  it("renders ready-state recovery CTA to focus the composer", () => {
+    const markup = renderToStaticMarkup(
+      <ChatView
+        backgroundPriorityNotice={null}
+        connectionState="live"
+        draftAssistantMessages={{}}
+        errorMessage={null}
+        isCreatingThread={false}
+        isCreatingWorkspace={false}
+        isInterruptingThread={false}
+        isLoadingThread={false}
+        isLoadingThreads={false}
+        isLoadingWorkspaces={false}
+        isRespondingToRequest={false}
+        isSendingMessage={false}
+        composerDraft=""
+        onCreateWorkspace={() => {}}
+        onApproveRequest={() => {}}
+        onSubmitComposer={() => {}}
+        onDenyRequest={() => {}}
+        onInterruptThread={() => {}}
+        onOpenBackgroundPriorityThread={() => {}}
+        onAskCodex={() => {}}
+        onComposerDraftChange={() => {}}
+        onSelectWorkspace={() => {}}
+        onSelectThread={() => {}}
+        onWorkspaceNameChange={() => {}}
+        selectedRequestDetail={null}
+        selectedThreadId="thread_001"
+        selectedThreadView={{
+          thread: {
+            thread_id: "thread_001",
+            title: "Ready thread",
+            workspace_id: "ws_alpha",
+            native_status: {
+              thread_status: "waiting_input",
+              active_flags: [],
+              latest_turn_status: null,
+            },
+            updated_at: "2026-03-27T05:22:00Z",
+          },
+          current_activity: {
+            kind: "waiting_on_user_input",
+            label: "Waiting for your input",
+          },
+          pending_request: null,
+          latest_resolved_request: null,
+          composer: {
+            accepting_user_input: true,
+            interrupt_available: false,
+            blocked_by_request: false,
+            input_unavailable_reason: null,
+          },
+          timeline: {
+            items: [],
+            next_cursor: null,
+            has_more: false,
+          },
+        }}
+        statusMessage={null}
+        streamEvents={[]}
+        threads={[]}
+        workspaceId="ws_alpha"
+        workspaceName=""
+        workspaces={[]}
+      />,
+    );
+
+    expect(markup).toContain("Ready for your next input");
+    expect(markup).toContain(
+      "Codex is idle and the composer below is available for the next instruction.",
+    );
+    expect(markup).toContain("Focus composer");
+  });
+
   it("renders recovery input-unavailable reason as the single disabled composer state", () => {
     const markup = renderToStaticMarkup(
       <ChatView
@@ -916,5 +995,305 @@ describe("ChatView", () => {
     expect(markup).toContain("disabled");
     expect(markup).not.toContain('id="thread-input"');
     expect(markup).not.toContain('id="message-input"');
+  });
+
+  it("surfaces a latest-activity CTA when auto-scroll is suppressed", async () => {
+    const baseProps = {
+      backgroundPriorityNotice: null,
+      connectionState: "live" as const,
+      draftAssistantMessages: {},
+      errorMessage: null,
+      isCreatingThread: false,
+      isCreatingWorkspace: false,
+      isInterruptingThread: false,
+      isLoadingThread: false,
+      isLoadingThreads: false,
+      isLoadingWorkspaces: false,
+      isRespondingToRequest: false,
+      isSendingMessage: false,
+      composerDraft: "",
+      onCreateWorkspace: () => {},
+      onApproveRequest: () => {},
+      onSubmitComposer: () => {},
+      onDenyRequest: () => {},
+      onInterruptThread: () => {},
+      onOpenBackgroundPriorityThread: () => {},
+      onAskCodex: () => {},
+      onComposerDraftChange: () => {},
+      onSelectWorkspace: () => {},
+      onSelectThread: () => {},
+      onWorkspaceNameChange: () => {},
+      selectedRequestDetail: null,
+      selectedThreadId: "thread_001",
+      statusMessage: null,
+      threads: [],
+      workspaceId: "ws_alpha",
+      workspaceName: "",
+      workspaces: [],
+    };
+
+    await act(async () => {
+      root.render(
+        <ChatView
+          {...baseProps}
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Scroll thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+            },
+            current_activity: {
+              kind: "running",
+              label: "Running",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: false,
+              interrupt_available: true,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [
+                {
+                  timeline_item_id: "evt_001",
+                  thread_id: "thread_001",
+                  turn_id: null,
+                  item_id: null,
+                  sequence: 1,
+                  occurred_at: "2026-03-27T05:22:00Z",
+                  kind: "message.user",
+                  payload: {
+                    summary: "user input accepted",
+                    content: "First item",
+                  },
+                },
+              ],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          streamEvents={[]}
+        />,
+      );
+    });
+
+    const scrollRegion = container.querySelector(".thread-view-scroll-region") as HTMLDivElement;
+    expect(scrollRegion).not.toBeNull();
+    Object.defineProperty(scrollRegion, "clientHeight", {
+      configurable: true,
+      value: 100,
+    });
+    Object.defineProperty(scrollRegion, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+      writable: true,
+    });
+    Object.defineProperty(scrollRegion, "scrollTop", {
+      configurable: true,
+      value: 780,
+      writable: true,
+    });
+
+    await act(async () => {
+      scrollRegion.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    await act(async () => {
+      root.render(
+        <ChatView
+          {...baseProps}
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Scroll thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:23:00Z",
+            },
+            current_activity: {
+              kind: "running",
+              label: "Running",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: false,
+              interrupt_available: true,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [
+                {
+                  timeline_item_id: "evt_001",
+                  thread_id: "thread_001",
+                  turn_id: null,
+                  item_id: null,
+                  sequence: 1,
+                  occurred_at: "2026-03-27T05:22:00Z",
+                  kind: "message.user",
+                  payload: {
+                    summary: "user input accepted",
+                    content: "First item",
+                  },
+                },
+                {
+                  timeline_item_id: "evt_002",
+                  thread_id: "thread_001",
+                  turn_id: null,
+                  item_id: null,
+                  sequence: 2,
+                  occurred_at: "2026-03-27T05:23:00Z",
+                  kind: "message.assistant.completed",
+                  payload: {
+                    summary: "assistant completed",
+                    content: "Second item",
+                  },
+                },
+              ],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          streamEvents={[]}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("New activity is available below.");
+    const jumpButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Jump to latest activity",
+    );
+    expect(jumpButton).not.toBeUndefined();
+
+    await act(async () => {
+      jumpButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(scrollRegion.scrollTop).toBe(1000);
+    expect(container.textContent).not.toContain("New activity is available below.");
+  });
+
+  it("keeps following latest activity when live assistant content grows on the same row", async () => {
+    const baseProps = {
+      backgroundPriorityNotice: null,
+      connectionState: "live" as const,
+      errorMessage: null,
+      isCreatingThread: false,
+      isCreatingWorkspace: false,
+      isInterruptingThread: false,
+      isLoadingThread: false,
+      isLoadingThreads: false,
+      isLoadingWorkspaces: false,
+      isRespondingToRequest: false,
+      isSendingMessage: false,
+      composerDraft: "",
+      onCreateWorkspace: () => {},
+      onApproveRequest: () => {},
+      onSubmitComposer: () => {},
+      onDenyRequest: () => {},
+      onInterruptThread: () => {},
+      onOpenBackgroundPriorityThread: () => {},
+      onAskCodex: () => {},
+      onComposerDraftChange: () => {},
+      onSelectWorkspace: () => {},
+      onSelectThread: () => {},
+      onWorkspaceNameChange: () => {},
+      selectedRequestDetail: null,
+      selectedThreadId: "thread_001",
+      selectedThreadView: {
+        thread: {
+          thread_id: "thread_001",
+          title: "Streaming thread",
+          workspace_id: "ws_alpha",
+          native_status: {
+            thread_status: "running",
+            active_flags: [],
+            latest_turn_status: "running",
+          },
+          updated_at: "2026-03-27T05:22:00Z",
+        },
+        current_activity: {
+          kind: "running",
+          label: "Running",
+        },
+        pending_request: null,
+        latest_resolved_request: null,
+        composer: {
+          accepting_user_input: false,
+          interrupt_available: true,
+          blocked_by_request: false,
+          input_unavailable_reason: null,
+        },
+        timeline: {
+          items: [],
+          next_cursor: null,
+          has_more: false,
+        },
+      },
+      statusMessage: null,
+      streamEvents: [],
+      threads: [],
+      workspaceId: "ws_alpha",
+      workspaceName: "",
+      workspaces: [],
+    };
+
+    await act(async () => {
+      root.render(<ChatView {...baseProps} draftAssistantMessages={{ msg_live_001: "Working" }} />);
+    });
+
+    const scrollRegion = container.querySelector(".thread-view-scroll-region") as HTMLDivElement;
+    expect(scrollRegion).not.toBeNull();
+    Object.defineProperty(scrollRegion, "clientHeight", {
+      configurable: true,
+      value: 100,
+    });
+    Object.defineProperty(scrollRegion, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+      writable: true,
+    });
+    Object.defineProperty(scrollRegion, "scrollTop", {
+      configurable: true,
+      value: 1000,
+      writable: true,
+    });
+
+    await act(async () => {
+      root.render(
+        <ChatView {...baseProps} draftAssistantMessages={{ msg_live_001: "Working longer now" }} />,
+      );
+    });
+
+    Object.defineProperty(scrollRegion, "scrollHeight", {
+      configurable: true,
+      value: 1400,
+      writable: true,
+    });
+
+    await act(async () => {
+      root.render(
+        <ChatView
+          {...baseProps}
+          draftAssistantMessages={{ msg_live_001: "Working longer now with more streamed detail" }}
+        />,
+      );
+    });
+
+    expect(scrollRegion.scrollTop).toBe(1400);
+    expect(container.textContent).not.toContain("New activity is available below.");
   });
 });

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- `None`
+- [issue-218-feedback-recovery](./issue-218-feedback-recovery/README.md)
 
 ## Archived Task Packages
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,10 +69,11 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- [issue-218-feedback-recovery](./issue-218-feedback-recovery/README.md)
+- `None`
 
 ## Archived Task Packages
 
+- [issue-218-feedback-recovery](./archive/issue-218-feedback-recovery/README.md)
 - [issue-217-navigation-return-surface](./archive/issue-217-navigation-return-surface/README.md)
 - [issue-216-timeline-chronology](./archive/issue-216-timeline-chronology/README.md)
 - [issue-215-first-input-composer](./archive/issue-215-first-input-composer/README.md)

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-218-feedback-recovery](./issue-218-feedback-recovery/README.md)
 - [issue-217-navigation-return-surface](./issue-217-navigation-return-surface/README.md)
 - [issue-216-timeline-chronology](./issue-216-timeline-chronology/README.md)
 - [issue-215-first-input-composer](./issue-215-first-input-composer/README.md)

--- a/tasks/archive/issue-218-feedback-recovery/README.md
+++ b/tasks/archive/issue-218-feedback-recovery/README.md
@@ -35,14 +35,30 @@
 
 ## Artifacts / evidence
 
-- Planned: focused frontend validation command output in handoff notes.
+- Sprint validation:
+  - `npm run check`: passed
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - `npm test -- chat-view.test.tsx chat-page-client.test.tsx`: passed, 29 tests
+- Dedicated pre-push validation:
+  - `npm run check`: passed
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - focused Vitest: 2 files passed, 29 tests passed
+  - full `npm test`: 11 files passed, 88 tests passed
 
 ## Status / handoff notes
 
-- Status: `started`
+- Status: `locally complete`
 - Active branch: `issue-218-feedback-recovery`
 - Active worktree: `.worktrees/issue-218-feedback-recovery`
-- Notes: Package created from #218 before implementation.
+- Notes: Implemented Thread View feedback/recovery states, supported CTAs, and bounded scroll anchoring with a latest-activity CTA. Evaluator approved after same-row live assistant content growth was added to the scroll-follow trigger.
+- Completion retrospective:
+  - Completion boundary: package archive after local completion and pre-push validation.
+  - Contract check: Issue #218 acceptance criteria are satisfied locally; Issue close still requires PR merge to `main`, parent checkout sync, worktree cleanup, and GitHub tracking update.
+  - What worked: evaluator caught a live-stream scroll anchoring gap that jsdom tests could target directly.
+  - Workflow problems: none requiring durable workflow changes.
+  - Improvements to adopt: scroll anchoring tests should include same-row content growth, not only appended rows.
+  - Skill candidates or skill updates: none required.
+  - Follow-up updates: none required before archive; publish-oriented GitHub handoff remains required.
 
 ## Archive conditions
 

--- a/tasks/issue-218-feedback-recovery/README.md
+++ b/tasks/issue-218-feedback-recovery/README.md
@@ -1,0 +1,49 @@
+# Issue 218 Feedback Recovery
+
+## Purpose
+
+- Execute Issue #218 by making post-action progress, scroll behavior, and degraded-state recovery actions explicit in Thread View.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/218
+
+## Source docs
+
+- `docs/notes/codex_webui_current_ui_gap_analysis_note_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Show clearer post-submit state progression for accepted, opening/connecting, running, completed, or blocked states where current client state supports it.
+- Define bounded scroll anchoring for open, send, live streaming, approval, and recovery without disrupting users reading older context.
+- Add action-oriented CTAs for degraded states where supported by existing actions.
+
+## Exit criteria
+
+- Users can tell whether input was accepted and what the UI is waiting for.
+- New live content is reachable without disruptive scroll jumps.
+- Failure and degraded states show a clear next action in thread context.
+- Focused frontend validation passes for the changed feedback/recovery behavior.
+
+## Work plan
+
+- Inspect `chat-page-client.tsx` and `chat-view.tsx` state/status handling.
+- Implement one bounded feedback/recovery slice from existing state and actions only.
+- Add focused tests for progression text, recovery CTAs, and scroll anchoring behavior where testable.
+- Run targeted frontend validation.
+
+## Artifacts / evidence
+
+- Planned: focused frontend validation command output in handoff notes.
+
+## Status / handoff notes
+
+- Status: `started`
+- Active branch: `issue-218-feedback-recovery`
+- Active worktree: `.worktrees/issue-218-feedback-recovery`
+- Notes: Package created from #218 before implementation.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary

- Add a compact Thread View feedback/recovery card for submit/open/connect/reconnect/running/ready/blocked/degraded states.
- Surface only supported recovery actions from existing UI actions.
- Add bounded Thread View scroll anchoring and a latest-activity CTA when auto-scroll is suppressed.
- Cover same-row live assistant content growth so following latest continues to scroll.

Closes #218

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test -- chat-view.test.tsx chat-page-client.test.tsx`
- `npm test`

Pre-push validation passed with focused feedback/scroll tests and full frontend Vitest suite.