### PR TITLE
feat(ui): improve mobile thread reachability

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -1031,7 +1031,7 @@ textarea {
 
   .thread-view-card {
     display: grid;
-    gap: 12px;
+    gap: 8px;
     grid-template-rows: auto minmax(0, 1fr);
     height: 100%;
     min-height: 0;
@@ -1039,29 +1039,30 @@ textarea {
   }
 
   .thread-view-header-stack {
-    gap: 12px;
+    gap: 8px;
     min-height: 0;
   }
 
   .thread-view-body {
-    gap: 12px;
-    grid-template-rows: minmax(0, 1fr) auto;
+    gap: 8px;
+    grid-template-rows: minmax(0, 1fr) auto auto;
     height: 100%;
     min-height: 0;
     overflow: hidden;
   }
 
   .thread-view-scroll-region {
-    gap: 12px;
+    gap: 10px;
     min-height: 0;
     overflow: auto;
     overscroll-behavior: contain;
+    scroll-padding-top: 112px;
   }
 
   .workspace-card,
   .create-card {
     border-radius: 18px;
-    padding: 14px;
+    padding: 10px;
   }
 
   .workspace-card header,
@@ -1081,8 +1082,9 @@ textarea {
 
   .metric-chip,
   .status-badge {
-    padding: 6px 10px;
-    font-size: 0.82rem;
+    padding: 4px 7px;
+    font-size: 0.75rem;
+    line-height: 1.2;
   }
 
   .thread-context-metrics {
@@ -1100,11 +1102,15 @@ textarea {
   .request-detail-card,
   .chat-composer {
     border-radius: 16px;
-    padding: 12px;
+    padding: 8px;
   }
 
   .pending-request-card {
-    gap: 10px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    gap: 8px;
+    box-shadow: 0 10px 18px rgba(42, 25, 9, 0.08);
   }
 
   .pending-request-card .workspace-actions,
@@ -1135,39 +1141,64 @@ textarea {
   .latest-activity-cta {
     align-items: stretch;
     border-radius: 16px;
-    padding: 10px;
+    padding: 7px 9px;
   }
 
   .timeline-section {
-    gap: 10px;
+    gap: 8px;
   }
 
   .timeline-turn-group {
-    padding-left: 9px;
+    gap: 6px;
+    padding-left: 8px;
+  }
+
+  .timeline-turn-label {
+    gap: 6px;
   }
 
   .timeline-row {
-    border-radius: 13px;
-    padding: 11px 12px;
+    gap: 6px;
+    border-radius: 12px;
+    padding: 8px 9px;
   }
 
   .timeline-row-primary {
-    padding: 13px;
+    padding: 9px 10px;
   }
 
   .timeline-row-compact {
-    padding: 8px 10px;
+    padding: 6px 8px;
+  }
+
+  .timeline-row-primary p,
+  .timeline-row-compact p,
+  .timeline-row .workspace-meta-row {
+    line-height: 1.35;
+  }
+
+  .thread-mobile-footer-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 6px;
+    flex-shrink: 0;
   }
 
   .chat-textarea {
-    min-height: 96px;
+    min-height: 56px;
     border-radius: 14px;
   }
 
   .chat-composer {
-    margin: 0 -2px calc(env(safe-area-inset-bottom) + 2px);
+    gap: 8px;
+    margin: 0;
     flex-shrink: 0;
-    padding-bottom: calc(12px + env(safe-area-inset-bottom));
+    padding-bottom: calc(8px + env(safe-area-inset-bottom));
+  }
+
+  .composer-guidance {
+    font-size: 0.86rem;
+    line-height: 1.3;
   }
 
   .primary-link,
@@ -1175,7 +1206,7 @@ textarea {
   .submit-button {
     max-width: 100%;
     white-space: normal;
-    padding: 10px 12px;
+    padding: 7px 9px;
     border-radius: 14px;
     line-height: 1.2;
     text-align: center;
@@ -1184,6 +1215,12 @@ textarea {
   .thread-filter-chip {
     justify-content: space-between;
     width: calc(50% - 4px);
+  }
+
+  .thread-feedback-actions,
+  .pending-request-card .workspace-actions,
+  .request-detail-actions {
+    gap: 6px;
   }
 }
 
@@ -1211,6 +1248,10 @@ textarea {
   }
 
   .navigation-toggle {
+    display: none;
+  }
+
+  .thread-mobile-footer-actions {
     display: none;
   }
 

--- a/apps/frontend-bff/e2e/issue-220-mobile-thread-density.spec.ts
+++ b/apps/frontend-bff/e2e/issue-220-mobile-thread-density.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  expectNoHorizontalScroll,
+  mockApprovalFlow,
+  stubEventSource,
+} from "./helpers/browser-mocks";
+
+async function expectNoDocumentVerticalScroll(page: Parameters<typeof test>[0]["page"]) {
+  return page.evaluate(() => {
+    const scrollingElement = document.scrollingElement ?? document.documentElement;
+    return scrollingElement.scrollHeight <= window.innerHeight + 1;
+  });
+}
+
+async function collectOverflowingLabels(page: Parameters<typeof test>[0]["page"]) {
+  return page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll<HTMLElement>(
+        ".thread-view-card .status-badge, .thread-view-card .metric-chip, .thread-view-card button",
+      ),
+    )
+      .filter((element) => element.scrollWidth > element.clientWidth + 1)
+      .map((element) => element.textContent?.trim() ?? ""),
+  );
+}
+
+test("keeps selected pending-approval mobile thread dense and reachable at 360px", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 360, height: 780 });
+  await stubEventSource(page);
+  await mockApprovalFlow(page, { longTimeline: true });
+
+  await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
+
+  const scrollRegion = page.locator(".thread-view-scroll-region");
+  const pendingCard = page.locator(".pending-request-card");
+  const composer = page.locator(".chat-composer");
+  const composerInput = page.locator("#thread-composer-input");
+  const composerSubmitButton = composer.locator(".submit-button");
+  const mobileActions = page.locator(".thread-mobile-footer-actions");
+  const footerThreadsButton = mobileActions.getByRole("button", { name: "Threads" });
+  const footerDetailsButton = mobileActions.getByRole("button", { name: "Details" });
+
+  await expect(page.locator(".thread-view-card > .thread-view-header-stack header h2")).toHaveText(
+    "Ask Codex in alpha",
+  );
+  await expect(page.getByText("Apply the prepared deployment plan.")).toBeVisible();
+  await expect(pendingCard.getByRole("button", { name: "Approve request" })).toBeVisible();
+  await expect(scrollRegion).toBeVisible();
+  await expect(composer).toBeVisible();
+  await expect(composerInput).toBeVisible();
+  await expect(composerSubmitButton).toBeVisible();
+  await expect(mobileActions).toBeVisible();
+  await expect(footerThreadsButton).toBeVisible();
+  await expect(footerDetailsButton).toBeVisible();
+
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+  await expect.poll(async () => expectNoDocumentVerticalScroll(page)).toBe(true);
+  await expect.poll(async () => collectOverflowingLabels(page)).toEqual([]);
+
+  const initialLayout = await page.evaluate(() => {
+    const mobileActionsElement = document.querySelector<HTMLElement>(
+      ".thread-mobile-footer-actions",
+    );
+    const composerElement = document.querySelector<HTMLElement>(".chat-composer");
+    const mobileActionsRect = mobileActionsElement?.getBoundingClientRect() ?? null;
+    const composerRect = composerElement?.getBoundingClientRect() ?? null;
+    return {
+      footerVisible:
+        mobileActionsRect !== null &&
+        mobileActionsRect.top >= 0 &&
+        mobileActionsRect.bottom <= window.innerHeight,
+      noOverlap:
+        composerRect !== null &&
+        mobileActionsRect !== null &&
+        mobileActionsRect.bottom <= composerRect.top + 1,
+    };
+  });
+
+  expect(initialLayout).toEqual({
+    footerVisible: true,
+    noOverlap: true,
+  });
+
+  await scrollRegion.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+
+  await expect
+    .poll(async () =>
+      scrollRegion.evaluate((element) => ({
+        clientHeight: element.clientHeight,
+        scrollHeight: element.scrollHeight,
+        scrollTop: element.scrollTop,
+      })),
+    )
+    .toMatchObject({
+      clientHeight: expect.any(Number),
+      scrollHeight: expect.any(Number),
+      scrollTop: expect.any(Number),
+    });
+
+  const afterScroll = await page.evaluate(() => {
+    const scrollRegionElement = document.querySelector<HTMLElement>(".thread-view-scroll-region");
+    const footerThreadsElement = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".thread-mobile-footer-actions button"),
+    ).find((button) => button.textContent?.trim() === "Threads");
+    const footerDetailsElement = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".thread-mobile-footer-actions button"),
+    ).find((button) => button.textContent?.trim() === "Details");
+    const footerThreadsRect = footerThreadsElement?.getBoundingClientRect() ?? null;
+    const footerDetailsRect = footerDetailsElement?.getBoundingClientRect() ?? null;
+
+    return {
+      scrollMoved:
+        scrollRegionElement !== null &&
+        scrollRegionElement.scrollTop > scrollRegionElement.clientHeight * 0.25,
+      footerThreadsVisible:
+        footerThreadsRect !== null &&
+        footerThreadsRect.top >= 0 &&
+        footerThreadsRect.bottom <= window.innerHeight,
+      footerDetailsVisible:
+        footerDetailsRect !== null &&
+        footerDetailsRect.top >= 0 &&
+        footerDetailsRect.bottom <= window.innerHeight,
+    };
+  });
+
+  await expect(pendingCard.getByRole("button", { name: "Approve request" })).toBeVisible();
+  await expect(pendingCard.getByRole("button", { name: "Deny request" })).toBeVisible();
+  await expect(composerInput).toBeVisible();
+  await expect(composerSubmitButton).toBeVisible();
+
+  expect(afterScroll).toEqual({
+    scrollMoved: true,
+    footerThreadsVisible: true,
+    footerDetailsVisible: true,
+  });
+
+  await footerDetailsButton.click();
+  await expect(page.locator(".thread-detail-surface")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Request detail" })).toBeVisible();
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(page.locator(".thread-detail-surface")).toHaveCount(0);
+
+  await footerThreadsButton.click();
+  await expect(page.locator(".thread-navigation.open")).toBeVisible();
+});

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -558,6 +558,7 @@ export function ChatView({
     streamEvents,
     draftAssistantMessages,
   });
