### PR TITLE
feat(ui): add thread details surface

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -922,6 +922,15 @@ textarea {
   padding: 10px 12px;
 }
 
+.thread-detail-section {
+  display: grid;
+  gap: 10px;
+  border: 1px solid rgba(22, 47, 52, 0.08);
+  border-radius: 12px;
+  background: rgba(245, 249, 249, 0.96);
+  padding: 10px 12px;
+}
+
 .detail-artifact-section {
   border-color: var(--artifact-border);
   background: rgba(237, 244, 245, 0.62);

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -187,6 +187,7 @@ function workspaceSummary(workspace: PublicWorkspaceSummary) {
 }
 
 type ThreadDetailSelection =
+  | { kind: "thread_details" }
   | { kind: "request_detail" }
   | { kind: "timeline_item_detail"; timelineItemId: string };
 
@@ -619,6 +620,10 @@ export function ChatView({
     streamEvents,
     draftAssistantMessages,
   });
+  const timelineArtifactCount = timelineModel.groups.reduce(
+    (count, group) => count + group.rows.filter((row) => row.showDetailButton).length,
+    0,
+  );
   const hasRequestDetailAffordance = selectedRequestDetail !== null;
   const latestTimelineGroup = timelineModel.groups[timelineModel.groups.length - 1] ?? null;
   const latestTimelineRow = latestTimelineGroup?.rows[latestTimelineGroup.rows.length - 1] ?? null;
@@ -1083,6 +1088,14 @@ export function ChatView({
                     Refresh
                   </Link>
                 ) : null}
+                <button
+                  className="secondary-link compact-link"
+                  disabled={!workspaceId}
+                  onClick={() => setDetailSelection({ kind: "thread_details" })}
+                  type="button"
+                >
+                  Details
+                </button>
               </div>
             </header>
           </div>
@@ -1270,8 +1283,14 @@ export function ChatView({
               </button>
               <button
                 className="secondary-link action-button compact-button"
-                disabled={!hasRequestDetailAffordance}
-                onClick={() => setDetailSelection({ kind: "request_detail" })}
+                disabled={!workspaceId}
+                onClick={() =>
+                  setDetailSelection(
+                    hasRequestDetailAffordance
+                      ? { kind: "request_detail" }
+                      : { kind: "thread_details" },
+                  )
+                }
                 type="button"
               >
                 Details
@@ -1335,11 +1354,160 @@ export function ChatView({
                 </button>
               </div>
               <h2>
-                {detailSelection.kind === "request_detail"
-                  ? "Request detail"
-                  : (selectedTimelineItemDetail?.title ?? "Timeline detail")}
+                {detailSelection.kind === "thread_details"
+                  ? "Thread details"
+                  : detailSelection.kind === "request_detail"
+                    ? "Request detail"
+                    : (selectedTimelineItemDetail?.title ?? "Timeline detail")}
               </h2>
             </header>
+
+            {detailSelection.kind === "thread_details" ? (
+              <div className="detail-stack">
+                <section className="thread-detail-section detail-text-section">
+                  <strong>Overview</strong>
+                  <dl className="request-detail-list">
+                    <div>
+                      <dt>Title</dt>
+                      <dd>
+                        {selectedThreadView?.thread.title ??
+                          (workspaceId ? "New workspace input" : "No workspace selected")}
+                      </dd>
+                    </div>
+                    <div className={detailFieldClass("Thread")}>
+                      <dt>Thread</dt>
+                      <dd>
+                        {selectedThreadView?.thread.thread_id ? (
+                          <code className="artifact-inline">
+                            {selectedThreadView.thread.thread_id}
+                          </code>
+                        ) : (
+                          "Not started"
+                        )}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Workspace</dt>
+                      <dd>{selectedWorkspace?.workspace_name ?? workspaceId ?? "Not selected"}</dd>
+                    </div>
+                    <div>
+                      <dt>Updated</dt>
+                      <dd>{formatTimestamp(selectedThreadView?.thread.updated_at ?? null)}</dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <section className="thread-detail-section detail-text-section">
+                  <strong>Status</strong>
+                  <dl className="request-detail-list">
+                    <div>
+                      <dt>Current activity</dt>
+                      <dd>
+                        {selectedThreadView?.current_activity.label ??
+                          (isOpeningSelectedThread
+                            ? "Opening"
+                            : workspaceId
+                              ? "Ready for first input"
+                              : "Workspace required")}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Activity summary</dt>
+                      <dd>
+                        {workspaceId
+                          ? currentActivitySummary(selectedThreadView, isOpeningSelectedThread)
+                          : "Choose a workspace to enable the composer."}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Stream</dt>
+                      <dd>{connectionState}</dd>
+                    </div>
+                    <div>
+                      <dt>Composer</dt>
+                      <dd>
+                        {selectedThreadView?.composer.accepting_user_input
+                          ? "Accepting input"
+                          : composerGuidance}
+                      </dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <section className="thread-detail-section detail-text-section">
+                  <strong>Next action</strong>
+                  <p>{threadFeedback.summary}</p>
+                  {threadFeedback.actions.length > 0 ? (
+                    <div className="workspace-actions thread-feedback-actions">
+                      {threadFeedback.actions.map((action) => renderThreadFeedbackAction(action))}
+                    </div>
+                  ) : null}
+                </section>
+
+                <section className="thread-detail-section detail-text-section">
+                  <strong>Requests</strong>
+                  <p>
+                    {selectedThreadView?.pending_request
+                      ? selectedThreadView.pending_request.summary
+                      : selectedThreadView?.latest_resolved_request
+                        ? `Latest resolved request: ${selectedThreadView.latest_resolved_request.decision}`
+                        : "No pending or recently resolved request."}
+                  </p>
+                  {selectedRequestDetail ? (
+                    <button
+                      className="secondary-link action-button compact-button"
+                      onClick={() => setDetailSelection({ kind: "request_detail" })}
+                      type="button"
+                    >
+                      Request detail
+                    </button>
+                  ) : null}
+                </section>
+
+                <section className="thread-detail-section detail-text-section">
+                  <strong>Artifacts</strong>
+                  {timelineArtifactCount > 0 ? (
+                    <ul className="detail-list">
+                      {timelineModel.groups.flatMap((group) =>
+                        group.rows
+                          .filter((row) => row.showDetailButton && row.timelineItemId)
+                          .map((row) => (
+                            <li key={row.id}>
+                              <strong>{row.label}</strong>
+                              <span>{row.content}</span>
+                              <button
+                                className="secondary-link action-button inline-detail-button"
+                                onClick={() =>
+                                  setDetailSelection({
+                                    kind: "timeline_item_detail",
+                                    timelineItemId: row.timelineItemId ?? "",
+                                  })
+                                }
+                                type="button"
+                              >
+                                {row.detailActionLabel ?? "Inspect details"}
+                              </button>
+                            </li>
+                          )),
+                      )}
+                    </ul>
+                  ) : (
+                    <p>No extracted artifacts are available for this thread yet.</p>
+                  )}
+                </section>
+
+                <details className="detail-debug">
+                  <summary>Debug: raw thread view JSON</summary>
+                  <pre className="detail-json">
+                    {JSON.stringify(
+                      selectedThreadView ?? { workspaceId, selectedThreadId },
+                      null,
+                      2,
+                    )}
+                  </pre>
+                </details>
+              </div>
+            ) : null}
 
             {detailSelection.kind === "request_detail" && selectedRequestDetail ? (
               <div className="detail-stack">

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -1166,6 +1166,225 @@ describe("ChatView", () => {
     expect(markup).not.toContain("thread-feedback-card-inline");
   });
 
+  it("opens Thread Details with status metadata and collapsed debug content", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={null}
+          connectionState="live"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_001"
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Ready thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "waiting_input",
+                active_flags: [],
+                latest_turn_status: null,
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+            },
+            current_activity: {
+              kind: "waiting_on_user_input",
+              label: "Waiting for your input",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: true,
+              interrupt_available: false,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[
+            {
+              workspace_id: "ws_alpha",
+              workspace_name: "alpha",
+              created_at: "2026-03-27T05:00:00Z",
+              updated_at: "2026-03-27T05:22:00Z",
+              active_session_summary: null,
+              pending_approval_count: 0,
+            },
+          ]}
+        />,
+      );
+    });
+
+    const detailsButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Details",
+    );
+    expect(detailsButton).toBeDefined();
+
+    await act(async () => {
+      detailsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Thread details");
+    expect(container.textContent).toContain("Overview");
+    expect(container.textContent).toContain("Status");
+    expect(container.textContent).toContain("Next action");
+    expect(container.textContent).toContain("Requests");
+    expect(container.textContent).toContain("Artifacts");
+    expect(container.textContent).toContain("Ready thread");
+    expect(container.textContent).toContain("Waiting for your input");
+    expect(container.textContent).toContain("This thread is ready for your next input.");
+    expect(container.textContent).toContain("No pending or recently resolved request.");
+    expect(container.textContent).toContain("Debug: raw thread view JSON");
+    const debugDetails = container.querySelector("details.detail-debug");
+    expect(debugDetails).not.toBeNull();
+    expect(debugDetails?.hasAttribute("open")).toBe(false);
+  });
+
+  it("lists contextual artifacts from Thread Details and opens their detail", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={null}
+          connectionState="live"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_001"
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Artifact thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "waiting_input",
+                active_flags: [],
+                latest_turn_status: null,
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+            },
+            current_activity: {
+              kind: "waiting_on_user_input",
+              label: "Waiting for your input",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: true,
+              interrupt_available: false,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [
+                {
+                  timeline_item_id: "timeline_failure",
+                  thread_id: "thread_001",
+                  turn_id: "turn_001",
+                  item_id: "item_failure_001",
+                  sequence: 1,
+                  occurred_at: "2026-03-27T05:15:00Z",
+                  kind: "turn.failed",
+                  payload: {
+                    summary: "Tests failed after the patch",
+                    command: "npm run check",
+                    file_paths: ["apps/frontend-bff/src/chat-view.tsx"],
+                    tests: ["tests/chat-view.test.tsx"],
+                    request_id: "req_failure_001",
+                  },
+                },
+              ],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[]}
+        />,
+      );
+    });
+
+    const detailsButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Details",
+    );
+    await act(async () => {
+      detailsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Thread details");
+    expect(container.textContent).toContain("Artifacts");
+    expect(container.textContent).toContain("Turn failed");
+    expect(container.textContent).toContain("Tests failed after the patch");
+
+    const artifactButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Inspect failure",
+    );
+    expect(artifactButton).toBeDefined();
+
+    await act(async () => {
+      artifactButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Failure detail");
+    expect(container.textContent).toContain("Commands");
+    expect(container.textContent).toContain("npm run check");
+    expect(container.textContent).toContain("apps/frontend-bff/src/chat-view.tsx");
+    expect(container.textContent).toContain("Debug: raw timeline payload JSON");
+  });
+
   it("renders recovery input-unavailable reason as the single disabled composer state", () => {
     const markup = renderToStaticMarkup(
       <ChatView

--- a/tasks/archive/issue-232-thread-details/README.md
+++ b/tasks/archive/issue-232-thread-details/README.md
@@ -1,0 +1,74 @@
+# Issue #232 Thread Details
+
+## Purpose
+
+Add a recoverable Thread Details surface for lower-frequency thread status, metadata, requests, artifacts, and debug information without putting that information back into the primary Timeline viewport.
+
+## Primary issue
+
+- https://github.com/tsukushibito/codex-webui/issues/232
+
+## Source docs
+
+- `docs/notes/codex_webui_thread_view_information_architecture_note_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md`
+
+## Scope for this package
+
+- Add an explicit Thread Details entry point near the compact Thread View context.
+- Expose Overview, Status, Next action, Requests, Artifacts, and Debug information in a secondary details surface.
+- Keep Debug collapsed by default.
+- Preserve Timeline scroll position and primary thread workflows when details opens or closes.
+
+## Exit criteria
+
+- Thread metadata, current activity explanation, feedback summary, request state, artifacts, and debug data remain reachable from Thread Details.
+- Details opens with Overview and any current required action visible first.
+- Details does not become another always-visible dashboard.
+- Existing thread selection, message sending, approval, refresh, and interruption workflows continue to work.
+- Focused tests and `apps/frontend-bff` checks pass.
+
+## Work plan
+
+1. Inspect the existing detail surface and selected item detail behavior.
+2. Add a Thread Details trigger and surface using existing component patterns.
+3. Populate Overview, Status, Next action, Requests, Artifacts, and Debug sections from existing `thread_view` data.
+4. Add focused tests for details reachability and default debug collapse.
+5. Run targeted validation and prepare for pre-push validation.
+
+## Artifacts / evidence
+
+- Sprint evaluator verdict: approved.
+- Dedicated pre-push validation: passed.
+- Validation evidence:
+  - `npm run check`: passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm test -- tests/chat-view.test.tsx`: 15 tests passed.
+  - `npm run test:e2e -- e2e/chat-flow.spec.ts e2e/issue-222-approval-resolution-followup.spec.ts --project=desktop-chromium --reporter=line`: 3 tests passed.
+  - `npm run test:e2e -- e2e/chat-flow.spec.ts --project=mobile-chromium --reporter=line`: 1 test passed.
+
+## Status / handoff notes
+
+- Active worktree: `.worktrees/issue-232-thread-details`
+- Active branch: `issue-232-thread-details`
+- Active PR: None yet.
+- Completion boundary: package archive and PR handoff.
+- Contract check:
+  - Thread Details exposes Overview, Status, Next action, Requests, Artifacts, and collapsed Debug sections.
+  - Detail surface opens only after an explicit Details/request/artifact action.
+  - Artifacts list contextual timeline rows and can open their detail item.
+  - Mobile CSS does not hide the Thread Details sections.
+- Retrospective:
+  - What worked: evaluator found both artifact reachability and mobile CSS hiding gaps before publish.
+  - Workflow problems: a parallel desktop/mobile E2E run contended on the Playwright runtime SQLite DB; sequential E2E avoids this.
+  - Improvements to adopt: run Playwright projects that share the same configured runtime DB sequentially unless the config isolates DB paths.
+  - Skill candidates or skill updates: consider adding a note to pre-push validation prompts when multiple E2E commands use the same Playwright webServer database.
+  - Follow-up updates: none required for this package.
+
+## Archive conditions
+
+- Sprint implementation is approved.
+- Dedicated pre-push validation passes.
+- Package notes include validation evidence.
+- Package is moved to `tasks/archive/issue-232-thread-details/` before final Project completion tracking.


### PR DESCRIPTION
## Summary
- add an explicit Thread Details surface for lower-frequency thread metadata, status, requests, artifacts, and debug JSON
- keep debug collapsed by default and make contextual timeline artifacts reachable from details
- add focused component coverage and archive the #232 task package

## Validation
- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm test -- tests/chat-view.test.tsx
- npm run test:e2e -- e2e/chat-flow.spec.ts e2e/issue-222-approval-resolution-followup.spec.ts --project=desktop-chromium --reporter=line
- npm run test:e2e -- e2e/chat-flow.spec.ts --project=mobile-chromium --reporter=line

Closes #232