### PR TITLE
fix: normalize active thread request errors

### DIFF
--- a/apps/codex-runtime/src/domain/threads/thread-service.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-service.ts
@@ -252,9 +252,24 @@ function mapRequestError(error: unknown, requestId: string): never {
     throw error;
   }
 
+  if (runtimeError.code === "session_not_found" || runtimeError.code === "thread_not_found") {
+    throw new RuntimeError(404, "request_not_found", "request was not found", {
+      request_id: requestId,
+      thread_id: runtimeError.details?.thread_id ?? runtimeError.details?.session_id ?? null,
+    });
+  }
+
   if (runtimeError.code === "approval_not_found") {
     throw new RuntimeError(404, "request_not_found", "request was not found", {
       request_id: requestId,
+    });
+  }
+
+  if (runtimeError.code === "session_invalid_state") {
+    throw new RuntimeError(409, "request_not_pending", "request is not pending", {
+      request_id: requestId,
+      thread_id: runtimeError.details?.thread_id ?? runtimeError.details?.session_id ?? null,
+      status: runtimeError.details?.current_status ?? runtimeError.details?.status ?? null,
     });
   }
 

--- a/apps/codex-runtime/tests/thread-routes.test.ts
+++ b/apps/codex-runtime/tests/thread-routes.test.ts
@@ -1194,6 +1194,43 @@ describe("thread routes", () => {
     database.db
       .insert(sessions)
       .values({
+        sessionId: "thread_orphan",
+        workspaceId: "ws_alpha",
+        title: "Orphaned request thread",
+        status: "waiting_approval",
+        createdAt: "2026-04-09T00:00:30.000Z",
+        updatedAt: "2026-04-09T00:01:30.000Z",
+        startedAt: "2026-04-09T00:00:30.000Z",
+        lastMessageAt: "2026-04-09T00:01:00.000Z",
+        activeApprovalId: "apr_orphan",
+        currentTurnId: "turn_orphan",
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    database.db
+      .insert(approvals)
+      .values({
+        approvalId: "apr_orphan",
+        sessionId: "thread_orphan",
+        workspaceId: "ws_alpha",
+        status: "pending",
+        resolution: null,
+        approvalCategory: "external_side_effect",
+        summary: "Run git push",
+        reason: "Codex requests permission to push changes to remote.",
+        operationSummary: "git push origin main",
+        context: null,
+        createdAt: "2026-04-09T00:01:30.000Z",
+        resolvedAt: null,
+        nativeRequestKind: "approval",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
         sessionId: "thread_001",
         workspaceId: "ws_alpha",
         title: "Resolved request thread",
@@ -1208,6 +1245,18 @@ describe("thread routes", () => {
         appSessionOverlayState: "open",
       })
       .run();
+
+    const orphanDetailResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/requests/apr_orphan",
+    });
+
+    expect(orphanDetailResponse.statusCode).toBe(200);
+    expect(orphanDetailResponse.json()).toMatchObject({
+      request_id: "apr_orphan",
+      thread_id: "thread_orphan",
+      status: "pending",
+    });
 
     database.db
       .insert(approvals)
@@ -1246,6 +1295,33 @@ describe("thread routes", () => {
         },
       },
     });
+
+    app.runtimeServices.nativeSessionGateway.resolveApproval = async () => {
+      throw new RuntimeError(404, "session_not_found", "session was not found", {
+        session_id: "thread_orphan",
+      });
+    };
+
+    const orphanResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/requests/apr_orphan/response",
+      payload: {
+        decision: "approved",
+      },
+    });
+
+    expect(orphanResponse.statusCode).toBe(404);
+    const orphanJson = orphanResponse.json();
+    expect(orphanJson).toMatchObject({
+      error: {
+        code: "request_not_found",
+        details: {
+          request_id: "apr_orphan",
+          thread_id: "thread_orphan",
+        },
+      },
+    });
+    expect(orphanJson.error.details).not.toHaveProperty("session_id");
 
     await app.close();
   });

