### PR TITLE
docs: align README scope with v0.9 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,19 @@ The MVP targets browser access from both PC and smartphone while keeping the pub
 
 This repository currently contains two application directories under [`apps/`](./apps/README.md):
 
-- [`apps/codex-runtime/`](./apps/codex-runtime/README.md): private runtime service that manages `codex app-server`, workspace and session state, and app-owned persistence
-- [`apps/frontend-bff/`](./apps/frontend-bff/README.md): public BFF and browser UI built on Next.js, including REST facade and SSE relay responsibilities
+- [`apps/codex-runtime/`](./apps/codex-runtime/README.md): private runtime service that manages `codex app-server`, workspace state, and v0.9 thread/request/timeline projections
+- [`apps/frontend-bff/`](./apps/frontend-bff/README.md): public BFF and browser UI built on Next.js, including the v0.9 REST facade, browser shaping, and SSE relay responsibilities
 
 ## Source-of-truth documents
 
 Start with these maintained documents when you need project intent or interface boundaries:
 
 - [`docs/codex_webui_mvp_roadmap_v0_1.md`](./docs/codex_webui_mvp_roadmap_v0_1.md)
-- [`docs/requirements/codex_webui_mvp_requirements_v0_8.md`](./docs/requirements/codex_webui_mvp_requirements_v0_8.md)
-- [`docs/specs/codex_webui_common_spec_v0_8.md`](./docs/specs/codex_webui_common_spec_v0_8.md)
-- [`docs/specs/codex_webui_public_api_v0_8.md`](./docs/specs/codex_webui_public_api_v0_8.md)
-- [`docs/specs/codex_webui_internal_api_v0_8.md`](./docs/specs/codex_webui_internal_api_v0_8.md)
+- [`docs/requirements/codex_webui_mvp_requirements_v0_9.md`](./docs/requirements/codex_webui_mvp_requirements_v0_9.md)
+- [`docs/specs/codex_webui_common_spec_v0_9.md`](./docs/specs/codex_webui_common_spec_v0_9.md)
+- [`docs/specs/codex_webui_public_api_v0_9.md`](./docs/specs/codex_webui_public_api_v0_9.md)
+- [`docs/specs/codex_webui_internal_api_v0_9.md`](./docs/specs/codex_webui_internal_api_v0_9.md)
+- [`docs/specs/codex_webui_ui_layout_spec_v0_9.md`](./docs/specs/codex_webui_ui_layout_spec_v0_9.md)
 - [`docs/specs/codex_webui_technical_stack_decision_v0_1.md`](./docs/specs/codex_webui_technical_stack_decision_v0_1.md)
 
 ## Development entrypoints

--- a/apps/codex-runtime/README.md
+++ b/apps/codex-runtime/README.md
@@ -1,13 +1,19 @@
 # codex-runtime
 
-This directory contains the first implementation slice of the MVP runtime described in the maintained specifications.
+This directory contains the private runtime service for the MVP implementation described in the maintained v0.9 specifications.
 
-## Scope in this slice
+## Current scope
 
 - App-server supervisor lifecycle wired into runtime startup and shutdown
-- SQLite-backed workspace registry
-- `workspace_id <-> session_id` correspondence storage helpers
-- Internal `GET /api/v1/workspaces`, `POST /api/v1/workspaces`, and `GET /api/v1/workspaces/{workspace_id}`
+- SQLite-backed workspace registry and app-owned persistence
+- Internal v0.9 workspace, thread, request-helper, timeline, and stream routes
+- Thread/request projections over the native `codex app-server` thread lifecycle
+- Recovery-oriented helper state that can be rebuilt from native facts plus minimal app-owned metadata
+
+Use the maintained v0.9 internal API spec and roadmap for current behavior boundaries:
+
+- `../../docs/specs/codex_webui_internal_api_v0_9.md`
+- `../../docs/codex_webui_mvp_roadmap_v0_1.md`
 
 ## Stack
 

--- a/apps/frontend-bff/README.md
+++ b/apps/frontend-bff/README.md
@@ -1,14 +1,21 @@
 # frontend-bff
 
-This directory contains the first public API BFF slice for Phase 4A.
+This directory contains the public BFF and browser UI for the MVP implementation described in the maintained v0.9 specifications.
 
-## Scope in this slice
+## Current scope
 
