### PR TITLE
feat(ui): add contextual timeline details

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -886,6 +886,19 @@ textarea {
   padding: 10px 12px;
 }
 
+.detail-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.detail-list li + li {
+  margin-top: 6px;
+}
+
+.detail-debug summary {
+  cursor: pointer;
+}
+
 .request-detail-actions {
   margin-top: 2px;
 }

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -7,9 +7,9 @@ import type {
   PublicThreadListItem,
   PublicThreadStreamEvent,
   PublicThreadView,
-  PublicTimelineItem,
 } from "./thread-types";
 import { buildTimelineDisplayModel, type TimelineDisplayRow } from "./timeline-display-model";
+import { getTimelineItemDetail } from "./timeline-item-detail";
 
 export interface ChatViewProps {
   workspaceId: string | null;
@@ -192,10 +192,6 @@ type ThreadFeedbackDescriptor = {
   summary: string;
   actions: ThreadFeedbackAction[];
 };
-
-function timelineItemLabel(item: PublicTimelineItem) {
-  return String(item.payload.content ?? item.payload.summary ?? item.kind);
-}
 
 function timelineRowClass(row: TimelineDisplayRow) {
   return `timeline-row timeline-row-${row.density} timeline-row-${row.role}`;
@@ -554,6 +550,9 @@ export function ChatView({
           (item) => item.timeline_item_id === detailSelection.timelineItemId,
         ) ?? null)
       : null;
+  const selectedTimelineItemDetail = selectedTimelineItem
+    ? getTimelineItemDetail(selectedTimelineItem)
+    : null;
   const timelineModel = buildTimelineDisplayModel({
     timelineItems: selectedThreadView?.timeline.items ?? [],
     streamEvents,
@@ -1221,7 +1220,7 @@ export function ChatView({
                               }
                               type="button"
                             >
-                              Timeline item detail
+                              {row.detailActionLabel ?? "Inspect details"}
                             </button>
                           ) : null}
                         </article>
@@ -1291,7 +1290,7 @@ export function ChatView({
               <h2>
                 {detailSelection.kind === "request_detail"
                   ? "Request detail"
-                  : "Timeline item detail"}
+                  : (selectedTimelineItemDetail?.title ?? "Timeline detail")}
               </h2>
             </header>
 
@@ -1374,15 +1373,48 @@ export function ChatView({
               </div>
             ) : null}
 
-            {detailSelection.kind === "timeline_item_detail" && selectedTimelineItem ? (
+            {detailSelection.kind === "timeline_item_detail" &&
+            selectedTimelineItem &&
+            selectedTimelineItemDetail ? (
               <div className="detail-stack">
                 <p className="workspace-meta">
                   {selectedTimelineItem.kind} at {formatTimestamp(selectedTimelineItem.occurred_at)}
                 </p>
-                <p>{timelineItemLabel(selectedTimelineItem)}</p>
-                <pre className="detail-json">
-                  {JSON.stringify(selectedTimelineItem.payload, null, 2)}
-                </pre>
+                <p>{selectedTimelineItemDetail.summary}</p>
+                {selectedTimelineItemDetail.sections.map((section) => (
+                  <div className="request-operation-summary" key={section.title}>
+                    <strong>{section.title}</strong>
+                    <ul className="detail-list">
+                      {section.items.map((entry) => (
+                        <li key={entry}>{section.code ? <code>{entry}</code> : entry}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+                {selectedTimelineItemDetail.fields.length > 0 ? (
+                  <dl className="request-detail-list">
+                    {selectedTimelineItemDetail.fields.map((field) => (
+                      <div key={`${field.label}:${field.value}`}>
+                        <dt>{field.label}</dt>
+                        <dd>
+                          {field.href ? (
+                            <a href={field.href} rel="noreferrer" target="_blank">
+                              {field.value}
+                            </a>
+                          ) : (
+                            field.value
+                          )}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                ) : null}
+                <details className="detail-debug">
+                  <summary>Debug: raw timeline payload JSON</summary>
+                  <pre className="detail-json">
+                    {JSON.stringify(selectedTimelineItem.payload, null, 2)}
+                  </pre>
+                </details>
               </div>
             ) : null}
           </aside>

--- a/apps/frontend-bff/src/timeline-display-model.ts
+++ b/apps/frontend-bff/src/timeline-display-model.ts
@@ -1,4 +1,5 @@
 import type { PublicThreadStreamEvent, PublicTimelineItem } from "./thread-types";
+import { getTimelineItemDetail } from "./timeline-item-detail";
 
 export type TimelineRowDensity = "primary" | "prominent" | "compact";
 
@@ -16,6 +17,7 @@ export interface TimelineDisplayRow {
   timelineItemId: string | null;
   isLive: boolean;
   showDetailButton: boolean;
+  detailActionLabel: string | null;
 }
 
 export interface TimelineDisplayGroup {
@@ -194,24 +196,27 @@ function shouldHideRow(kind: string, content: string, payload: Record<string, un
   return false;
 }
 
-function shouldShowDetailButton(
-  kind: string,
-  role: TimelineRowRole,
-  timelineItemId: string | null,
-) {
-  if (!timelineItemId) {
-    return false;
+function timelineRowDetail(item: PublicTimelineItem, role: TimelineRowRole) {
+  if (!item.timeline_item_id || role !== "event" || item.kind === "session.status_changed") {
+    return {
+      showDetailButton: false,
+      detailActionLabel: null,
+    };
   }
 
-  if (role !== "event") {
-    return false;
-  }
+  const detail = getTimelineItemDetail(item);
 
-  if (kind === "session.status_changed") {
-    return false;
-  }
+  return {
+    showDetailButton: detail.hasContext,
+    detailActionLabel: detail.hasContext ? detail.actionLabel : null,
+  };
+}
 
-  return true;
+function streamRowDetail() {
+  return {
+    showDetailButton: false,
+    detailActionLabel: null,
+  };
 }
 
 export function classifyTimelineDensity(kind: string): TimelineRowDensity {
@@ -411,7 +416,7 @@ export function buildTimelineDisplayModel({
       role,
       timelineItemId: item.timeline_item_id,
       isLive: false,
-      showDetailButton: shouldShowDetailButton(item.kind, role, item.timeline_item_id),
+      ...timelineRowDetail(item, role),
     });
   }
 
@@ -513,6 +518,7 @@ export function buildTimelineDisplayModel({
       timelineItemId: null,
       isLive: !isCompleted,
       showDetailButton: false,
+      detailActionLabel: null,
     });
   }
 
@@ -535,6 +541,7 @@ export function buildTimelineDisplayModel({
       timelineItemId: group.timelineItemId,
       isLive: !isCompleted,
       showDetailButton: false,
+      detailActionLabel: null,
     });
   }
 
@@ -555,6 +562,7 @@ export function buildTimelineDisplayModel({
       timelineItemId: null,
       isLive: true,
       showDetailButton: false,
+      detailActionLabel: null,
     });
   }
 
@@ -587,7 +595,7 @@ export function buildTimelineDisplayModel({
       role,
       timelineItemId: null,
       isLive: false,
-      showDetailButton: false,
+      ...streamRowDetail(),
     });
   }
 

--- a/apps/frontend-bff/src/timeline-item-detail.ts
+++ b/apps/frontend-bff/src/timeline-item-detail.ts
@@ -1,0 +1,243 @@
+import type { PublicTimelineItem } from "./thread-types";
+
+export interface TimelineDetailEntry {
+  label: string;
+  value: string;
+  href?: string;
+}
+
+export interface TimelineDetailSection {
+  title: string;
+  items: string[];
+  code?: boolean;
+}
+
+export interface TimelineItemDetail {
+  actionLabel: string;
+  title: string;
+  summary: string | null;
+  sections: TimelineDetailSection[];
+  fields: TimelineDetailEntry[];
+  hasContext: boolean;
+}
+
+const COMMAND_KEYS = ["command", "commands", "command_line", "command_lines", "cmd", "argv"];
+const FILE_KEYS = [
+  "file",
+  "files",
+  "path",
+  "paths",
+  "file_path",
+  "file_paths",
+  "changed_files",
+  "touched_files",
+  "modified_files",
+  "created_files",
+  "deleted_files",
+];
+const TEST_KEYS = ["test", "tests", "test_path", "test_paths", "test_file", "test_files"];
+const DIFF_KEYS = ["diff", "diffs", "patch", "patches", "diff_excerpt", "diff_summary"];
+const OUTPUT_KEYS = [
+  "output",
+  "outputs",
+  "generated_output",
+  "generated_outputs",
+  "artifact",
+  "artifacts",
+  "result",
+  "results",
+];
+const ISSUE_PR_LINK_KEYS = [
+  "issue_url",
+  "issue_urls",
+  "pr_url",
+  "pr_urls",
+  "pull_request_url",
+  "pull_request_urls",
+];
+const REQUEST_ID_KEYS = ["request_id", "request_ids"];
+const ERROR_KEYS = ["error", "errors", "stderr", "failure_reason", "failure", "exception"];
+const OPERATION_KEYS = ["operation", "operations", "operation_summary"];
+const TARGET_KEYS = ["target", "targets"];
+const CONSEQUENCE_KEYS = ["consequence", "consequences"];
+
+function asNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function flattenStrings(value: unknown, seen = new Set<unknown>()): string[] {
+  if (value === null || value === undefined || seen.has(value)) {
+    return [];
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return [String(value)];
+  }
+
+  if (Array.isArray(value)) {
+    seen.add(value);
+    return value.flatMap((entry) => flattenStrings(entry, seen));
+  }
+
+  if (typeof value === "object") {
+    seen.add(value);
+    return Object.values(value).flatMap((entry) => flattenStrings(entry, seen));
+  }
+
+  return [];
+}
+
+function collectItems(payload: Record<string, unknown>, keys: string[]) {
+  const items = keys.flatMap((key) => flattenStrings(payload[key]));
+  return Array.from(new Set(items));
+}
+
+function findFirstString(payload: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = asNonEmptyString(payload[key]);
+    if (value) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function firstIssueOrPrLink(payload: Record<string, unknown>) {
+  const explicit = collectItems(payload, ISSUE_PR_LINK_KEYS);
+  if (explicit.length > 0) {
+    return explicit[0];
+  }
+
+  const generic = flattenStrings(payload.url);
+  return generic.find((item) => /\/(issues|pull)\//.test(item)) ?? null;
+}
+
+function dedupeEntries(entries: TimelineDetailEntry[]) {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    const key = `${entry.label}:${entry.value}:${entry.href ?? ""}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function detailActionLabel(kind: string, payload: Record<string, unknown>) {
+  if (
+    kind.includes("error") ||
+    kind.includes("failed") ||
+    collectItems(payload, ERROR_KEYS).length > 0
+  ) {
+    return "Inspect failure";
+  }
+
+  if (
+    kind.includes("approval") ||
+    kind.includes("request") ||
+    collectItems(payload, REQUEST_ID_KEYS).length > 0
+  ) {
+    return "Inspect request";
+  }
+
+  if (kind.includes("command") || kind.includes("tool") || kind.includes("file")) {
+    return "Inspect artifacts";
+  }
+
+  return "Inspect details";
+}
+
+function detailTitle(actionLabel: string) {
+  switch (actionLabel) {
+    case "Inspect request":
+      return "Request detail";
+    case "Inspect failure":
+      return "Failure detail";
+    case "Inspect artifacts":
+      return "Artifact detail";
+    default:
+      return "Timeline detail";
+  }
+}
+
+export function getTimelineItemDetail(item: PublicTimelineItem): TimelineItemDetail {
+  const summary =
+    findFirstString(item.payload, ["summary", "content", "message", "delta"]) ?? item.kind;
+  const commands = collectItems(item.payload, COMMAND_KEYS);
+  const filePaths = collectItems(item.payload, FILE_KEYS);
+  const tests = collectItems(item.payload, TEST_KEYS);
+  const diffs = collectItems(item.payload, DIFF_KEYS);
+  const outputs = collectItems(item.payload, OUTPUT_KEYS);
+  const requestIds = collectItems(item.payload, REQUEST_ID_KEYS);
+  const errors = collectItems(item.payload, ERROR_KEYS);
+  const operations = collectItems(item.payload, OPERATION_KEYS);
+  const targets = collectItems(item.payload, TARGET_KEYS);
+  const consequences = collectItems(item.payload, CONSEQUENCE_KEYS);
+  const issueOrPrLink = firstIssueOrPrLink(item.payload);
+
+  const sections: TimelineDetailSection[] = [];
+  if (commands.length > 0) {
+    sections.push({ title: "Commands", items: commands, code: true });
+  }
+  if (filePaths.length > 0) {
+    sections.push({ title: "Files", items: filePaths, code: true });
+  }
+  if (tests.length > 0) {
+    sections.push({ title: "Tests", items: tests, code: true });
+  }
+  if (diffs.length > 0) {
+    sections.push({ title: "Diffs", items: diffs, code: true });
+  }
+  if (outputs.length > 0) {
+    sections.push({ title: "Generated outputs", items: outputs });
+  }
+  if (errors.length > 0) {
+    sections.push({ title: "Errors", items: errors });
+  }
+
+  const fields = dedupeEntries(
+    [
+      ...requestIds.map((value) => ({ label: "Request ID", value })),
+      ...operations.map((value) => ({ label: "Operation", value })),
+      ...targets.map((value) => ({ label: "Target", value })),
+      ...consequences.map((value) => ({ label: "Consequence", value })),
+      ...(issueOrPrLink
+        ? [
+            {
+              label: /\/pull\//.test(issueOrPrLink) ? "Pull request" : "Issue",
+              value: issueOrPrLink,
+              href: issueOrPrLink,
+            },
+          ]
+        : []),
+    ].filter((entry) => entry.value.length > 0),
+  );
+
+  const actionLabel = detailActionLabel(item.kind, item.payload);
+  const structuralSignal =
+    sections.length > 0 ||
+    fields.length > 0 ||
+    item.kind.includes("approval") ||
+    item.kind.includes("request") ||
+    item.kind.includes("error") ||
+    item.kind.includes("failed") ||
+    item.kind.includes("command") ||
+    item.kind.includes("tool") ||
+    item.kind.includes("file");
+
+  return {
+    actionLabel,
+    title: detailTitle(actionLabel),
+    summary,
+    sections,
+    fields,
+    hasContext: structuralSignal,
+  };
+}

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -639,7 +639,8 @@ describe("ChatView", () => {
     expect(markup).toContain("timeline-row-prominent");
     expect(markup).toContain("Status update");
     expect(markup).toContain("timeline-row-compact");
-    expect(markup.match(/Timeline item detail/g) ?? []).toHaveLength(1);
+    expect(markup).toContain("Inspect artifacts");
+    expect(markup).not.toContain("Timeline item detail");
     expect(markup).not.toContain("approval.requested");
     expect(markup).not.toContain("session.status_changed");
     expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
@@ -692,6 +693,123 @@ describe("ChatView", () => {
     expect(markup).toContain("Failed to interrupt the thread.");
     expect(markup.indexOf("chat-feedback-stack")).toBeLessThan(
       markup.indexOf("chat-panel create-card"),
+    );
+  });
+
+  it("renders structured timeline detail before collapsed debug JSON", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={null}
+          connectionState="idle"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_001"
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Failure thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "idle",
+                active_flags: [],
+                latest_turn_status: "failed",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+            },
+            current_activity: {
+              kind: "latest_turn_failed",
+              label: "Latest turn failed",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: true,
+              interrupt_available: false,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [
+                {
+                  timeline_item_id: "evt_failure_001",
+                  thread_id: "thread_001",
+                  turn_id: "turn_001",
+                  item_id: "item_failure_001",
+                  sequence: 1,
+                  occurred_at: "2026-03-27T05:15:00Z",
+                  kind: "turn.failed",
+                  payload: {
+                    summary: "Tests failed after the patch",
+                    command: "npm run check",
+                    file_paths: ["apps/frontend-bff/src/chat-view.tsx"],
+                    tests: ["tests/chat-view.test.tsx"],
+                    diff: "diff --git a/apps/frontend-bff/src/chat-view.tsx b/apps/frontend-bff/src/chat-view.tsx",
+                    request_id: "req_failure_001",
+                    output: "artifacts/visual-inspection/issue-219-failure.txt",
+                    operation: "Validate timeline detail surface",
+                    target: "Issue #219",
+                    consequence: "Turn halted until review",
+                    error: "Expected contextual detail button",
+                  },
+                },
+              ],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[]}
+        />,
+      );
+    });
+
+    const inspectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Inspect failure",
+    );
+    expect(inspectButton).not.toBeUndefined();
+
+    await act(async () => {
+      inspectButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Failure detail");
+    expect(container.textContent).toContain("Commands");
+    expect(container.textContent).toContain("apps/frontend-bff/src/chat-view.tsx");
+    expect(container.textContent).toContain("tests/chat-view.test.tsx");
+    expect(container.textContent).toContain("Request ID");
+    expect(container.textContent).toContain("Debug: raw timeline payload JSON");
+
+    const debugDetails = container.querySelector("details.detail-debug");
+    expect(debugDetails).not.toBeNull();
+    expect(debugDetails?.hasAttribute("open")).toBe(false);
+    expect(container.innerHTML.indexOf("Commands")).toBeLessThan(
+      container.innerHTML.indexOf("Debug: raw timeline payload JSON"),
     );
   });
 

--- a/apps/frontend-bff/tests/timeline-display-model.test.ts
+++ b/apps/frontend-bff/tests/timeline-display-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { PublicThreadStreamEvent, PublicTimelineItem } from "../src/thread-types";
 import { buildTimelineDisplayModel, classifyTimelineDensity } from "../src/timeline-display-model";
+import { getTimelineItemDetail } from "../src/timeline-item-detail";
 
 function timelineItem(overrides: Partial<PublicTimelineItem>): PublicTimelineItem {
   return {
@@ -546,12 +547,20 @@ describe("timeline display model", () => {
             summary: "Updated src/app.ts",
           },
         }),
+        timelineItem({
+          timeline_item_id: "note_001",
+          sequence: 3,
+          kind: "thread.note",
+          payload: {
+            summary: "Saved progress",
+          },
+        }),
       ],
       streamEvents: [
         streamEvent({
           event_id: "status_001",
           event_type: "session.status_changed",
-          sequence: 3,
+          sequence: 4,
           payload: {
             summary: "Running tool",
           },
@@ -570,6 +579,13 @@ describe("timeline display model", () => {
         id: "timeline:file_001",
         label: "File update",
         showDetailButton: true,
+        detailActionLabel: "Inspect artifacts",
+      }),
+      expect.objectContaining({
+        id: "timeline:note_001",
+        label: "Thread update",
+        showDetailButton: false,
+        detailActionLabel: null,
       }),
       expect.objectContaining({
         id: "stream:status_001",
@@ -617,5 +633,78 @@ describe("timeline display model", () => {
       "Request needs attention",
       "Turn failed",
     ]);
+  });
+
+  it("extracts contextual artifacts and operational fields from timeline payloads", () => {
+    const detail = getTimelineItemDetail(
+      timelineItem({
+        kind: "approval.requested",
+        payload: {
+          summary: "Run release flow",
+          request_id: "req_219",
+          command: "npm run build",
+          file_paths: ["apps/frontend-bff/src/chat-view.tsx"],
+          tests: ["node ./node_modules/vitest/vitest.mjs run tests/chat-view.test.tsx"],
+          diff: "diff --git a/src/chat-view.tsx b/src/chat-view.tsx",
+          issue_url: "https://github.com/example/repo/issues/219",
+          generated_outputs: ["artifacts/visual-inspection/issue-219.png"],
+          operation_summary: "Create release candidate",
+          target: "Issue #219 detail surface",
+          consequence: "Approval required before publish",
+        },
+      }),
+    );
+
+    expect(detail.actionLabel).toBe("Inspect request");
+    expect(detail.hasContext).toBe(true);
+    expect(detail.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Commands",
+          items: ["npm run build"],
+        }),
+        expect.objectContaining({
+          title: "Files",
+          items: ["apps/frontend-bff/src/chat-view.tsx"],
+        }),
+        expect.objectContaining({
+          title: "Tests",
+          items: ["node ./node_modules/vitest/vitest.mjs run tests/chat-view.test.tsx"],
+        }),
+        expect.objectContaining({
+          title: "Diffs",
+          items: ["diff --git a/src/chat-view.tsx b/src/chat-view.tsx"],
+        }),
+        expect.objectContaining({
+          title: "Generated outputs",
+          items: ["artifacts/visual-inspection/issue-219.png"],
+        }),
+      ]),
+    );
+    expect(detail.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Request ID",
+          value: "req_219",
+        }),
+        expect.objectContaining({
+          label: "Issue",
+          value: "https://github.com/example/repo/issues/219",
+          href: "https://github.com/example/repo/issues/219",
+        }),
+        expect.objectContaining({
+          label: "Operation",
+          value: "Create release candidate",
+        }),
+        expect.objectContaining({
+          label: "Target",
+          value: "Issue #219 detail surface",
+        }),
+        expect.objectContaining({
+          label: "Consequence",
+          value: "Approval required before publish",
+        }),
+      ]),
+    );
   });
 });

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,10 +69,11 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- [issue-219-contextual-details](./issue-219-contextual-details/README.md)
+- `None`
 
 ## Archived Task Packages
 
+- [issue-219-contextual-details](./archive/issue-219-contextual-details/README.md)
 - [issue-218-feedback-recovery](./archive/issue-218-feedback-recovery/README.md)
 - [issue-217-navigation-return-surface](./archive/issue-217-navigation-return-surface/README.md)
 - [issue-216-timeline-chronology](./archive/issue-216-timeline-chronology/README.md)

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- `None`
+- [issue-219-contextual-details](./issue-219-contextual-details/README.md)
 
 ## Archived Task Packages
 

--- a/tasks/archive/issue-219-contextual-details/README.md
+++ b/tasks/archive/issue-219-contextual-details/README.md
@@ -50,6 +50,14 @@
 - Active branch: `issue-219-contextual-details`
 - Active worktree: `.worktrees/issue-219-contextual-details`
 - Notes: Implemented contextual timeline detail inspection for stored event rows. Detail actions are gated by extracted contextual signals, visible action labels are contextual, structured artifact/operation sections render before raw debug data, and raw payload JSON is available only behind a collapsed debug affordance. Keep #220 mobile density, #221 visual language, and #222 broader validation out of this slice except for tests directly covering #219 behavior.
+- Completion retrospective:
+  - Completion boundary: package archive after local completion, evaluator approval, and pre-push validation.
+  - Contract check: Issue #219 acceptance criteria are satisfied locally; Issue close still requires PR merge to `main`, parent checkout sync, worktree cleanup, and GitHub tracking update.
+  - What worked: planner's bounded slice kept this focused on contextual inspection and avoided pulling in #220/#221 polish concerns.
+  - Workflow problems: initial work-package handoff was interrupted before mutation and had to be rerun from verified clean state; no durable workflow change needed.
+  - Improvements to adopt: artifact inspection tests should assert both contextual labels and collapsed raw debug payload behavior.
+  - Skill candidates or skill updates: none required.
+  - Follow-up updates: none required before archive; publish-oriented GitHub handoff remains required.
 
 ## Archive conditions
 

--- a/tasks/issue-219-contextual-details/README.md
+++ b/tasks/issue-219-contextual-details/README.md
@@ -1,0 +1,55 @@
+# Issue 219 Contextual Details
+
+## Purpose
+
+- Execute Issue #219 by replacing generic timeline detail affordances with contextual inspection for task artifacts and operational risk.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/219
+
+## Source docs
+
+- `docs/notes/codex_webui_current_ui_gap_analysis_note_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Reserve visible detail actions for timeline rows with meaningful contextual content.
+- Keep raw payload inspection behind an explicit debug affordance.
+- Extract available commands, file paths, tests, diffs, request IDs, issue/PR links, and generated outputs into scannable detail content.
+- Improve approval, error, failure, and request detail layouts around operation, target, consequence, and supporting artifacts.
+
+## Exit criteria
+
+- Detail Surface is useful for selected-item inspection without being required for basic notification.
+- Timeline rows use contextual detail actions instead of a full-width generic detail button on every item.
+- Coding artifacts are visible as first-class content rather than buried in prose or raw JSON.
+- Focused frontend validation passes for contextual detail rendering and timeline action gating.
+
+## Work plan
+
+- Inspect current `chat-view.tsx` timeline/detail rendering and display-model detail action metadata.
+- Define a small artifact extraction helper from existing row payload, summary, and content fields.
+- Render contextual detail sections and debug payload access without changing public API contracts.
+- Add focused tests for detail action visibility, artifact extraction, and debug payload gating.
+- Run targeted frontend validation before pre-push validation.
+
+## Artifacts / evidence
+
+- Planned validation:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - focused Vitest for changed detail/timeline behavior
+
+## Status / handoff notes
+
+- Status: `in progress`
+- Active branch: `issue-219-contextual-details`
+- Active worktree: `.worktrees/issue-219-contextual-details`
+- Notes: Started from `origin/main` after #218 reached main. Keep #220 mobile density, #221 visual language, and #222 broader validation out of this slice except for tests directly covering #219 behavior.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.

--- a/tasks/issue-219-contextual-details/README.md
+++ b/tasks/issue-219-contextual-details/README.md
@@ -38,17 +38,18 @@
 
 ## Artifacts / evidence
 
-- Planned validation:
-  - `npm run check`
-  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
-  - focused Vitest for changed detail/timeline behavior
+- Sprint validation:
+  - `npm run check`: passed
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - `node ./node_modules/vitest/vitest.mjs run tests/timeline-display-model.test.ts tests/chat-view.test.tsx tests/chat-page-client.test.tsx`: passed, 3 files / 47 tests
+- Sprint evaluator: approved
 
 ## Status / handoff notes
 
-- Status: `in progress`
+- Status: `locally complete pending pre-push validation`
 - Active branch: `issue-219-contextual-details`
 - Active worktree: `.worktrees/issue-219-contextual-details`
-- Notes: Started from `origin/main` after #218 reached main. Keep #220 mobile density, #221 visual language, and #222 broader validation out of this slice except for tests directly covering #219 behavior.
+- Notes: Implemented contextual timeline detail inspection for stored event rows. Detail actions are gated by extracted contextual signals, visible action labels are contextual, structured artifact/operation sections render before raw debug data, and raw payload JSON is available only behind a collapsed debug affordance. Keep #220 mobile density, #221 visual language, and #222 broader validation out of this slice except for tests directly covering #219 behavior.
 
 ## Archive conditions
 


### PR DESCRIPTION
## Summary

- add contextual timeline detail extraction for commands, files, tests, diffs, request IDs, links, outputs, and operation fields
- gate timeline detail actions to rows with meaningful inspection content and replace generic action copy
- render structured detail sections before collapsed debug payload JSON
- archive the #219 task package after pre-push validation

Closes #219

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `node ./node_modules/vitest/vitest.mjs run tests/timeline-display-model.test.ts tests/chat-view.test.tsx tests/chat-page-client.test.tsx`
- `npm test`