### PR TITLE
feat(ui): improve timeline density

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -694,7 +694,7 @@ textarea {
 
 .thread-view-scroll-region {
   display: grid;
-  gap: 14px;
+  gap: 12px;
   min-height: 0;
   overflow: auto;
   padding-bottom: 12px;
@@ -717,7 +717,7 @@ textarea {
 
 .timeline-section {
   display: grid;
-  gap: 12px;
+  gap: 10px;
   min-width: 0;
   min-height: 0;
   align-content: start;
@@ -775,13 +775,13 @@ textarea {
 .timeline-turn-group,
 .timeline-ungrouped-item {
   display: grid;
-  gap: 8px;
+  gap: 7px;
   min-width: 0;
 }
 
 .timeline-turn-group {
   border-left: 2px solid rgba(15, 95, 93, 0.22);
-  padding-left: 12px;
+  padding-left: 10px;
 }
 
 .timeline-turn-label {
@@ -805,12 +805,12 @@ textarea {
 }
 
 .timeline-row {
-  padding: 12px 14px;
+  padding: 10px 12px;
 }
 
 .timeline-row-primary {
   gap: 10px;
-  padding: 16px;
+  padding: 12px 14px;
 }
 
 .timeline-row-primary p {
@@ -827,7 +827,7 @@ textarea {
   gap: 5px;
   border-color: rgba(22, 47, 52, 0.07);
   background: rgba(244, 248, 249, 0.92);
-  padding: 9px 12px;
+  padding: 7px 10px;
 }
 
 .timeline-row-compact p,
@@ -843,6 +843,24 @@ textarea {
 
 .timeline-row-assistant {
   border-color: rgba(22, 47, 52, 0.12);
+}
+
+.timeline-row-meta {
+  gap: 8px;
+}
+
+.timeline-row-content {
+  white-space: pre-wrap;
+}
+
+.timeline-row-folded .timeline-row-content {
+  color: var(--text-muted);
+}
+
+.timeline-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .chat-message.user {

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -211,6 +211,34 @@ function timelineRowClass(row: TimelineDisplayRow) {
   return `timeline-row timeline-row-${row.density} timeline-row-${row.role}`;
 }
 
+const TIMELINE_PREVIEW_LINE_LIMIT = 8;
+const TIMELINE_PREVIEW_CHARACTER_LIMIT = 520;
+
+function timelineContentPreview(content: string) {
+  const lines = content.split(/\r?\n/);
+  const lineFolded = lines.length > TIMELINE_PREVIEW_LINE_LIMIT;
+  const linePreview = lineFolded ? lines.slice(0, TIMELINE_PREVIEW_LINE_LIMIT).join("\n") : content;
+
+  if (linePreview.length <= TIMELINE_PREVIEW_CHARACTER_LIMIT) {
+    return {
+      isFoldable: lineFolded,
+      preview: lineFolded ? `${linePreview.trimEnd()}\n...` : content,
+    };
+  }
+
+  const clipped = linePreview.slice(0, TIMELINE_PREVIEW_CHARACTER_LIMIT);
+  const lastWhitespace = clipped.search(/\s+\S*$/);
+  const preview =
+    lastWhitespace > TIMELINE_PREVIEW_CHARACTER_LIMIT * 0.72
+      ? clipped.slice(0, lastWhitespace)
+      : clipped;
+
+  return {
+    isFoldable: true,
+    preview: `${preview.trimEnd()}...`,
+  };
+}
+
 function composerUnavailableReason(threadView: PublicThreadView | null) {
   if (!threadView) {
     return null;
@@ -553,6 +581,7 @@ export function ChatView({
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
   const [selectedFilterId, setSelectedFilterId] = useState<ThreadFilterId>("all");
+  const [expandedTimelineRows, setExpandedTimelineRows] = useState<Set<string>>(() => new Set());
   const [followLatestActivity, setFollowLatestActivity] = useState(true);
   const [hasSuppressedActivity, setHasSuppressedActivity] = useState(false);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
@@ -658,6 +687,7 @@ export function ChatView({
   useEffect(() => {
     setIsNavigationOpen(false);
     setDetailSelection(null);
+    setExpandedTimelineRows(new Set());
   }, [selectedThreadId]);
 
   useEffect(() => {
@@ -730,6 +760,18 @@ export function ChatView({
     }
     setFollowLatestActivity(true);
     setHasSuppressedActivity(false);
+  }
+
+  function toggleTimelineRowExpansion(rowId: string) {
+    setExpandedTimelineRows((current) => {
+      const next = new Set(current);
+      if (next.has(rowId)) {
+        next.delete(rowId);
+      } else {
+        next.add(rowId);
+      }
+      return next;
+    });
   }
 
   function renderThreadFeedbackAction(action: ThreadFeedbackAction) {
@@ -1242,31 +1284,63 @@ export function ChatView({
                           <strong>{group.turnId}</strong>
                         </div>
                       ) : null}
-                      {group.rows.map((row) => (
-                        <article className={timelineRowClass(row)} key={row.id}>
-                          <div className="workspace-meta-row">
-                            <strong>{row.label}</strong>
-                            <span className="workspace-meta">
-                              {row.isLive ? "Live" : formatTimestamp(row.occurredAt)}
-                            </span>
-                          </div>
-                          <p>{row.content}</p>
-                          {row.showDetailButton && row.timelineItemId ? (
-                            <button
-                              className="secondary-link action-button inline-detail-button"
-                              onClick={() =>
-                                setDetailSelection({
-                                  kind: "timeline_item_detail",
-                                  timelineItemId: row.timelineItemId ?? "",
-                                })
-                              }
-                              type="button"
+                      {group.rows.map((row) =>
+                        (() => {
+                          const contentPreview = timelineContentPreview(row.content);
+                          const isExpanded = expandedTimelineRows.has(row.id);
+                          const displayedContent =
+                            contentPreview.isFoldable && !isExpanded
+                              ? contentPreview.preview
+                              : row.content;
+
+                          return (
+                            <article
+                              className={`${timelineRowClass(row)}${
+                                contentPreview.isFoldable && !isExpanded
+                                  ? " timeline-row-folded"
+                                  : ""
+                              }`}
+                              key={row.id}
                             >
-                              {row.detailActionLabel ?? "Inspect details"}
-                            </button>
-                          ) : null}
-                        </article>
-                      ))}
+                              <div className="workspace-meta-row timeline-row-meta">
+                                <strong>{row.label}</strong>
+                                <span className="workspace-meta">
+                                  {row.isLive ? "Live" : formatTimestamp(row.occurredAt)}
+                                </span>
+                              </div>
+                              <p className="timeline-row-content">{displayedContent}</p>
+                              {contentPreview.isFoldable || row.showDetailButton ? (
+                                <div className="timeline-row-actions">
+                                  {contentPreview.isFoldable ? (
+                                    <button
+                                      aria-expanded={isExpanded}
+                                      className="secondary-link action-button inline-detail-button"
+                                      onClick={() => toggleTimelineRowExpansion(row.id)}
+                                      type="button"
+                                    >
+                                      {isExpanded ? "Show less" : "Show more"}
+                                    </button>
+                                  ) : null}
+                                  {row.showDetailButton && row.timelineItemId ? (
+                                    <button
+                                      className="secondary-link action-button inline-detail-button"
+                                      onClick={() =>
+                                        setDetailSelection({
+                                          kind: "timeline_item_detail",
+                                          timelineItemId: row.timelineItemId ?? "",
+                                        })
+                                      }
+                                      type="button"
+                                    >
+                                      {row.detailActionLabel ?? "Inspect details"}
+                                    </button>
+                                  ) : null}
+                                </div>
+                              ) : null}
+                            </article>
+                          );
+                        })(),
+                      )}
                     </section>
                   ))}
                 </div>

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -1460,6 +1460,111 @@ describe("ChatView", () => {
     expect(markup).not.toContain('id="message-input"');
   });
 
+  it("folds long timeline rows and expands them in place", async () => {
+    const longOutput = Array.from(
+      { length: 12 },
+      (_, index) => `diagnostic line ${String(index + 1).padStart(2, "0")}`,
+    ).join("\n");
+
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={null}
+          connectionState="live"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_001"
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Dense timeline thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "waiting_input",
+                active_flags: [],
+                latest_turn_status: null,
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+            },
+            current_activity: {
+              kind: "waiting_on_user_input",
+              label: "Waiting for your input",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: true,
+              interrupt_available: false,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [
+                {
+                  timeline_item_id: "evt_long_001",
+                  thread_id: "thread_001",
+                  turn_id: "turn_001",
+                  item_id: "item_long_001",
+                  sequence: 1,
+                  occurred_at: "2026-03-27T05:22:00Z",
+                  kind: "tool.output",
+                  payload: {
+                    content: longOutput,
+                  },
+                },
+              ],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[]}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("diagnostic line 08");
+    expect(container.textContent).not.toContain("diagnostic line 12");
+
+    const showMoreButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Show more",
+    );
+    expect(showMoreButton).toBeDefined();
+    expect(showMoreButton?.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      showMoreButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("diagnostic line 12");
+    expect(container.textContent).toContain("Show less");
+  });
+
   it("surfaces a latest-activity CTA when auto-scroll is suppressed", async () => {
     const baseProps = {
       backgroundPriorityNotice: null,

--- a/tasks/archive/issue-233-timeline-density/README.md
+++ b/tasks/archive/issue-233-timeline-density/README.md
@@ -1,0 +1,65 @@
+# Issue #233 Timeline Density
+
+## Purpose
+
+Improve Timeline density and local expand behavior so the thread work log remains the primary surface while verbose rows stay recoverable.
+
+## Primary issue
+
+- https://github.com/tsukushibito/codex-webui/issues/233
+
+## Source docs
+
+- `docs/notes/codex_webui_thread_view_information_architecture_note_v0_1.md`
+- `apps/frontend-bff/src/timeline-display-model.ts`
+- `apps/frontend-bff/src/chat-view.tsx`
+
+## Scope for this package
+
+- Fold long or noisy Timeline row content behind an inline expand control.
+- Keep the first useful content visible in the Timeline.
+- Tighten Timeline spacing without removing metadata or contextual details.
+- Preserve latest-activity scroll and return-to-latest behavior.
+
+## Exit criteria
+
+- Long Timeline content can be expanded in place.
+- Timeline rows use less vertical space for routine scanning.
+- Existing Timeline detail buttons continue to work.
+- Return-to-latest behavior remains covered.
+- Focused tests and `apps/frontend-bff` checks pass.
+
+## Work plan
+
+1. Inspect the existing Timeline display model, scroll behavior, and row rendering.
+2. Add local row expansion state and preview generation in `ChatView`.
+3. Tighten Timeline CSS spacing and add folded-row affordance styles.
+4. Add focused coverage for fold/expand behavior.
+5. Run targeted validation, then the pre-push validation gate.
+
+## Artifacts / evidence
+
+- Local implementation validation passed:
+  - `npm run check`: passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm test -- tests/chat-view.test.tsx`: 16 tests passed.
+  - `npm run test:e2e -- e2e/chat-flow.spec.ts --project=desktop-chromium --reporter=line`: 1 test passed.
+  - `npm run test:e2e -- e2e/chat-flow.spec.ts --project=mobile-chromium --reporter=line`: 1 test passed.
+- Playwright emitted the known `NO_COLOR` / `FORCE_COLOR` warning; it did not block tests.
+
+## Status / handoff notes
+
+- Active worktree: `.worktrees/issue-233-timeline-density`
+- Active branch: `issue-233-timeline-density`
+- Active PR: None yet.
+- Completion boundary: package archive, PR, main merge, Issue close.
+- Contract check:
+  - Long Timeline rows preview the first useful lines and expand in place.
+  - Routine Timeline spacing is tighter on desktop and mobile.
+  - Existing Timeline detail buttons remain reachable from row actions.
+  - Existing return-to-latest tests still pass.
+- Retrospective:
+  - What worked: local fold state kept the behavior isolated to `ChatView`; no data model contract change was needed.
+  - Workflow problems: none beyond the known Playwright color warning.
+  - Improvements to adopt: keep row action affordances grouped so future row-level actions do not add extra vertical scaffolding.
+  - Skill candidates or skill updates: none.


### PR DESCRIPTION
## Summary
- fold long Timeline rows behind inline Show more / Show less controls
- tighten Timeline row spacing while preserving metadata and contextual detail actions
- add focused component coverage for long-row expansion and keep scroll-follow E2E coverage passing

## Validation
- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm test -- tests/chat-view.test.tsx
- npm run test:e2e -- e2e/chat-flow.spec.ts --project=desktop-chromium --reporter=line
- npm run test:e2e -- e2e/chat-flow.spec.ts --project=mobile-chromium --reporter=line

Closes #233