-- Next.js 15 Route Handlers for the public REST facade
-- Runtime client wiring to `codex-runtime`
-- Public-to-internal schema mapping for workspace, session, message, event, and approval REST routes
+- Next.js 15 Route Handlers for the public v0.9 REST facade
+- Runtime client wiring to private `codex-runtime`
+- Public shaping for workspace, thread, thread view, timeline, request helper, and notification stream data
+- Browser-facing SSE relay responsibilities for thread and notification streams
+- Thread-first browser UI surfaces for navigation, timeline, details, request response, and composer workflows
 - Public error passthrough and runtime-unavailable handling
-- `can_*` derivation in the BFF
+
+Use the maintained v0.9 public API and UI layout specs for current behavior boundaries:
+
+- `../../docs/specs/codex_webui_public_api_v0_9.md`
+- `../../docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `../../docs/codex_webui_mvp_roadmap_v0_1.md`
 
 ## Stack
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-257-readme-v09-sync](./archive/issue-257-readme-v09-sync/README.md)
 - [issue-261-tracking-drift](./archive/issue-261-tracking-drift/README.md)
 - [issue-222-ui-gap-validation](./archive/issue-222-ui-gap-validation/README.md)
 - [issue-221-visual-language-polish](./archive/issue-221-visual-language-polish/README.md)

--- a/tasks/archive/issue-257-readme-v09-sync/README.md
+++ b/tasks/archive/issue-257-readme-v09-sync/README.md
@@ -1,0 +1,64 @@
+# Issue 257 README v0.9 sync
+
+## Purpose
+
+Update stale root and app README scope text so contributors start from the maintained v0.9 thread/request direction instead of the older session/approval implementation framing.
+
+## Primary issue
+
+- https://github.com/tsukushibito/codex-webui/issues/257
+
+## Source docs
+
+- `README.md`
+- `apps/codex-runtime/README.md`
+- `apps/frontend-bff/README.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+
+## Scope for this package
+
+- Replace stale session/approval-centered scope wording in README files with v0.9 thread/request wording.
+- Keep setup, commands, validation order, and app-local operational instructions intact.
+- Avoid duplicating long v0.9 specs in README files.
+
+## Exit criteria
+
+- Root README points contributors to current v0.9 source-of-truth docs.
+- `apps/codex-runtime/README.md` describes current runtime responsibilities around thread/request/timeline helpers.
+- `apps/frontend-bff/README.md` describes current BFF/UI responsibilities around public v0.9 routes, shaping, and streams.
+- Markdown/diff validation passes.
+
+## Work plan
+
+1. Update root README current implementation and source-of-truth links.
+2. Update runtime README scope text without changing command sections.
+3. Update frontend-bff README scope text without changing command sections.
+4. Run focused markdown/diff checks.
+5. Archive this package after local completion evidence is recorded.
+
+## Artifacts / evidence
+
+- Validation:
+  - `rg -n "v0_8|session/message/event/approval|workspace and session state|Scope in this slice|first public API BFF slice|first implementation slice" README.md apps/codex-runtime/README.md apps/frontend-bff/README.md` returned no matches.
+  - `git diff --check` passed.
+- `docs/index.md` and `docs/log.md` were not updated because this slice changed root/app operational README orientation, not maintained `docs/` wiki content or navigation.
+
+## Status / handoff notes
+
+- 2026-04-26: Package created. Active branch is `issue-257-readme-v09-sync`; active worktree is `.worktrees/issue-257-readme-v09-sync`.
+- 2026-04-26: Updated root, runtime, and frontend-bff README scope text to point at v0.9 thread/request/timeline contracts while preserving command sections.
+- 2026-04-26 retrospective:
+  - Completion boundary: package archive for #257.
+  - Contract check: stale README terminology removed; command/validation sections were left intact.
+  - What worked: limiting the patch to scope/source-of-truth text kept the docs change low risk.
+  - Workflow problems: none beyond the already logged Issue-body quoting anomaly from the parent refactor run.
+  - Improvements to adopt: for README scope refreshes, verify stale phrases with `rg` before archiving.
+  - Skill candidates or updates: none.
+  - Follow-up updates: final Issue close waits for PR merge, parent sync, and worktree cleanup.
+
+## Archive conditions
+
+- Archive after README updates are complete, focused validation has passed, and the package notes include final evidence.


### PR DESCRIPTION
## Summary

- update root README source-of-truth links from v0.8 to v0.9
- refresh runtime README scope around v0.9 thread/request/timeline responsibilities
- refresh frontend-bff README scope around v0.9 public API, browser shaping, streams, and thread-first UI
- archive the #257 task package with validation notes

Closes #257

## Validation

- `rg -n "v0_8|session/message/event/approval|workspace and session state|Scope in this slice|first public API BFF slice|first implementation slice" README.md apps/codex-runtime/README.md apps/frontend-bff/README.md` returned no matches
- `git diff --check`