--- a/apps/frontend-bff/src/handlers.ts
+++ b/apps/frontend-bff/src/handlers.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { logLiveChatDebug } from "./debug";
+import type { ErrorEnvelope } from "./errors";
 import { isErrorEnvelope, toErrorResponse } from "./errors";
 import {
   mapApprovalDetail,
@@ -117,11 +118,173 @@ function jsonResponse(status: number, body: unknown) {
   return NextResponse.json(body, { status });
 }
 
-async function parseRuntimeErrorResponse(response: Response) {
+type ActiveRuntimeErrorMapping = {
+  requestId?: string;
+  sessionInvalidStateCode?: string;
+  sessionNotFoundCode: string;
+  threadId?: string;
+};
+
+function normalizeActiveRuntimeErrorEnvelope(
+  body: ErrorEnvelope,
+  mapping: ActiveRuntimeErrorMapping,
+): ErrorEnvelope {
+  const details = { ...body.error.details };
+
+  const sessionId =
+    typeof details.session_id === "string"
+      ? details.session_id
+      : typeof mapping.threadId === "string"
+        ? mapping.threadId
+        : null;
+  const currentStatus =
+    typeof details.current_status === "string"
+      ? details.current_status
+      : typeof details.status === "string"
+        ? details.status
+        : null;
+
+  if (body.error.code === "session_not_found") {
+    if (mapping.sessionNotFoundCode === "request_not_found") {
+      return {
+        error: {
+          code: "request_not_found",
+          message: "request was not found",
+          details: {
+            ...(mapping.requestId ? { request_id: mapping.requestId } : {}),
+            ...(typeof details.thread_id === "string"
+              ? { thread_id: details.thread_id }
+              : typeof sessionId === "string"
+                ? { thread_id: sessionId }
+                : {}),
+          },
+        },
+      };
+    }
+
+    return {
+      error: {
+        code: "thread_not_found",
+        message: "thread was not found",
+        details: {
+          ...(typeof details.thread_id === "string"
+            ? { thread_id: details.thread_id }
+            : typeof sessionId === "string"
+              ? { thread_id: sessionId }
+              : {}),
+        },
+      },
+    };
+  }
+
+  if (body.error.code === "session_invalid_state" && mapping.sessionInvalidStateCode) {
+    if (mapping.sessionInvalidStateCode === "request_not_pending") {
+      return {
+        error: {
+          code: "request_not_pending",
+          message: "request is not pending",
+          details: {
+            ...(mapping.requestId ? { request_id: mapping.requestId } : {}),
+            ...(typeof details.thread_id === "string"
+              ? { thread_id: details.thread_id }
+              : typeof sessionId === "string"
+                ? { thread_id: sessionId }
+                : {}),
+            ...(typeof currentStatus === "string" ? { status: currentStatus } : {}),
+          },
+        },
+      };
+    }
+
+    return {
+      error: {
+        code: mapping.sessionInvalidStateCode,
+        message:
+          mapping.sessionInvalidStateCode === "thread_not_interruptible"
+            ? "thread is not interruptible"
+            : "thread is not accepting user input",
+        details: {
+          ...(typeof details.thread_id === "string"
+            ? { thread_id: details.thread_id }
+            : typeof sessionId === "string"
+              ? { thread_id: sessionId }
+              : {}),
+          ...(typeof currentStatus === "string" ? { status: currentStatus } : {}),
+          workspace_id: typeof details.workspace_id === "string" ? details.workspace_id : undefined,
+          active_thread_id:
+            typeof details.active_thread_id === "string"
+              ? details.active_thread_id
+              : typeof details.active_session_id === "string"
+                ? details.active_session_id
+                : undefined,
+        },
+      },
+    };
+  }
+
+  if (body.error.code.startsWith("session_")) {
+    const normalizedDetails = { ...details };
+    if (typeof details.session_id === "string" && !("thread_id" in normalizedDetails)) {
+      normalizedDetails.thread_id = details.session_id;
+    }
+    if (
+      typeof details.active_session_id === "string" &&
+      !("active_thread_id" in normalizedDetails)
+    ) {
+      normalizedDetails.active_thread_id = details.active_session_id;
+    }
+    delete normalizedDetails.session_id;
+    delete normalizedDetails.active_session_id;
+
+    return {
+      error: {
+        code: body.error.code.replace(/^session_/, "thread_"),
+        message: body.error.message.replace(/\bsession\b/g, "thread"),
+        details:
+          typeof sessionId === "string" && !("thread_id" in normalizedDetails)
+            ? { ...normalizedDetails, thread_id: sessionId }
+            : normalizedDetails,
+      },
+    };
+  }
+
+  if ("session_id" in details || "active_session_id" in details) {
+    const normalizedDetails = { ...details };
+    if (typeof details.session_id === "string" && !("thread_id" in normalizedDetails)) {
+      normalizedDetails.thread_id = details.session_id;
+    }
+    if (
+      typeof details.active_session_id === "string" &&
+      !("active_thread_id" in normalizedDetails)
+    ) {
+      normalizedDetails.active_thread_id = details.active_session_id;
+    }
+    delete normalizedDetails.session_id;
+    delete normalizedDetails.active_session_id;
+
+    if (mapping.requestId && !("request_id" in normalizedDetails)) {
+      normalizedDetails.request_id = mapping.requestId;
+    }
+
+    return {
+      error: {
+        ...body.error,
+        details: normalizedDetails,
+      },
+    };
+  }
+
+  return body;
+}
+
+async function parseRuntimeErrorResponse(response: Response, mapping?: ActiveRuntimeErrorMapping) {
   try {
     const payload = await response.json();
     if (isErrorEnvelope(payload)) {
-      return jsonResponse(response.status, payload);
+      return jsonResponse(
+        response.status,
+        mapping ? normalizeActiveRuntimeErrorEnvelope(payload, mapping) : payload,
+      );
     }
   } catch {
     // fall through
@@ -285,6 +448,7 @@ async function relaySse<TInput, TOutput>(
   request: Request,
   path: string,
   mapper: (value: TInput) => TOutput,
+  errorMapping?: ActiveRuntimeErrorMapping,
 ) {
   logLiveChatDebug("sse-relay", "opening runtime stream", {
     path,
@@ -295,7 +459,7 @@ async function relaySse<TInput, TOutput>(
       path,
       status: response.status,
     });
-    return parseRuntimeErrorResponse(response);
+    return parseRuntimeErrorResponse(response, errorMapping);
   }
 
   if (!response.body) {
@@ -316,9 +480,16 @@ async function relaySse<TInput, TOutput>(
   });
 }
 
-function passthroughRuntimeError(status: number, body: unknown) {
+function passthroughRuntimeError(
+  status: number,
+  body: unknown,
+  mapping?: ActiveRuntimeErrorMapping,
+) {
   if (isErrorEnvelope(body)) {
-    return jsonResponse(status, body);
+    return jsonResponse(
+      status,
+      mapping ? normalizeActiveRuntimeErrorEnvelope(body, mapping) : body,
+    );
   }
 
   throw new Error("expected runtime error envelope");
@@ -360,7 +531,9 @@ export async function getHome(_request: Request) {
 
     const runtimeThreadError = threadResults.find((result) => isErrorEnvelope(result.body));
     if (runtimeThreadError && isErrorEnvelope(runtimeThreadError.body)) {
-      return passthroughRuntimeError(runtimeThreadError.status, runtimeThreadError.body);
+      return passthroughRuntimeError(runtimeThreadError.status, runtimeThreadError.body, {
+        sessionNotFoundCode: "thread_not_found",
+      });
     }
 
     const resumeCandidates = threadResults
@@ -426,7 +599,9 @@ export async function listThreads(request: Request, workspaceId: string) {
     );
 
     if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body);
+      return passthroughRuntimeError(result.status, result.body, {
+        sessionNotFoundCode: "thread_not_found",
+      });
     }
 
     return jsonResponse(result.status, mapThreadList(result.body));
@@ -442,7 +617,10 @@ export async function getThread(_request: Request, threadId: string) {
     );
 
     if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body);
+      return passthroughRuntimeError(result.status, result.body, {
+        sessionNotFoundCode: "thread_not_found",
+        threadId,
+      });
     }
 
     return jsonResponse(result.status, mapThread(result.body));
@@ -458,7 +636,10 @@ export async function getPendingRequest(_request: Request, threadId: string) {
     );
 
     if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body);
+      return passthroughRuntimeError(result.status, result.body, {
+        sessionNotFoundCode: "thread_not_found",
+        threadId,
+      });
     }
 
     return jsonResponse(result.status, mapPendingRequestView(result.body));
@@ -474,7 +655,10 @@ export async function getRequestDetail(_request: Request, requestId: string) {
     );
 
     if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body);
