### PR TITLE
test(ui): cover timeline first ia

### DIFF
--- a/apps/frontend-bff/e2e/issue-235-timeline-first-ia.spec.ts
+++ b/apps/frontend-bff/e2e/issue-235-timeline-first-ia.spec.ts
@@ -1,0 +1,124 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import {
+  expectNoHorizontalScroll,
+  mockApprovalFlow,
+  mockChatFlow,
+  stubEventSource,
+} from "./helpers/browser-mocks";
+
+async function expectTimelineFirstViewport(page: Page) {
+  const metrics = await page.evaluate(() => {
+    const threadView = document.querySelector<HTMLElement>(".thread-view-card");
+    const header = document.querySelector<HTMLElement>(".thread-view-header-stack");
+    const body = document.querySelector<HTMLElement>(".thread-view-body");
+    const timeline = document.querySelector<HTMLElement>(".thread-view-scroll-region");
+
+    return {
+      bodyHeight: body?.getBoundingClientRect().height ?? 0,
+      headerHeight: header?.getBoundingClientRect().height ?? 0,
+      threadViewHeight: threadView?.getBoundingClientRect().height ?? 0,
+      timelineHeight: timeline?.getBoundingClientRect().height ?? 0,
+    };
+  });
+
+  expect(metrics.threadViewHeight).toBeGreaterThan(0);
+  expect(metrics.timelineHeight).toBeGreaterThan(120);
+  expect(metrics.timelineHeight).toBeGreaterThan(metrics.headerHeight);
+  expect(metrics.bodyHeight / metrics.threadViewHeight).toBeGreaterThan(0.58);
+}
+
+test("desktop preserves Timeline-first IA, recoverable details, and Navigation minibar", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-chromium", "desktop-only IA viewport check");
+
+  await stubEventSource(page);
+  await mockChatFlow(page);
+
+  await page.goto("/chat");
+  await page.locator("details.workspace-switcher summary").click();
+  await page.locator("#workspace-name").fill("alpha");
+  await page.getByRole("button", { name: "Create workspace" }).click();
+  await page.getByLabel("Ask Codex").fill("Inspect the Timeline-first IA");
+  await page.getByRole("button", { name: "Start thread", exact: true }).click();
+  await expect(page).toHaveURL(/threadId=thread_001/);
+  await expect(page.getByRole("region", { name: "Timeline", exact: true })).toBeVisible();
+
+  const navigation = page.getByRole("region", { name: "Navigation", exact: true });
+  const selectedThreadCard = navigation.locator(".thread-summary-card.active");
+  await expect(selectedThreadCard).toHaveAttribute("aria-current", "page");
+  await expect(selectedThreadCard).not.toContainText("Selected");
+  await expect(page.locator(".current-activity-card")).toHaveCount(0);
+  await expect(page.locator(".thread-feedback-card-inline")).toHaveCount(0);
+  await expectTimelineFirstViewport(page);
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+  await page.getByRole("button", { name: "Details", exact: true }).first().click();
+  const detailSurface = page.locator(".thread-detail-surface");
+  await expect(detailSurface).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Thread details", exact: true })).toBeVisible();
+  await expect(detailSurface).toContainText("Overview");
+  await expect(detailSurface).toContainText("Status");
+  await expect(detailSurface).toContainText("Next action");
+  await expect(detailSurface).toContainText("Requests");
+  await expect(detailSurface).toContainText("Artifacts");
+  await expect(detailSurface).toContainText("Debug: raw thread view JSON");
+
+  await detailSurface.getByRole("button", { name: "Close", exact: true }).click();
+  await expect(detailSurface).toHaveCount(0);
+  await page.getByLabel("Collapse Navigation to minibar").click();
+  await expect(page.locator(".chat-layout.sidebar-minibar")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Expand Navigation", exact: true })).toBeVisible();
+  await expect(page.locator(".navigation-minibar-stack .minibar-button.active")).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+  await page.getByRole("button", { name: "Expand Navigation", exact: true }).click();
+  await expect(page.locator(".chat-layout.sidebar-minibar")).toHaveCount(0);
+
+  await testInfo.attach("issue-235-desktop-timeline-first", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+});
+
+test("mobile keeps compact thread recovery and details reachable", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "mobile-chromium", "mobile-only compact recovery check");
+
+  await stubEventSource(page);
+  await mockApprovalFlow(page, { longTimeline: true });
+
+  await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
+  await expect(page.getByRole("region", { name: "Timeline", exact: true })).toBeVisible();
+  await expect(page.locator(".pending-request-card")).toBeVisible();
+  await expect(page.locator(".thread-mobile-footer-actions")).toBeVisible();
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+  await page
+    .locator(".thread-mobile-footer-actions")
+    .getByRole("button", { name: "Details", exact: true })
+    .click();
+  const detailSurface = page.locator(".thread-detail-surface");
+  await expect(detailSurface).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Request detail", exact: true })).toBeVisible();
+  await expect(detailSurface).toContainText("Apply the prepared deployment plan.");
+  await expect(detailSurface.getByRole("button", { name: "Approve request" })).toBeVisible();
+  await expect(detailSurface.getByRole("button", { name: "Deny request" })).toBeVisible();
+  await detailSurface.getByRole("button", { name: "Close", exact: true }).click();
+
+  await page
+    .locator(".thread-mobile-footer-actions")
+    .getByRole("button", { name: "Threads", exact: true })
+    .click();
+  await expect(page.locator(".thread-navigation.open")).toBeVisible();
+  await expect(
+    page.locator("section.thread-navigation").getByRole("button", { name: /Needs your response/ }),
+  ).toBeVisible();
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+  await testInfo.attach("issue-235-mobile-thread-recovery", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+});

