### PR TITLE
feat(ui): add navigation minibar mode

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -544,6 +544,46 @@ textarea {
   width: 100%;
 }
 
+.navigation-header-row {
+  gap: 8px;
+}
+
+.sidebar-mode-toggle {
+  display: none;
+  flex-shrink: 0;
+}
+
+.navigation-minibar-stack {
+  display: grid;
+  gap: 8px;
+  justify-items: stretch;
+}
+
+.minibar-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 42px;
+  padding: 8px;
+  border-radius: 10px;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.minibar-button.active {
+  border-color: rgba(15, 95, 93, 0.34);
+  background: rgba(15, 95, 93, 0.12);
+  color: var(--accent-strong);
+  box-shadow: inset 3px 0 0 rgba(15, 95, 93, 0.74);
+}
+
+.minibar-button.attention {
+  border-color: rgba(185, 98, 31, 0.28);
+  background: rgba(255, 249, 242, 0.98);
+  color: var(--warning);
+}
+
 .thread-list-group {
   display: grid;
   gap: 8px;
@@ -603,8 +643,37 @@ textarea {
 }
 
 .thread-summary-header {
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
   gap: 8px;
+}
+
+.thread-status-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.55rem;
+  min-height: 1.55rem;
+  border: 1px solid rgba(22, 47, 52, 0.12);
+  border-radius: 999px;
+  background: rgba(22, 47, 52, 0.06);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.thread-status-mark.warning {
+  border-color: rgba(185, 98, 31, 0.28);
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
+.thread-status-mark.success {
+  border-color: rgba(36, 112, 75, 0.24);
+  background: var(--success-soft);
+  color: var(--success);
 }
 
 .thread-summary-title-block {
@@ -618,26 +687,15 @@ textarea {
   line-height: 1.2;
 }
 
-.thread-summary-statuses,
 .thread-summary-cues {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.thread-summary-statuses {
-  justify-content: flex-end;
-}
-
-.thread-summary-activity,
 .thread-summary-notice {
   margin: 0;
   line-height: 1.4;
-}
-
-.thread-summary-activity {
-  color: var(--text-main);
-  font-size: 0.92rem;
 }
 
 .thread-summary-notice {
@@ -1365,6 +1423,10 @@ textarea {
     display: none;
   }
 
+  .sidebar-mode-toggle {
+    display: inline-flex;
+  }
+
   .thread-mobile-footer-actions {
     display: none;
   }
@@ -1381,8 +1443,16 @@ textarea {
     box-shadow: 0 18px 42px rgba(17, 31, 39, 0.1);
   }
 
+  .chat-layout.sidebar-minibar {
+    grid-template-columns: 64px minmax(0, 1fr);
+  }
+
   .chat-layout:has(.thread-detail-surface) {
     grid-template-columns: minmax(230px, 285px) minmax(0, 1fr) minmax(300px, 360px);
+  }
+
+  .chat-layout.sidebar-minibar:has(.thread-detail-surface) {
+    grid-template-columns: 64px minmax(0, 1fr) minmax(300px, 360px);
   }
 
   .thread-navigation,
@@ -1407,6 +1477,11 @@ textarea {
     border-right: 1px solid rgba(22, 47, 52, 0.1);
     background: linear-gradient(180deg, rgba(246, 250, 250, 0.96), rgba(240, 246, 246, 0.9));
     padding: 16px;
+  }
+
+  .thread-navigation.minibar {
+    justify-content: center;
+    padding: 10px;
   }
 
   .thread-view-card,

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -136,6 +136,9 @@ function isRecentThread(thread: PublicThreadListItem) {
 }
 
 type ThreadFilterId = "all" | "active" | "waiting_approval" | "errors_failed" | "recent";
+type SidebarMode = "full" | "mini";
+
+const SIDEBAR_MODE_STORAGE_KEY = "codex-webui.sidebar-mode";
 
 function filterThreads(threads: PublicThreadListItem[], filterId: ThreadFilterId) {
   switch (filterId) {
@@ -152,24 +155,81 @@ function filterThreads(threads: PublicThreadListItem[], filterId: ThreadFilterId
   }
 }
 
-function summarizeThreadActivity(thread: PublicThreadListItem) {
-  if (thread.blocked_cue) {
-    return thread.blocked_cue.label;
-  }
-
-  if (thread.badge) {
-    return thread.badge.label;
-  }
-
-  if (thread.resume_cue) {
-    return thread.resume_cue.label;
-  }
-
-  return thread.current_activity.label;
-}
-
 function threadCueLabel(thread: PublicThreadListItem) {
   return thread.blocked_cue?.label ?? thread.resume_cue?.label ?? thread.badge?.label ?? null;
+}
+
+function threadStatusSymbol(thread: PublicThreadListItem) {
+  if (isWaitingApprovalThread(thread)) {
+    return "!";
+  }
+
+  if (isErrorOrFailedThread(thread)) {
+    return "x";
+  }
+
+  if (isActiveThread(thread)) {
+    return ">";
+  }
+
+  return ".";
+}
+
+function threadStatusLabel(thread: PublicThreadListItem) {
+  if (isWaitingApprovalThread(thread)) {
+    return "Waiting approval";
+  }
+
+  if (isErrorOrFailedThread(thread)) {
+    return "Needs review";
+  }
+
+  if (isActiveThread(thread)) {
+    return "Running";
+  }
+
+  return "Idle";
+}
+
+function compactName(value: string | null | undefined) {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return "--";
+  }
+
+  const initials = normalized
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("");
+
+  return (initials || normalized.slice(0, 2)).toUpperCase();
+}
+
+function readStoredSidebarMode() {
+  try {
+    const storage = window.localStorage;
+    if (typeof storage.getItem !== "function") {
+      return null;
+    }
+
+    const storedMode = storage.getItem(SIDEBAR_MODE_STORAGE_KEY);
+    return storedMode === "full" || storedMode === "mini" ? storedMode : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSidebarMode(nextMode: SidebarMode) {
+  try {
+    const storage = window.localStorage;
+    if (typeof storage.setItem === "function") {
+      storage.setItem(SIDEBAR_MODE_STORAGE_KEY, nextMode);
+    }
+  } catch {
+    // Sidebar preference should never block Navigation controls.
+  }
 }
 
 function workspaceSummary(workspace: PublicWorkspaceSummary) {
@@ -581,6 +641,7 @@ export function ChatView({
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
   const [selectedFilterId, setSelectedFilterId] = useState<ThreadFilterId>("all");
+  const [sidebarMode, setSidebarMode] = useState<SidebarMode>("full");
   const [expandedTimelineRows, setExpandedTimelineRows] = useState<Set<string>>(() => new Set());
   const [followLatestActivity, setFollowLatestActivity] = useState(true);
   const [hasSuppressedActivity, setHasSuppressedActivity] = useState(false);
@@ -589,7 +650,15 @@ export function ChatView({
   const latestActivitySignatureRef = useRef<string | null>(null);
   const selectedWorkspace =
     workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
+  const selectedThreadSummary =
+    threads.find((thread) => thread.thread_id === selectedThreadId) ?? null;
   const visibleThreads = filterThreads(threads, selectedFilterId);
+  const attentionThreads = threads.filter(
+    (thread) =>
+      isWaitingApprovalThread(thread) ||
+      isErrorOrFailedThread(thread) ||
+      backgroundPriorityNotice?.threadId === thread.thread_id,
+  );
   const threadFilters: Array<{ id: ThreadFilterId; label: string; count: number }> = [
     { id: "all", label: "All", count: threads.length },
     { id: "active", label: "Active", count: threads.filter(isActiveThread).length },
@@ -683,6 +752,14 @@ export function ChatView({
     selectedThreadView,
     workspaceId,
   });
+  const isSidebarMinibar = sidebarMode === "mini" && !isNavigationOpen;
+
+  useEffect(() => {
+    const storedMode = readStoredSidebarMode();
+    if (storedMode) {
+      setSidebarMode(storedMode);
+    }
+  }, []);
 
   useEffect(() => {
     setIsNavigationOpen(false);
@@ -731,6 +808,14 @@ export function ChatView({
   function askCodex() {
     onAskCodex();
     setIsNavigationOpen(false);
+  }
+
+  function updateSidebarMode(nextMode: SidebarMode) {
+    setSidebarMode(nextMode);
+    writeStoredSidebarMode(nextMode);
+    if (nextMode === "full") {
+      setIsNavigationOpen(false);
+    }
   }
 
   function handleScrollRegionScroll() {
@@ -865,7 +950,7 @@ export function ChatView({
           </button>
         </div>
       </header>
-      <div className="chat-layout">
+      <div className={isSidebarMinibar ? "chat-layout sidebar-minibar" : "chat-layout"}>
         {errorMessage || statusMessage ? (
           <div aria-live="polite" className="chat-feedback-stack">
             {errorMessage ? (
@@ -907,173 +992,260 @@ export function ChatView({
 
         <section
           aria-label="Navigation"
-          className={
-            isNavigationOpen
-              ? "chat-panel create-card thread-navigation open"
-              : "chat-panel create-card thread-navigation"
-          }
+          className={[
+            "chat-panel create-card thread-navigation",
+            isNavigationOpen ? "open" : "",
+            isSidebarMinibar ? "minibar" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
         >
-          <header>
-            <h2>{selectedWorkspace?.workspace_name ?? "Select workspace"}</h2>
-            <p className="workspace-meta">
-              {workspaceId ? "Workspace scope active" : "Choose or create a workspace."}
-            </p>
-          </header>
-
-          {workspaceId ? (
-            <button
-              className={
-                hasSelectedThread
-                  ? "primary-link action-button navigation-ask-codex"
-                  : "secondary-link action-button navigation-ask-codex"
-              }
-              onClick={askCodex}
-              type="button"
-            >
-              Ask Codex
-            </button>
-          ) : null}
-
-          <details className="workspace-switcher">
-            <summary>Switch workspace</summary>
-            <div className="workspace-switcher-control">
-              {isLoadingWorkspaces ? (
-                <p className="workspace-status">Loading workspaces...</p>
-              ) : null}
-              {workspaces.length > 0 ? (
-                <div className="workspace-option-list">
-                  {workspaces.map((workspace) => (
-                    <button
-                      className={
-                        workspace.workspace_id === workspaceId
-                          ? "workspace-option-card active"
-                          : "workspace-option-card"
-                      }
-                      key={workspace.workspace_id}
-                      onClick={() => onSelectWorkspace(workspace.workspace_id)}
-                      type="button"
-                    >
-                      <strong>{workspace.workspace_name}</strong>
-                      <span className="workspace-meta">{workspace.workspace_id}</span>
-                      <span className="workspace-meta">{workspaceSummary(workspace)}</span>
-                    </button>
-                  ))}
-                </div>
-              ) : !isLoadingWorkspaces ? (
-                <p className="empty-state">Create a workspace to start scoped work.</p>
-              ) : null}
-
-              <div className="create-form workspace-create-form">
-                <label className="form-label" htmlFor="workspace-name">
-                  New workspace
-                  <input
-                    id="workspace-name"
-                    name="workspace-name"
-                    onChange={(event) => onWorkspaceNameChange(event.target.value)}
-                    placeholder="Workspace name"
-                    value={workspaceName}
-                  />
-                </label>
+          {isSidebarMinibar ? (
+            <div className="navigation-minibar-stack">
+              <button
+                aria-label="Expand Navigation"
+                className="secondary-link action-button minibar-button"
+                onClick={() => updateSidebarMode("full")}
+                title="Expand Navigation"
+                type="button"
+              >
+                Nav
+              </button>
+              {workspaceId ? (
                 <button
-                  className="submit-button"
-                  disabled={isCreatingWorkspace || workspaceName.trim().length === 0}
-                  onClick={onCreateWorkspace}
+                  aria-label={`Start new thread in ${selectedWorkspace?.workspace_name ?? workspaceId}`}
+                  className="primary-link action-button minibar-button"
+                  onClick={askCodex}
+                  title="Ask Codex"
                   type="button"
                 >
-                  {isCreatingWorkspace ? "Creating..." : "Create workspace"}
+                  New
                 </button>
-              </div>
-            </div>
-          </details>
-
-          <div className="thread-list">
-            {isLoadingThreads ? <p className="workspace-status">Loading threads...</p> : null}
-
-            {!workspaceId && !isLoadingWorkspaces ? (
-              <p className="empty-state">Select a workspace to show its threads.</p>
-            ) : null}
-
-            {workspaceId && !isLoadingThreads && threads.length === 0 ? (
-              <p className="empty-state">No threads yet. Use Ask Codex in Thread View.</p>
-            ) : null}
-
-            {workspaceId && threads.length > 0 ? (
-              <div className="thread-filter-bar" role="tablist" aria-label="Thread filters">
-                {threadFilters.map((filter) => (
+              ) : null}
+              <button
+                aria-label={`Current workspace: ${
+                  selectedWorkspace?.workspace_name ?? workspaceId ?? "none"
+                }`}
+                className="secondary-link action-button minibar-button"
+                onClick={() => updateSidebarMode("full")}
+                title={selectedWorkspace?.workspace_name ?? workspaceId ?? "Select workspace"}
+                type="button"
+              >
+                {compactName(selectedWorkspace?.workspace_name ?? workspaceId)}
+              </button>
+              {selectedThreadSummary ? (
+                <button
+                  aria-label={`Current thread: ${selectedThreadSummary.title}`}
+                  aria-current="page"
+                  className="secondary-link action-button minibar-button active"
+                  onClick={() => selectThread(selectedThreadSummary.thread_id)}
+                  title={selectedThreadSummary.title}
+                  type="button"
+                >
+                  {threadStatusSymbol(selectedThreadSummary)}
+                </button>
+              ) : null}
+              {attentionThreads
+                .filter((thread) => thread.thread_id !== selectedThreadId)
+                .slice(0, 4)
+                .map((thread) => (
                   <button
-                    className={
-                      selectedFilterId === filter.id
-                        ? "thread-filter-chip active"
-                        : "thread-filter-chip"
-                    }
-                    key={filter.id}
-                    onClick={() => setSelectedFilterId(filter.id)}
-                    role="tab"
-                    aria-selected={selectedFilterId === filter.id}
+                    aria-label={`${threadStatusLabel(thread)}: ${thread.title}`}
+                    className="secondary-link action-button minibar-button attention"
+                    key={thread.thread_id}
+                    onClick={() => selectThread(thread.thread_id)}
+                    title={thread.title}
                     type="button"
                   >
-                    <span>{filter.label}</span>
-                    <span className="thread-filter-count">{filter.count}</span>
+                    {threadStatusSymbol(thread)}
                   </button>
                 ))}
-              </div>
-            ) : null}
+            </div>
+          ) : (
+            <>
+              <header>
+                <div className="workspace-meta-row navigation-header-row">
+                  <h2>{selectedWorkspace?.workspace_name ?? "Select workspace"}</h2>
+                  <button
+                    aria-label="Collapse Navigation to minibar"
+                    className="secondary-link action-button compact-button sidebar-mode-toggle"
+                    onClick={() => updateSidebarMode("mini")}
+                    type="button"
+                  >
+                    Minimize
+                  </button>
+                </div>
+                <p className="workspace-meta">
+                  {workspaceId ? "Workspace scope active" : "Choose or create a workspace."}
+                </p>
+              </header>
 
-            {workspaceId &&
-            !isLoadingThreads &&
-            threads.length > 0 &&
-            visibleThreads.length === 0 ? (
-              <p className="empty-state">No threads match this filter.</p>
-            ) : null}
-
-            {visibleThreads.map((thread) => {
-              const isSelected = selectedThreadId === thread.thread_id;
-              const rowCueLabel = threadCueLabel(thread);
-              const hasBackgroundNotice =
-                backgroundPriorityNotice?.threadId === thread.thread_id && !isSelected;
-
-              return (
+              {workspaceId ? (
                 <button
-                  className={isSelected ? "thread-summary-card active" : "thread-summary-card"}
-                  key={thread.thread_id}
-                  onClick={() => selectThread(thread.thread_id)}
+                  className={
+                    hasSelectedThread
+                      ? "primary-link action-button navigation-ask-codex"
+                      : "secondary-link action-button navigation-ask-codex"
+                  }
+                  onClick={askCodex}
                   type="button"
                 >
-                  <div className="workspace-meta-row thread-summary-header">
-                    <div className="thread-summary-title-block">
-                      <strong>{thread.title}</strong>
-                      <span className="workspace-meta">
-                        Updated {formatTimestamp(thread.updated_at)}
-                      </span>
-                    </div>
-                    <div className="thread-summary-statuses">
-                      {isSelected ? <span className="status-badge">Selected</span> : null}
-                      <span className={threadBadgeClass(thread)}>
-                        {thread.current_activity.label}
-                      </span>
-                    </div>
-                  </div>
-                  <p className="thread-summary-activity">{summarizeThreadActivity(thread)}</p>
-                  <div className="thread-summary-cues">
-                    {rowCueLabel ? (
-                      <span className="status-badge">{formatMachineLabel(rowCueLabel)}</span>
-                    ) : null}
-                    {hasBackgroundNotice ? (
-                      <span className="status-badge warning">Needs attention now</span>
-                    ) : null}
-                    {thread.badge && rowCueLabel !== thread.badge.label ? (
-                      <span className="status-badge">{formatMachineLabel(thread.badge.label)}</span>
-                    ) : null}
-                  </div>
-                  {hasBackgroundNotice ? (
-                    <p className="thread-summary-notice">
-                      Background notice: {backgroundPriorityNotice?.reason}
-                    </p>
-                  ) : null}
+                  Ask Codex
                 </button>
-              );
-            })}
-          </div>
+              ) : null}
+
+              <details className="workspace-switcher">
+                <summary>Switch workspace</summary>
+                <div className="workspace-switcher-control">
+                  {isLoadingWorkspaces ? (
+                    <p className="workspace-status">Loading workspaces...</p>
+                  ) : null}
+                  {workspaces.length > 0 ? (
+                    <div className="workspace-option-list">
+                      {workspaces.map((workspace) => (
+                        <button
+                          className={
+                            workspace.workspace_id === workspaceId
+                              ? "workspace-option-card active"
+                              : "workspace-option-card"
+                          }
+                          key={workspace.workspace_id}
+                          onClick={() => onSelectWorkspace(workspace.workspace_id)}
+                          type="button"
+                        >
+                          <strong>{workspace.workspace_name}</strong>
+                          <span className="workspace-meta">{workspace.workspace_id}</span>
+                          <span className="workspace-meta">{workspaceSummary(workspace)}</span>
+                        </button>
+                      ))}
+                    </div>
+                  ) : !isLoadingWorkspaces ? (
+                    <p className="empty-state">Create a workspace to start scoped work.</p>
+                  ) : null}
+
+                  <div className="create-form workspace-create-form">
+                    <label className="form-label" htmlFor="workspace-name">
+                      New workspace
+                      <input
+                        id="workspace-name"
+                        name="workspace-name"
+                        onChange={(event) => onWorkspaceNameChange(event.target.value)}
+                        placeholder="Workspace name"
+                        value={workspaceName}
+                      />
+                    </label>
+                    <button
+                      className="submit-button"
+                      disabled={isCreatingWorkspace || workspaceName.trim().length === 0}
+                      onClick={onCreateWorkspace}
+                      type="button"
+                    >
+                      {isCreatingWorkspace ? "Creating..." : "Create workspace"}
+                    </button>
+                  </div>
+                </div>
+              </details>
+
+              <div className="thread-list">
+                {isLoadingThreads ? <p className="workspace-status">Loading threads...</p> : null}
+
+                {!workspaceId && !isLoadingWorkspaces ? (
+                  <p className="empty-state">Select a workspace to show its threads.</p>
+                ) : null}
+
+                {workspaceId && !isLoadingThreads && threads.length === 0 ? (
+                  <p className="empty-state">No threads yet. Use Ask Codex in Thread View.</p>
+                ) : null}
+
+                {workspaceId && threads.length > 0 ? (
+                  <div className="thread-filter-bar" role="tablist" aria-label="Thread filters">
+                    {threadFilters.map((filter) => (
+                      <button
+                        className={
+                          selectedFilterId === filter.id
+                            ? "thread-filter-chip active"
+                            : "thread-filter-chip"
+                        }
+                        key={filter.id}
+                        onClick={() => setSelectedFilterId(filter.id)}
+                        role="tab"
+                        aria-selected={selectedFilterId === filter.id}
+                        type="button"
+                      >
+                        <span>{filter.label}</span>
+                        <span className="thread-filter-count">{filter.count}</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+
+                {workspaceId &&
+                !isLoadingThreads &&
+                threads.length > 0 &&
+                visibleThreads.length === 0 ? (
+                  <p className="empty-state">No threads match this filter.</p>
+                ) : null}
+
+                {visibleThreads.map((thread) => {
+                  const isSelected = selectedThreadId === thread.thread_id;
+                  const rowCueLabel = threadCueLabel(thread);
+                  const hasBackgroundNotice =
+                    backgroundPriorityNotice?.threadId === thread.thread_id && !isSelected;
+                  const isAttention = rowCueLabel !== null || hasBackgroundNotice;
+
+                  return (
+                    <button
+                      aria-current={isSelected ? "page" : undefined}
+                      className={isSelected ? "thread-summary-card active" : "thread-summary-card"}
+                      key={thread.thread_id}
+                      onClick={() => selectThread(thread.thread_id)}
+                      type="button"
+                    >
+                      <div className="workspace-meta-row thread-summary-header">
+                        <span
+                          aria-label={threadStatusLabel(thread)}
+                          className={threadBadgeClass(thread).replace(
+                            "status-badge",
+                            "thread-status-mark",
+                          )}
+                          role="img"
+                          title={threadStatusLabel(thread)}
+                        >
+                          {threadStatusSymbol(thread)}
+                        </span>
+                        <div className="thread-summary-title-block">
+                          <strong>{thread.title}</strong>
+                          <span className="workspace-meta">
+                            Updated {formatTimestamp(thread.updated_at)}
+                          </span>
+                        </div>
+                      </div>
+                      {isAttention ? (
+                        <div className="thread-summary-cues">
+                          {rowCueLabel ? (
+                            <span className="status-badge">{formatMachineLabel(rowCueLabel)}</span>
+                          ) : null}
+                          {hasBackgroundNotice ? (
+                            <span className="status-badge warning">Needs attention now</span>
+                          ) : null}
+                          {thread.badge && rowCueLabel !== thread.badge.label ? (
+                            <span className="status-badge">
+                              {formatMachineLabel(thread.badge.label)}
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : null}
+                      {hasBackgroundNotice ? (
+                        <p className="thread-summary-notice">
+                          Background notice: {backgroundPriorityNotice?.reason}
+                        </p>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
         </section>
 
         <section aria-label="Thread View" className="chat-panel workspace-card thread-view-card">

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -184,15 +184,151 @@ describe("ChatView", () => {
     expect(markup).toContain("Approval thread");
     expect(markup).toContain("Active thread");
     expect(markup).toContain("Recent thread");
-    expect(markup).toContain("Selected");
+    expect(markup).toContain('aria-current="page"');
+    expect(markup).not.toContain(">Selected<");
     expect(markup).toContain("Needs response");
-    expect(markup).toContain("Waiting for your input");
+    expect(markup).toContain('aria-label="Idle"');
     expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
     expect(markup).toContain('id="thread-composer-input"');
     expect(markup).not.toContain('id="thread-input"');
     expect(markup).not.toContain('id="message-input"');
     expect(markup).not.toContain("Home");
     expect(markup).not.toContain("Thread ref:");
+  });
+
+  it("switches desktop Navigation into a recoverable minibar", async () => {
+    const storage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    };
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={{
+            threadId: "thread_approval",
+            reason: "Needs response",
+          }}
+          connectionState="idle"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_active"
+          selectedThreadView={null}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[
+            {
+              thread_id: "thread_active",
+              title: "Active thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:20:00Z",
+              current_activity: {
+                kind: "running",
+                label: "Running",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+            {
+              thread_id: "thread_approval",
+              title: "Approval thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: ["waiting_on_request"],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+              current_activity: {
+                kind: "waiting_on_approval",
+                label: "Approval required",
+              },
+              badge: {
+                kind: "approval",
+                label: "Waiting approval",
+              },
+              blocked_cue: {
+                kind: "approval_required",
+                label: "Needs response",
+              },
+              resume_cue: null,
+            },
+          ]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[
+            {
+              workspace_id: "ws_alpha",
+              workspace_name: "alpha",
+              created_at: "2026-03-27T05:00:00Z",
+              updated_at: "2026-03-27T05:22:00Z",
+              active_session_summary: null,
+              pending_approval_count: 1,
+            },
+          ]}
+        />,
+      );
+    });
+
+    const minimizeButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Minimize",
+    );
+    expect(minimizeButton).toBeDefined();
+
+    await act(async () => {
+      minimizeButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector(".chat-layout.sidebar-minibar")).not.toBeNull();
+    expect(container.textContent).toContain("Nav");
+    expect(container.textContent).toContain("New");
+    expect(container.querySelector('[aria-label="Expand Navigation"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Current thread: Active thread"]')).not.toBeNull();
+    expect(
+      container.querySelector('[aria-label="Waiting approval: Approval thread"]'),
+    ).not.toBeNull();
+    expect(storage.setItem).toHaveBeenCalledWith("codex-webui.sidebar-mode", "mini");
+
+    const expandButton = container.querySelector(
+      '[aria-label="Expand Navigation"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      expandButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector(".chat-layout.sidebar-minibar")).toBeNull();
+    expect(storage.setItem).toHaveBeenCalledWith("codex-webui.sidebar-mode", "full");
   });
 
   it("filters visible rows without changing thread selection behavior", async () => {
@@ -436,7 +572,7 @@ describe("ChatView", () => {
     });
 
     expect(container.textContent).toContain("Mapped idle thread");
-    expect(container.textContent).toContain("Waiting for your input");
+    expect(container.querySelector('[aria-label="Idle"]')).not.toBeNull();
     expect(container.textContent).not.toContain("Running thread");
   });
 

--- a/tasks/archive/issue-234-navigation-minibar/README.md
+++ b/tasks/archive/issue-234-navigation-minibar/README.md
@@ -1,0 +1,56 @@
+# Issue #234 Navigation Minibar
+
+## Purpose
+
+Simplify Navigation thread cards and add a desktop sidebar minibar mode so Navigation supports selection and triage without competing with the Timeline.
+
+## Primary issue
+
+- https://github.com/tsukushibito/codex-webui/issues/234
+
+## Source docs
+
+- `docs/notes/codex_webui_thread_view_information_architecture_note_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/src/chat-view.tsx`
+
+## Scope for this package
+
+- Remove long repeated status prose from routine Navigation cards.
+- Replace the selected text badge with structural selected state and an icon-like status mark.
+- Add a desktop sidebar minibar mode with local preference persistence.
+- Keep recovery paths from minibar to full Navigation, new thread, current workspace, current thread, and attention threads.
+
+## Exit criteria
+
+- Navigation cards show title, compact updated time, status mark, selected state, and attention cues only when meaningful.
+- Full Navigation can collapse to a minibar and expand back via keyboard-accessible buttons.
+- The minibar keeps current workspace/thread orientation and attention-thread affordances.
+- Existing mobile Navigation and thread selection behavior continue to work.
+
+## Artifacts / evidence
+
+- Local implementation validation passed:
+  - `npm run check`: passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm test -- tests/chat-view.test.tsx`: 17 tests passed.
+  - `npm run test:e2e -- e2e/chat-flow.spec.ts --project=desktop-chromium --reporter=line`: 1 test passed.
+  - `npm run test:e2e -- e2e/chat-flow.spec.ts --project=mobile-chromium --reporter=line`: 1 test passed.
+- Playwright emitted the known `NO_COLOR` / `FORCE_COLOR` warning; it did not block tests.
+
+## Status / handoff notes
+
+- Active worktree: `.worktrees/issue-234-navigation-minibar`
+- Active branch: `issue-234-navigation-minibar`
+- Active PR: None yet.
+- Completion boundary: package archive, PR, main merge, Issue close.
+- Contract check:
+  - Selected Navigation card uses `aria-current="page"` and the active style, not a visible `Selected` badge.
+  - Routine idle cards no longer repeat long current-activity prose.
+  - Minibar exposes Expand Navigation, New, current workspace, current thread, and attention-thread buttons.
+  - Sidebar mode writes to `localStorage` when available and degrades without blocking controls.
+- Retrospective:
+  - What worked: keeping the minibar inside the existing Navigation landmark preserved recovery paths without adding a second navigation system.
+  - Workflow problems: jsdom's localStorage shape in this test environment required defensive storage access.
+  - Improvements to adopt: preference-backed UI state should tolerate unavailable or nonstandard storage APIs.
+  - Skill candidates or skill updates: none.


### PR DESCRIPTION
## Summary
- simplify Navigation thread cards around compact status marks, title, updated time, and meaningful attention cues
- replace the visible Selected badge with aria-current and active styling
- add a desktop sidebar minibar mode with local preference persistence and recovery actions

## Validation
- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm test -- tests/chat-view.test.tsx
- npm run test:e2e -- e2e/chat-flow.spec.ts --project=desktop-chromium --reporter=line
- npm run test:e2e -- e2e/chat-flow.spec.ts --project=mobile-chromium --reporter=line

Closes #234