+      return passthroughRuntimeError(result.status, result.body, {
+        requestId,
+        sessionNotFoundCode: "request_not_found",
+      });
     }
 
     return jsonResponse(result.status, mapRequestDetail(result.body));
@@ -493,11 +677,17 @@ export async function getThreadView(_request: Request, threadId: string) {
     ]);
 
     if (isErrorEnvelope(viewResult.body)) {
-      return passthroughRuntimeError(viewResult.status, viewResult.body);
+      return passthroughRuntimeError(viewResult.status, viewResult.body, {
+        sessionNotFoundCode: "thread_not_found",
+        threadId,
+      });
     }
 
     if (isErrorEnvelope(timelineResult.body)) {
-      return passthroughRuntimeError(timelineResult.status, timelineResult.body);
+      return passthroughRuntimeError(timelineResult.status, timelineResult.body, {
+        sessionNotFoundCode: "thread_not_found",
+        threadId,
+      });
     }
 
     return jsonResponse(viewResult.status, mapThreadView(viewResult.body, timelineResult.body));
@@ -513,7 +703,10 @@ export async function getTimeline(request: Request, threadId: string) {
     );
 
     if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body);
+      return passthroughRuntimeError(result.status, result.body, {
+        sessionNotFoundCode: "thread_not_found",
+        threadId,
+      });
     }
 
     return jsonResponse(result.status, mapTimeline(result.body));