--- a/tasks/archive/issue-235-ia-validation/README.md
+++ b/tasks/archive/issue-235-ia-validation/README.md
@@ -1,0 +1,57 @@
+# Issue #235 Timeline-First IA Validation
+
+## Purpose
+
+Add reproducible validation for the Timeline-first information architecture cleanup so reduced status chrome, Thread Details recoverability, Timeline space, and Navigation minibar behavior do not regress.
+
+## Primary issue
+
+- https://github.com/tsukushibito/codex-webui/issues/235
+
+## Source docs
+
+- `docs/notes/codex_webui_thread_view_information_architecture_note_v0_1.md`
+- `docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md`
+- `apps/frontend-bff/e2e/`
+
+## Scope for this package
+
+- Add focused Playwright coverage for desktop Timeline-first viewport behavior.
+- Validate Thread Details reachability after the cleanup.
+- Validate Navigation card density and sidebar/minibar recovery.
+- Validate mobile compact recovery paths and request detail reachability.
+- Attach desktop/mobile visual evidence from the E2E run.
+
+## Exit criteria
+
+- Desktop E2E proves duplicate visible status surfaces remain absent and Timeline keeps a dominant viewport share.
+- E2E proves details content is still reachable.
+- E2E proves minibar switching preserves current workspace/thread orientation.
+- Mobile E2E proves compact Threads/Details recovery paths remain reachable.
+- Focused checks pass.
+
+## Artifacts / evidence
+
+- Local validation passed:
+  - `npm run check`: passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `npm run test:e2e -- e2e/issue-235-timeline-first-ia.spec.ts --project=desktop-chromium --reporter=line`: 1 passed, 1 skipped.
+  - `npm run test:e2e -- e2e/issue-235-timeline-first-ia.spec.ts --project=mobile-chromium --reporter=line`: 1 passed, 1 skipped.
+- The new E2E attaches desktop and mobile screenshots through Playwright `testInfo.attach`.
+- Playwright emitted the known `NO_COLOR` / `FORCE_COLOR` warning; it did not block tests.
+
+## Status / handoff notes
+
+- Active worktree: `.worktrees/issue-235-ia-validation`
+- Active branch: `issue-235-ia-validation`
+- Active PR: None yet.
+- Completion boundary: package archive, PR, main merge, Issue close.
+- Contract check:
+  - Desktop E2E checks no visible Current Activity card, no inline idle Thread Feedback card, selected Navigation card `aria-current`, Thread Details reachability, minibar collapse/expand, and no horizontal scroll.
+  - Desktop viewport check confirms the Timeline scroll region remains visible and larger than the compact header in the initial thread view.
+  - Mobile E2E checks pending request controls, Details recovery, Threads recovery, and no horizontal scroll.
+- Retrospective:
+  - What worked: using existing browser mocks made the IA validation deterministic without new backend fixtures.
+  - Workflow problems: project-specific tests need explicit skips because the validation spec contains desktop-only and mobile-only cases.
+  - Improvements to adopt: future viewport assertions should verify concrete UI contracts without overfitting exact pixel ratios.
+  - Skill candidates or skill updates: none.


### PR DESCRIPTION
## Summary
- add focused Playwright coverage for Timeline-first desktop IA cleanup
- validate Thread Details reachability, Navigation selected-state/card density, and minibar recovery
- validate mobile Details/Threads recovery paths for compact thread views

## Validation
- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm run test:e2e -- e2e/issue-235-timeline-first-ia.spec.ts --project=desktop-chromium --reporter=line
- npm run test:e2e -- e2e/issue-235-timeline-first-ia.spec.ts --project=mobile-chromium --reporter=line

Closes #235