### PR TITLE
test(ui): cover approval resolution followup

### DIFF
--- a/apps/frontend-bff/e2e/issue-222-approval-resolution-followup.spec.ts
+++ b/apps/frontend-bff/e2e/issue-222-approval-resolution-followup.spec.ts
@@ -1,0 +1,152 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import {
+  expectNoHorizontalScroll,
+  mockApprovalFlow,
+  stubEventSource,
+} from "./helpers/browser-mocks";
+
+async function expectMobileFollowupReachability(page: Page) {
+  const mobileActions = page.locator(".thread-mobile-footer-actions");
+  const footerThreadsButton = mobileActions.getByRole("button", { name: "Threads", exact: true });
+  const footerDetailsButton = mobileActions.getByRole("button", { name: "Details", exact: true });
+
+  await expect(mobileActions).toBeVisible();
+  await expect(footerThreadsButton).toBeVisible();
+  await expect(footerDetailsButton).toBeVisible();
+
+  const mobileLayout = await page.evaluate(() => {
+    const scrollingElement = document.scrollingElement ?? document.documentElement;
+    const composer = document.querySelector<HTMLElement>(".chat-composer");
+    const mobileActionsElement = document.querySelector<HTMLElement>(
+      ".thread-mobile-footer-actions",
+    );
+    const composerRect = composer?.getBoundingClientRect() ?? null;
+    const mobileActionsRect = mobileActionsElement?.getBoundingClientRect() ?? null;
+
+    return {
+      composerVisible:
+        composerRect !== null && composerRect.top >= 0 && composerRect.bottom <= window.innerHeight,
+      footerVisible:
+        mobileActionsRect !== null &&
+        mobileActionsRect.top >= 0 &&
+        mobileActionsRect.bottom <= window.innerHeight,
+      noDocumentVerticalScroll: scrollingElement.scrollHeight <= window.innerHeight + 1,
+      noFooterComposerOverlap:
+        composerRect !== null &&
+        mobileActionsRect !== null &&
+        mobileActionsRect.bottom <= composerRect.top + 1,
+    };
+  });
+
+  expect(mobileLayout).toEqual({
+    composerVisible: true,
+    footerVisible: true,
+    noDocumentVerticalScroll: true,
+    noFooterComposerOverlap: true,
+  });
+
+  await footerThreadsButton.click();
+  await expect(page.locator(".thread-navigation.open")).toBeVisible();
+  await expect(
+    page
+      .locator("section.thread-navigation")
+      .getByRole("button", { name: "Ask Codex", exact: true }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Close threads", exact: true }).click();
+  await expect(page.locator(".thread-navigation.open")).toHaveCount(0);
+
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+}
+
+test.describe("Issue #222 approval resolution follow-up", () => {
+  for (const decision of ["approved", "denied"] as const) {
+    test(`keeps resolved follow-up usable after ${decision}`, async ({ page }, testInfo) => {
+      const isMobile = testInfo.project.name === "mobile-chromium";
+      const actionLabel = decision === "approved" ? "Approve request" : "Deny request";
+
+      await stubEventSource(page);
+      await mockApprovalFlow(page, { longTimeline: true });
+
+      await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
+
+      const pendingRequestCard = page.locator(".pending-request-card");
+      const threadFeedbackCard = page.locator(".thread-feedback-card");
+      const resolvedRequestCard = page.locator(".resolved-request-card");
+      const threadHeaderStack = page.locator(".thread-view-card > .thread-view-header-stack");
+      const timelineSection = page.getByRole("region", { name: "Timeline" });
+      const composer = page.locator(".chat-composer");
+      const composerInput = page.getByLabel("Send input");
+      const composerSubmitButton = page.getByRole("button", { name: "Send input", exact: true });
+
+      await expect(pendingRequestCard).toBeVisible();
+      await expect(page.getByText("Apply the prepared deployment plan.")).toBeVisible();
+      await expect(
+        pendingRequestCard.getByRole("button", { name: "Approve request", exact: true }),
+      ).toBeVisible();
+      await expect(
+        pendingRequestCard.getByRole("button", { name: "Deny request", exact: true }),
+      ).toBeVisible();
+      await expect(
+        threadFeedbackCard.getByRole("button", { name: actionLabel, exact: true }),
+      ).toBeVisible();
+      await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+      await threadFeedbackCard.getByRole("button", { name: actionLabel, exact: true }).click();
+
+      await expect(resolvedRequestCard).toBeVisible();
+      await expect(resolvedRequestCard).toContainText("Latest resolved request");
+      await expect(resolvedRequestCard).toContainText(`Decision: ${decision}`);
+      await expect(threadHeaderStack).toContainText("Waiting for your input");
+      await expect(composer).toBeVisible();
+      await expect(composerInput).toBeVisible();
+      await expect(composerInput).toBeEnabled();
+      await composerInput.fill(`Continue after ${decision}`);
+      await expect(composerSubmitButton).toBeVisible();
+      await expect(composerSubmitButton).toBeEnabled();
+      await expect(pendingRequestCard).toHaveCount(0);
+      await expect(
+        threadFeedbackCard.getByRole("button", { name: "Approve request", exact: true }),
+      ).toHaveCount(0);
+      await expect(
+        threadFeedbackCard.getByRole("button", { name: "Deny request", exact: true }),
+      ).toHaveCount(0);
+      await expect(page.getByRole("button", { name: "Interrupt thread", exact: true })).toHaveCount(
+        0,
+      );
+
+      await expect(timelineSection).toContainText(`Latest request: ${decision}`);
+      await expect(
+        timelineSection.getByRole("button", { name: "Inspect request", exact: true }).last(),
+      ).toBeVisible();
+
+      if (isMobile) {
+        await expectMobileFollowupReachability(page);
+        await page
+          .locator(".thread-mobile-footer-actions")
+          .getByRole("button", { name: "Details", exact: true })
+          .click();
+      } else {
+        await resolvedRequestCard
+          .getByRole("button", { name: "Reopen request detail", exact: true })
+          .click();
+      }
+
+      const detailSurface = page.locator(".thread-detail-surface");
+      await expect(detailSurface).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Request detail", exact: true }),
+      ).toBeVisible();
+      await expect(detailSurface).toContainText("Decision");
+      await expect(detailSurface).toContainText(decision);
+      await expect(detailSurface).toContainText("Responded");
+      await expect(
+        detailSurface.getByRole("button", { name: "Approve request", exact: true }),
+      ).toHaveCount(0);
+      await expect(
+        detailSurface.getByRole("button", { name: "Deny request", exact: true }),
+      ).toHaveCount(0);
+      await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+    });
+  }
+});

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- `None`
+- [issue-222-ui-gap-validation](./issue-222-ui-gap-validation/README.md)
 
 ## Archived Task Packages
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,10 +69,11 @@ Each active task package `README.md` must include at least the following section
 
 ## Current Active Tasks
 
-- [issue-222-ui-gap-validation](./issue-222-ui-gap-validation/README.md)
+- `None`
 
 ## Archived Task Packages
 
+- [issue-222-ui-gap-validation](./archive/issue-222-ui-gap-validation/README.md)
 - [issue-221-visual-language-polish](./archive/issue-221-visual-language-polish/README.md)
 - [issue-220-mobile-thread-density](./archive/issue-220-mobile-thread-density/README.md)
 - [issue-219-contextual-details](./archive/issue-219-contextual-details/README.md)

--- a/tasks/archive/issue-222-ui-gap-validation/README.md
+++ b/tasks/archive/issue-222-ui-gap-validation/README.md
@@ -49,6 +49,14 @@
 - Active branch: `issue-222-ui-gap-validation`
 - Active worktree: `.worktrees/issue-222-ui-gap-validation`
 - Notes: Added desktop/mobile Playwright validation for the post-approval follow-up state after actual approve/deny interactions. The spec verifies latest resolved request visibility, stale pending controls removal, restored composer sendability, request-detail access without response actions, timeline resolution evidence, and mobile reachability without horizontal overflow. This is the final child issue before #214 can be considered for closure.
+- Completion retrospective:
+  - Completion boundary: package archive after local completion, evaluator approval, and pre-push validation.
+  - Contract check: Issue #222 acceptance criteria are satisfied locally; Issue close still requires PR merge to `main`, parent checkout sync, worktree cleanup, and GitHub tracking update.
+  - What worked: the final validation slice stayed production-code-free and directly covered post-approval continuation on desktop and mobile.
+  - Workflow problems: worktree-local dependency symlinks needed correction before validation could run; no repo-tracked change was required.
+  - Improvements to adopt: gap-follow-up validation should prefer actual UI interaction from pending to resolved states rather than loading already-resolved fixtures.
+  - Skill candidates or skill updates: none required.
+  - Follow-up updates: after #222 reaches `main`, parent #214 can be checked for closure because all child issues should be complete.
 
 ## Archive conditions
 

--- a/tasks/issue-222-ui-gap-validation/README.md
+++ b/tasks/issue-222-ui-gap-validation/README.md
@@ -34,17 +34,21 @@
 
 ## Artifacts / evidence
 
-- Planned validation:
-  - `npm run check`
-  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
-  - focused Playwright/Vitest coverage for the new validation slice
+- Sprint validation:
+  - `npm run check`: passed
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed
+  - `npm run test:e2e -- e2e/issue-222-approval-resolution-followup.spec.ts --project=desktop-chromium --reporter=line`: passed, 2 tests
+  - `npm run test:e2e -- e2e/issue-222-approval-resolution-followup.spec.ts --project=mobile-chromium --reporter=line`: passed, 2 tests
+- New validation coverage:
+  - `apps/frontend-bff/e2e/issue-222-approval-resolution-followup.spec.ts`
+- Sprint evaluator: approved
 
 ## Status / handoff notes
 
-- Status: `in progress`
+- Status: `locally complete pending pre-push validation`
 - Active branch: `issue-222-ui-gap-validation`
 - Active worktree: `.worktrees/issue-222-ui-gap-validation`
-- Notes: Started from `origin/main` after #221 reached main. This is the final child issue before #214 can be considered for closure.
+- Notes: Added desktop/mobile Playwright validation for the post-approval follow-up state after actual approve/deny interactions. The spec verifies latest resolved request visibility, stale pending controls removal, restored composer sendability, request-detail access without response actions, timeline resolution evidence, and mobile reachability without horizontal overflow. This is the final child issue before #214 can be considered for closure.
 
 ## Archive conditions
 

--- a/tasks/issue-222-ui-gap-validation/README.md
+++ b/tasks/issue-222-ui-gap-validation/README.md
@@ -1,0 +1,51 @@
+# Issue 222 UI Gap Validation
+
+## Purpose
+
+- Execute Issue #222 by adding reproducible validation coverage for the current UI gap follow-up states.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/222
+
+## Source docs
+
+- `docs/notes/codex_webui_current_ui_gap_analysis_note_v0_1.md`
+- `docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Add or update reproducible desktop/mobile validation for the gap-analysis follow-up line after #215-221.
+- Cover high-impact states such as first input, selected idle completed response, running/streaming response, pending approval with detail, post-approval resolution, contextual detail, scroll anchoring, and mobile composer reachability where feasible.
+- Prefer focused Playwright or existing test helper coverage over broad manual-only evidence.
+
+## Exit criteria
+
+- The gap-analysis follow-up has reproducible desktop and mobile validation evidence.
+- Validation covers the high-impact states listed in the maintained note.
+- Focused frontend validation passes, including the new or updated validation coverage.
+
+## Work plan
+
+- Inspect existing e2e specs, visual evidence, and validation docs for coverage gaps.
+- Add one bounded validation slice for the most valuable missing states.
+- Run focused validation plus app-level checks before pre-push validation.
+
+## Artifacts / evidence
+
+- Planned validation:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - focused Playwright/Vitest coverage for the new validation slice
+
+## Status / handoff notes
+
+- Status: `in progress`
+- Active branch: `issue-222-ui-gap-validation`
+- Active worktree: `.worktrees/issue-222-ui-gap-validation`
+- Notes: Started from `origin/main` after #221 reached main. This is the final child issue before #214 can be considered for closure.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, the dedicated pre-push validation gate passes, completion retrospective is recorded, and package handoff notes are updated.


### PR DESCRIPTION
## Summary

- add focused desktop/mobile Playwright validation for post-approval follow-up state
- verify actual approve/deny interactions restore continuation-ready thread state
- assert resolved request detail remains accessible without response actions
- archive the #222 task package after pre-push validation

Closes #222

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm run test:e2e -- e2e/issue-222-approval-resolution-followup.spec.ts --project=desktop-chromium --reporter=line`
- `npm run test:e2e -- e2e/issue-222-approval-resolution-followup.spec.ts --project=mobile-chromium --reporter=line`
- `npm test`