@@ -553,7 +746,11 @@ export async function postThreadInput(request: Request, threadId: string) {
     );
 
     if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body);
+      return passthroughRuntimeError(result.status, result.body, {
+        sessionInvalidStateCode: "thread_not_accepting_input",
+        sessionNotFoundCode: "thread_not_found",
+        threadId,
+      });
     }
 
     return jsonResponse(result.status, mapThreadInputAcceptedResponse(result.body));
@@ -573,7 +770,11 @@ export async function postThreadInterrupt(_request: Request, threadId: string) {
     );
 
     if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body);
+      return passthroughRuntimeError(result.status, result.body, {
+        sessionInvalidStateCode: "thread_not_interruptible",
+        sessionNotFoundCode: "thread_not_found",
+        threadId,
+      });
     }
 
     return jsonResponse(result.status, mapThread(result.body.thread));
@@ -593,7 +794,11 @@ export async function postRequestResponse(request: Request, requestId: string) {
     );
 
     if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body);
+      return passthroughRuntimeError(result.status, result.body, {
+        requestId,
+        sessionInvalidStateCode: "request_not_pending",
+        sessionNotFoundCode: "request_not_found",
+      });
     }
 
     return jsonResponse(result.status, mapRequestResponseResult(result.body));
@@ -854,6 +1059,10 @@ export async function getThreadStream(request: Request, threadId: string) {
       request,
       `/api/v1/threads/${threadId}/stream`,
       mapThreadStreamEvent,
+      {
+        sessionNotFoundCode: "thread_not_found",
+        threadId,
+      },
     );
   } catch (error) {
     return toErrorResponse(error);

--- a/apps/frontend-bff/src/runtime-client.ts
+++ b/apps/frontend-bff/src/runtime-client.ts
@@ -53,7 +53,7 @@ export class RuntimeClient {
     } catch (error) {
       throw new BffError(
         503,
-        "session_runtime_error",
+        "thread_runtime_error",
         "backend dependency temporarily unavailable",
         {
           cause: error instanceof Error ? error.message : "failed to connect to codex-runtime",
@@ -100,7 +100,7 @@ export class RuntimeClient {
     } catch (error) {
       throw new BffError(
         503,
-        "session_runtime_error",
+        "thread_runtime_error",
         "backend dependency temporarily unavailable",
         {
           cause: error instanceof Error ? error.message : "failed to connect to codex-runtime",

--- a/apps/frontend-bff/tests/routes.test.ts
+++ b/apps/frontend-bff/tests/routes.test.ts
@@ -373,8 +373,9 @@ describe("frontend-bff route handlers", () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({
       error: {
-        code: "session_not_found",
-        message: "thread list missing",
+        code: "thread_not_found",
+        message: "thread was not found",
+        details: {},
       },
     });
   });
@@ -648,6 +649,50 @@ describe("frontend-bff route handlers", () => {
     });
   });
 
+  it("normalizes session-era runtime thread input errors to v0.9 thread vocabulary", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: {
+            code: "session_invalid_state",
+            message: "session is not ready to accept messages",
+            details: {
+              session_id: "thread_001",
+              current_status: "waiting_approval",
+            },
+          },
+        },
+        409,
+      ),
+    );
+
+    const response = await postThreadInput(
+      new Request("http://localhost/api/v1/threads/thread_001/inputs", {
+        method: "POST",
+        body: JSON.stringify({
+          client_request_id: "input_002",
+          content: "Show me the root cause.",
+        }),
+      }),
+      "thread_001",
+    );
+
+    expect(response.status).toBe(409);
+    const json = await response.json();
+    expect(json).toEqual({
+      error: {
+        code: "thread_not_accepting_input",
+        message: "thread is not accepting user input",
+        details: {
+          thread_id: "thread_001",
+          status: "waiting_approval",
+        },
+      },
+    });
+    expect(json.error.details).not.toHaveProperty("session_id");
+  });
+
   it("forwards thread interrupts and maps runtime thread wrappers to the public thread facade", async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValueOnce(
@@ -823,6 +868,90 @@ describe("frontend-bff route handlers", () => {
         },
       },
     });