+  const hasRequestDetailAffordance = selectedRequestDetail !== null;
   const latestTimelineGroup = timelineModel.groups[timelineModel.groups.length - 1] ?? null;
   const latestTimelineRow = latestTimelineGroup?.rows[latestTimelineGroup.rows.length - 1] ?? null;
   const latestActivitySignature = selectedThreadId
@@ -1229,6 +1230,24 @@ export function ChatView({
                   ))}
                 </div>
               </section>
+            </div>
+
+            <div className="thread-mobile-footer-actions">
+              <button
+                className="secondary-link action-button compact-button"
+                onClick={() => setIsNavigationOpen(true)}
+                type="button"
+              >
+                Threads
+              </button>
+              <button
+                className="secondary-link action-button compact-button"
+                disabled={!hasRequestDetailAffordance}
+                onClick={() => setDetailSelection({ kind: "request_detail" })}
+                type="button"
+              >
+                Details
+              </button>
             </div>
 
             <div className="chat-composer" data-composer-mode={isStartingThread ? "start" : "send"}>

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -629,6 +629,8 @@ describe("ChatView", () => {
       "Codex is blocked until you approve or deny the pending request in this thread.",
     );
     expect(markup).toContain("Approve request");
+    expect(markup).toContain(">Threads<");
+    expect(markup).toContain(">Details<");
     expect(markup).toContain("Input is paused while this thread waits for your approval response.");
     expect(markup).toContain("Operation: git push origin main");
     expect(markup).toContain("Interrupt thread");

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,10 +69,11 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- [issue-220-mobile-thread-density](./issue-220-mobile-thread-density/README.md)
+- `None`
 
 ## Archived Task Packages
 
+- [issue-220-mobile-thread-density](./archive/issue-220-mobile-thread-density/README.md)
 - [issue-219-contextual-details](./archive/issue-219-contextual-details/README.md)
 - [issue-218-feedback-recovery](./archive/issue-218-feedback-recovery/README.md)
 - [issue-217-navigation-return-surface](./archive/issue-217-navigation-return-surface/README.md)

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- `None`
+- [issue-220-mobile-thread-density](./issue-220-mobile-thread-density/README.md)
 
 ## Archived Task Packages
 

--- a/tasks/archive/issue-220-mobile-thread-density/README.md
+++ b/tasks/archive/issue-220-mobile-thread-density/README.md
@@ -50,6 +50,14 @@
 - Active branch: `issue-220-mobile-thread-density`
 - Active worktree: `.worktrees/issue-220-mobile-thread-density`
 - Notes: Implemented mobile-only selected-thread density changes, sticky pending approval reachability, bottom Threads/Details affordances, and focused 360x780 Playwright coverage. Keep #221 visual language and #222 broad validation out of this package.
+- Completion retrospective:
+  - Completion boundary: package archive after local completion, evaluator approval, and pre-push validation.
+  - Contract check: Issue #220 acceptance criteria are satisfied locally; Issue close still requires PR merge to `main`, parent checkout sync, worktree cleanup, and GitHub tracking update.
+  - What worked: the focused Playwright spec directly exercised the 360x780 mobile state and caught layout/reachability acceptance criteria in one place.
+  - Workflow problems: evaluator first returned a nonstandard output shape; strict retry produced the required gate shape without code changes.
+  - Improvements to adopt: mobile layout slices should include viewport metrics for horizontal scroll, document scroll, visible composer, and reachable critical actions.
+  - Skill candidates or skill updates: none required.
+  - Follow-up updates: none required before archive; publish-oriented GitHub handoff remains required.
 
 ## Archive conditions
 

--- a/tasks/issue-220-mobile-thread-density/README.md
+++ b/tasks/issue-220-mobile-thread-density/README.md
@@ -37,17 +37,19 @@
 
 ## Artifacts / evidence
 
-- Planned validation:
-  - `npm run check`
-  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
-  - focused Vitest for chat view behavior
+- Sprint validation:
+  - `npm run check`: passed
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - `node ./node_modules/vitest/vitest.mjs run tests/chat-view.test.tsx`: passed, 12 tests
+  - `node ./node_modules/@playwright/test/cli.js test e2e/issue-220-mobile-thread-density.spec.ts --project=mobile-chromium`: passed, 1 test
+- Sprint evaluator: approved
 
 ## Status / handoff notes
 
-- Status: `in progress`
+- Status: `locally complete pending pre-push validation`
 - Active branch: `issue-220-mobile-thread-density`
 - Active worktree: `.worktrees/issue-220-mobile-thread-density`
-- Notes: Started from `origin/main` after #219 reached main. Keep #221 visual language and #222 broad validation out of this package.
+- Notes: Implemented mobile-only selected-thread density changes, sticky pending approval reachability, bottom Threads/Details affordances, and focused 360x780 Playwright coverage. Keep #221 visual language and #222 broad validation out of this package.
 
 ## Archive conditions
 

--- a/tasks/issue-220-mobile-thread-density/README.md
+++ b/tasks/issue-220-mobile-thread-density/README.md
@@ -1,0 +1,54 @@
+# Issue 220 Mobile Thread Density
+
+## Purpose
+
+- Execute Issue #220 by improving mobile selected-thread density and bottom reachability at 360 CSS px.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/220
+
+## Source docs
+
+- `docs/notes/codex_webui_current_ui_gap_analysis_note_v0_1.md`
+- `docs/notes/codex_webui_target_ui_design_note_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Reduce mobile typographic, badge, chip, and button footprint in selected-thread context.
+- Keep approval summary, timeline, composer, Threads, and Details reachable without losing thread context.
+- Improve bottom reachability for composer and thread/detail affordances.
+- Preserve contextual detail behavior from #219 and leave broader visual-language polish to #221.
+
+## Exit criteria
+
+- Mobile selected-thread view shows more useful context per viewport at 360 CSS px.
+- Composer and approval actions remain reachable without scrolling through low-value timeline rows.
+- Mobile has no horizontal scroll, overlapping controls, or button text overflow in target states.
+- Focused frontend validation passes for mobile layout and existing chat behavior.
+
+## Work plan
+
+- Inspect mobile CSS breakpoints and `chat-view.tsx` thread/detail controls.
+- Implement one bounded mobile density/reachability slice using existing UI structure.
+- Add or update focused tests for mobile affordance labels and layout-safe class behavior where feasible.
+- Run targeted frontend validation.
+
+## Artifacts / evidence
+
+- Planned validation:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - focused Vitest for chat view behavior
+
+## Status / handoff notes
+
+- Status: `in progress`
+- Active branch: `issue-220-mobile-thread-density`
+- Active worktree: `.worktrees/issue-220-mobile-thread-density`
+- Notes: Started from `origin/main` after #219 reached main. Keep #221 visual language and #222 broad validation out of this package.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary

- tighten mobile selected-thread spacing, chips, timeline rows, and composer height
- keep pending approval actions sticky inside the mobile thread scroll region
- add mobile bottom Threads/Details affordances without changing desktop layout
- add focused 360x780 Playwright coverage for mobile long-timeline approval reachability
- archive the #220 task package after pre-push validation

Closes #220

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `node ./node_modules/vitest/vitest.mjs run tests/chat-view.test.tsx`
- `node ./node_modules/@playwright/test/cli.js test e2e/issue-220-mobile-thread-density.spec.ts --project=mobile-chromium`
- `npm test`