+  });
+
+  it("normalizes session-era runtime request errors to v0.9 request vocabulary", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: {
+            code: "session_not_found",
+            message: "session was not found",
+            details: {
+              session_id: "thread_001",
+            },
+          },
+        },
+        404,
+      ),
+    );
+
+    const response = await postRequestResponse(
+      new Request("http://localhost/api/v1/requests/req_001/response", {
+        method: "POST",
+        body: JSON.stringify({
+          client_response_id: "resp_001",
+          decision: "approved",
+        }),
+      }),
+      "req_001",
+    );
+
+    expect(response.status).toBe(404);
+    const json = await response.json();
+    expect(json).toEqual({
+      error: {
+        code: "request_not_found",
+        message: "request was not found",
+        details: {
+          request_id: "req_001",
+          thread_id: "thread_001",
+        },
+      },
+    });
+    expect(json.error.details).not.toHaveProperty("session_id");
+  });
+
+  it("normalizes generic session-era runtime envelopes without leaking session detail keys", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: {
+            code: "session_runtime_error",
+            message: "session backend dependency temporarily unavailable",
+            details: {
+              session_id: "thread_001",
+              active_session_id: "thread_active",
+              cause: "upstream timeout",
+            },
+          },
+        },
+        503,
+      ),
+    );
+
+    const response = await getThread(
+      new Request("http://localhost/api/v1/threads/thread_001"),
+      "thread_001",
+    );
+
+    expect(response.status).toBe(503);
+    const json = await response.json();
+    expect(json).toEqual({
+      error: {
+        code: "thread_runtime_error",
+        message: "thread backend dependency temporarily unavailable",
+        details: {
+          thread_id: "thread_001",
+          active_thread_id: "thread_active",
+          cause: "upstream timeout",
+        },
+      },
+    });
+    expect(json.error.details).not.toHaveProperty("session_id");
+    expect(json.error.details).not.toHaveProperty("active_session_id");
   });
 
   it("preserves pending_request null semantics", async () => {
@@ -1300,7 +1429,7 @@ describe("frontend-bff route handlers", () => {
     expect(response.status).toBe(503);
     expect(await response.json()).toEqual({
       error: {
-        code: "session_runtime_error",
+        code: "thread_runtime_error",
         message: "backend dependency temporarily unavailable",
         details: {
           cause: "connect ECONNREFUSED",

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-260-error-code-normalization](./archive/issue-260-error-code-normalization/README.md)
 - [issue-257-readme-v09-sync](./archive/issue-257-readme-v09-sync/README.md)
 - [issue-261-tracking-drift](./archive/issue-261-tracking-drift/README.md)
 - [issue-222-ui-gap-validation](./archive/issue-222-ui-gap-validation/README.md)

--- a/tasks/archive/issue-260-error-code-normalization/README.md
+++ b/tasks/archive/issue-260-error-code-normalization/README.md
@@ -1,0 +1,62 @@
+# Issue 260 Error Code Normalization
+
+## Purpose
+
+- Normalize active v0.9 thread/request error envelopes so public and internal endpoints no longer expose session-era error codes where the browser-facing operation is thread or request scoped.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/260
+
+## Source docs
+
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/codex-runtime/README.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Audit active v0.9 runtime and BFF thread/request endpoints for session-era error names in returned envelopes.
+- Rename or map representative thread/request errors at the correct boundary without changing retired legacy route behavior.
+- Update focused runtime and BFF tests for the normalized error behavior.
+- Keep compatibility with internal persistence and legacy implementation names where they are not exposed through active v0.9 contracts.
+
+## Exit criteria
+
+- Active v0.9 thread/request endpoints expose v0.9-aligned error names or an explicitly tested compatibility mapping.
+- Representative missing-thread, invalid-state, and runtime-unavailable cases are covered by focused tests.
+- Retired `/sessions` and `/approvals` route behavior remains out of scope and unchanged.
+- Touched app validation passes.
+
+## Work plan
+
+- Identify active route handlers and service boundaries that currently emit `session_not_found`, `session_invalid_state`, `session_runtime_error`, or `session_id` details for thread/request operations.
+- Introduce the smallest boundary helpers needed to translate active v0.9 endpoint errors to thread/request terminology.
+- Update route/service tests that assert active endpoint error envelopes.
+- Run targeted runtime and BFF validation before the dedicated pre-push gate.
+
+## Artifacts / evidence
+
+- Sprint evaluator verdict: `approved`.
+- Dedicated pre-push validation: passed.
+- Validation:
+  - `cd apps/codex-runtime && npm run check`
+  - `cd apps/codex-runtime && npm test -- tests/thread-routes.test.ts`
+  - `cd apps/frontend-bff && npm run check`
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `cd apps/frontend-bff && npm test -- tests/routes.test.ts`
+  - `git diff --check`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-260-error-code-normalization`
+- Active worktree: `.worktrees/issue-260-error-code-normalization`
+- Notes: Active v0.9 runtime and BFF thread/request error envelopes now normalize representative session-era codes and details at the thread/request boundary. Retired `/sessions` and `/approvals` route behavior remains out of scope and unchanged. Completion retrospective found no durable skill/doc update needed; the only workflow anomaly was a recoverable validator spawn retry after completed agent slots were still open. PR merge, parent sync, worktree cleanup, Issue close, and Project `Done` remain pending.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate has passed, and these handoff notes are updated with final evidence.


### PR DESCRIPTION
## Summary

- Normalize active runtime request errors from session-era codes/details to request/thread vocabulary.
- Normalize active BFF thread/request passthrough errors, including runtime-unavailable failures.
- Add focused runtime and BFF route coverage for the normalized error envelopes.
- Archive the #260 task package after sprint approval and dedicated pre-push validation.

## Validation

- `cd apps/codex-runtime && npm run check`
- `cd apps/codex-runtime && npm test -- tests/thread-routes.test.ts`
- `cd apps/frontend-bff && npm run check`
- `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `cd apps/frontend-bff && npm test -- tests/routes.test.ts`
- `git diff --check`

Closes #260
