### PR TITLE
refactor: extract thread input orchestrator

### DIFF
--- a/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
@@ -1,0 +1,227 @@
+import crypto from "node:crypto";
+
+import { and, eq } from "drizzle-orm";
+
+import type { RuntimeDatabase } from "../../db/database.js";
+import { messages, sessions, workspaces } from "../../db/schema.js";
+import { RuntimeError } from "../../errors.js";
+import type { NativeSessionGateway } from "../sessions/native-session-gateway.js";
+import type { SessionEventPublisher } from "../sessions/session-event-publisher.js";
+import type { MessageProjection } from "../sessions/types.js";
+
+type TurnStartConvergenceGateway = NativeSessionGateway & {
+  acknowledgeTurnStartPersisted?: (input: { sessionId: string; turnId: string }) => Promise<void>;
+};
+
+function generateMessageId() {
+  return `msg_user_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+function firstRow<T>(rows: T[]) {
+  return rows[0] ?? null;
+}
+
+export class ThreadInputOrchestrator {
+  constructor(
+    private readonly database: RuntimeDatabase,
+    private readonly sessionEventPublisher: SessionEventPublisher,
+    private readonly nativeSessionGateway: NativeSessionGateway,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async acceptThreadMessage(
+    threadId: string,
+    input: {
+      client_message_id: string;
+      content: string;
+    },
+  ): Promise<MessageProjection> {
+    const existingMessage = firstRow(
+      this.database.db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.sessionId, threadId),
+            eq(messages.clientMessageId, input.client_message_id),
+          ),
+        )
+        .limit(1)
+        .all(),
+    );
+
+    if (existingMessage) {
+      if (existingMessage.content !== input.content) {
+        throw new RuntimeError(
+          409,
+          "message_idempotency_conflict",
+          "client message id conflicts with a different message payload",
+          {
+            session_id: threadId,
+            client_message_id: input.client_message_id,
+          },
+        );
+      }
+
+      return {
+        message_id: existingMessage.messageId,
+        session_id: existingMessage.sessionId,
+        role: existingMessage.role as MessageProjection["role"],
+        content: existingMessage.content,
+        created_at: existingMessage.createdAt,
+        source_item_type: existingMessage.sourceItemType as MessageProjection["source_item_type"],
+      };
+    }
+
+    const session = firstRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, threadId))
+        .limit(1)
+        .all(),
+    );
+
+    if (!session) {
+      throw new RuntimeError(404, "session_not_found", "session was not found", {
+        session_id: threadId,
+      });
+    }
+
+    if (session.status !== "waiting_input") {
+      throw new RuntimeError(
+        409,
+        "session_invalid_state",
+        "session is not ready to accept messages",
+        {
+          session_id: threadId,
+          current_status: session.status,
+        },
+      );
+    }
+
+    const nativeTurn = await this.nativeSessionGateway.sendUserMessage({
+      sessionId: threadId,
+      content: input.content,
+    });
+    const userMessageId = generateMessageId();
+    const userCreatedAt = this.now().toISOString();
+
+    try {
+      this.database.sqlite.transaction(() => {
+        this.database.db
+          .insert(messages)
+          .values({
+            messageId: userMessageId,
+            sessionId: threadId,
+            role: "user",
+            content: input.content,
+            createdAt: userCreatedAt,
+            sourceItemType: "user_message",
+            clientMessageId: input.client_message_id,
+          })
+          .run();
+
+        this.sessionEventPublisher.appendSessionEvent({
+          sessionId: threadId,
+          eventType: "message.user",
+          occurredAt: userCreatedAt,
+          payload: {
+            message_id: userMessageId,
+            content: input.content,
+          },
+        });
+
+        this.database.db
+          .update(sessions)
+          .set({
+            status: "running",
+            updatedAt: userCreatedAt,
+            lastMessageAt: userCreatedAt,
+            currentTurnId: nativeTurn.turnId,
+            pendingAssistantMessageId: null,
+            appSessionOverlayState: "open",
+          })
+          .where(eq(sessions.sessionId, threadId))
+          .run();
+
+        this.database.db
+          .update(workspaces)
+          .set({
+            updatedAt: userCreatedAt,
+          })
+          .where(eq(workspaces.workspaceId, session.workspaceId))
+          .run();
+
+        this.sessionEventPublisher.appendSessionStatusChangedEvent({
+          sessionId: threadId,
+          occurredAt: userCreatedAt,
+          fromStatus: "waiting_input",
+          toStatus: "running",
+        });
+      })();
+      await this.acknowledgeTurnStartPersisted(threadId, nativeTurn.turnId);
+    } catch (error) {
+      try {
+        this.markThreadRecoveryPending(
+          threadId,
+          session.workspaceId,
+          userCreatedAt,
+          nativeTurn.turnId,
+        );
+      } catch {
+        // Keep the original post-native persistence failure as the primary error.
+      }
+
+      throw error;
+    }
+
+    return {
+      message_id: userMessageId,
+      session_id: threadId,
+      role: "user",
+      content: input.content,
+      created_at: userCreatedAt,
+      source_item_type: "user_message",
+    };
+  }
+
+  private async acknowledgeTurnStartPersisted(sessionId: string, turnId: string) {
+    await (
+      this.nativeSessionGateway as TurnStartConvergenceGateway
+    ).acknowledgeTurnStartPersisted?.({
+      sessionId,
+      turnId,
+    });
+  }
+
+  private markThreadRecoveryPending(
+    threadId: string,
+    workspaceId: string,
+    updatedAt: string,
+    currentTurnId: string,
+  ) {
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .update(sessions)
+        .set({
+          status: "running",
+          updatedAt,
+          lastMessageAt: updatedAt,
+          currentTurnId,
+          pendingAssistantMessageId: null,
+          appSessionOverlayState: "recovery_pending",
+        })
+        .where(eq(sessions.sessionId, threadId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          updatedAt,
+        })
+        .where(eq(workspaces.workspaceId, workspaceId))
+        .run();
+    })();
+  }
+}

--- a/apps/codex-runtime/src/domain/threads/thread-service.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-service.ts
@@ -1,12 +1,9 @@
-import crypto from "node:crypto";
-
 import { and, desc, eq } from "drizzle-orm";
 
 import type { RuntimeDatabase } from "../../db/database.js";
 import {
   type ApprovalRow,
   approvals,
-  messages,
   type SessionRow,
   sessionEvents,
   sessions,
@@ -27,6 +24,7 @@ import type {
 } from "../sessions/types.js";
 import type { WorkspaceFilesystem } from "../workspaces/workspace-filesystem.js";
 import type { WorkspaceRegistry } from "../workspaces/workspace-registry.js";
+import { ThreadInputOrchestrator } from "./thread-input-orchestrator.js";
 import type {
   LatestResolvedRequestSummary,
   NotificationEvent,
@@ -186,17 +184,9 @@ function deriveThreadTitle(content: string) {
   return compact.length <= 48 ? compact : `${compact.slice(0, 45)}...`;
 }
 
-function generateMessageId() {
-  return `msg_user_${crypto.randomUUID().replaceAll("-", "")}`;
-}
-
 function firstRow<T>(rows: T[]) {
   return rows[0] ?? null;
 }
-
-type TurnStartConvergenceGateway = NativeSessionGateway & {
-  acknowledgeTurnStartPersisted?: (input: { sessionId: string; turnId: string }) => Promise<void>;
-};
 
 function asRuntimeError(error: unknown) {
   return error instanceof RuntimeError ? error : null;
@@ -306,6 +296,8 @@ function mapThreadInterruptError(error: unknown, threadId: string): never {
 }
 
 export class ThreadService {
+  private readonly threadInputOrchestrator: ThreadInputOrchestrator;
+
   constructor(
     private readonly database: RuntimeDatabase,
     private readonly workspaceRegistry: WorkspaceRegistry,
@@ -313,15 +305,13 @@ export class ThreadService {
     private readonly sessionEventPublisher: SessionEventPublisher,
     private readonly nativeSessionGateway: NativeSessionGateway,
     private readonly now: () => Date = () => new Date(),
-  ) {}
-
-  private async acknowledgeTurnStartPersisted(sessionId: string, turnId: string) {
-    await (
-      this.nativeSessionGateway as TurnStartConvergenceGateway
-    ).acknowledgeTurnStartPersisted?.({
-      sessionId,
-      turnId,
-    });
+  ) {
+    this.threadInputOrchestrator = new ThreadInputOrchestrator(
+      this.database,
+      this.sessionEventPublisher,
+      this.nativeSessionGateway,
+      this.now,
+    );
   }
 
   async listThreads(workspaceId: string) {
@@ -403,7 +393,7 @@ export class ThreadService {
       deriveThreadTitle(input.content),
     );
     await this.startThreadSession(threadId);
-    await this.acceptThreadMessage(threadId, {
+    await this.threadInputOrchestrator.acceptThreadMessage(threadId, {
       client_message_id: input.client_request_id,
       content: input.content,
     });
@@ -430,7 +420,7 @@ export class ThreadService {
   ): Promise<{ thread: ThreadSummary; accepted_input: MessageProjection }> {
     let acceptedInput: MessageProjection;
     try {
-      acceptedInput = await this.acceptThreadMessage(threadId, {
+      acceptedInput = await this.threadInputOrchestrator.acceptThreadMessage(threadId, {
         client_message_id: input.client_request_id,
         content: input.content,
       });
@@ -936,191 +926,5 @@ export class ThreadService {
     })();
 
     return this.getThread(threadId);
-  }
-
-  private async acceptThreadMessage(
-    threadId: string,
-    input: {
-      client_message_id: string;
-      content: string;
-    },
-  ) {
-    const existingMessage = firstRow(
-      this.database.db
-        .select()
-        .from(messages)
-        .where(
-          and(
-            eq(messages.sessionId, threadId),
-            eq(messages.clientMessageId, input.client_message_id),
-          ),
-        )
-        .limit(1)
-        .all(),
-    );
-
-    if (existingMessage) {
-      if (existingMessage.content !== input.content) {
-        throw new RuntimeError(
-          409,
-          "message_idempotency_conflict",
-          "client message id conflicts with a different message payload",
-          {
-            session_id: threadId,
-            client_message_id: input.client_message_id,
-          },
-        );
-      }
-
-      return {
-        message_id: existingMessage.messageId,
-        session_id: existingMessage.sessionId,
-        role: existingMessage.role as MessageProjection["role"],
-        content: existingMessage.content,
-        created_at: existingMessage.createdAt,
-        source_item_type: existingMessage.sourceItemType as MessageProjection["source_item_type"],
-      } satisfies MessageProjection;
-    }
-
-    const session = firstRow(
-      this.database.db
-        .select()
-        .from(sessions)
-        .where(eq(sessions.sessionId, threadId))
-        .limit(1)
-        .all(),
-    );
-
-    if (!session) {
-      throw new RuntimeError(404, "session_not_found", "session was not found", {
-        session_id: threadId,
-      });
-    }
-
-    if (session.status !== "waiting_input") {
-      throw new RuntimeError(
-        409,
-        "session_invalid_state",
-        "session is not ready to accept messages",
-        {
-          session_id: threadId,
-          current_status: session.status,
-        },
-      );
-    }
-
-    const nativeTurn = await this.nativeSessionGateway.sendUserMessage({
-      sessionId: threadId,
-      content: input.content,
-    });
-    const userMessageId = generateMessageId();
-    const userCreatedAt = this.now().toISOString();
-
-    try {
-      this.database.sqlite.transaction(() => {
-        this.database.db
-          .insert(messages)
-          .values({
-            messageId: userMessageId,
-            sessionId: threadId,
-            role: "user",
-            content: input.content,
-            createdAt: userCreatedAt,
-            sourceItemType: "user_message",
-            clientMessageId: input.client_message_id,
-          })
-          .run();
-
-        this.sessionEventPublisher.appendSessionEvent({
-          sessionId: threadId,
-          eventType: "message.user",
-          occurredAt: userCreatedAt,
-          payload: {
-            message_id: userMessageId,
-            content: input.content,
-          },
-        });
-
-        this.database.db
-          .update(sessions)
-          .set({
-            status: "running",
-            updatedAt: userCreatedAt,
-            lastMessageAt: userCreatedAt,
-            currentTurnId: nativeTurn.turnId,
-            pendingAssistantMessageId: null,
-            appSessionOverlayState: "open",
-          })
-          .where(eq(sessions.sessionId, threadId))
-          .run();
-
-        this.database.db
-          .update(workspaces)
-          .set({
-            updatedAt: userCreatedAt,
-          })
-          .where(eq(workspaces.workspaceId, session.workspaceId))
-          .run();
-
-        this.sessionEventPublisher.appendSessionStatusChangedEvent({
-          sessionId: threadId,
-          occurredAt: userCreatedAt,
-          fromStatus: "waiting_input",
-          toStatus: "running",
-        });
-      })();
-      await this.acknowledgeTurnStartPersisted(threadId, nativeTurn.turnId);
-    } catch (error) {
-      try {
-        this.markThreadRecoveryPending(
-          threadId,
-          session.workspaceId,
-          userCreatedAt,
-          nativeTurn.turnId,
-        );
-      } catch {
-        // Keep the original post-native persistence failure as the primary error.
-      }
-      throw error;
-    }
-
-    return {
-      message_id: userMessageId,
-      session_id: threadId,
-      role: "user",
-      content: input.content,
-      created_at: userCreatedAt,
-      source_item_type: "user_message",
-    } satisfies MessageProjection;
-  }
-
-  private markThreadRecoveryPending(
-    threadId: string,
-    workspaceId: string,
-    updatedAt: string,
-    currentTurnId: string,
-  ) {
-    this.database.sqlite.transaction(() => {
-      this.database.db
-        .update(sessions)
-        .set({
-          status: "running",
-          updatedAt,
-          lastMessageAt: updatedAt,
-          currentTurnId,
-          pendingAssistantMessageId: null,
-          appSessionOverlayState: "recovery_pending",
-        })
-        .where(eq(sessions.sessionId, threadId))
-        .run();
-
-      this.database.db
-        .update(workspaces)
-        .set({
-          updatedAt,
-        })
-        .where(eq(workspaces.workspaceId, workspaceId))
-        .run();
-    })();
   }
 }

--- a/apps/codex-runtime/tests/thread-routes.test.ts
+++ b/apps/codex-runtime/tests/thread-routes.test.ts
@@ -14,6 +14,8 @@ import { createTempDatabase, createTempWorkspaceRoot } from "./helpers.js";
 const cleanupPaths: string[] = [];
 
 class StubNativeSessionGateway implements NativeSessionGateway {
+  readonly sendUserMessages: Array<{ sessionId: string; content: string }> = [];
+
   constructor(
     private readonly sessionIds: string[] = [],
     private readonly turnIds: string[] = [],
@@ -35,6 +37,7 @@ class StubNativeSessionGateway implements NativeSessionGateway {
   }
 
   async sendUserMessage(_input: { sessionId: string; content: string }) {
+    this.sendUserMessages.push(_input);
     const turnId = this.turnIds.shift();
     if (!turnId) {
       throw new Error("no stub turn id available");
@@ -1331,6 +1334,8 @@ describe("thread routes", () => {
     const database = await createTempDatabase("thread-routes-db");
     cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
 
+    const nativeSessionGateway = new StubNativeSessionGateway([], ["turn_001"]);
+
     const app = await buildApp({
       config: {
         workspaceRoot,
@@ -1341,7 +1346,7 @@ describe("thread routes", () => {
       },
       database,
       services: {
-        nativeSessionGateway: new StubNativeSessionGateway([], ["turn_001"]),
+        nativeSessionGateway,
       },
     });
 
@@ -1384,6 +1389,68 @@ describe("thread routes", () => {
     });
 
     expect(inputResponse.statusCode).toBe(202);
+    expect(nativeSessionGateway.sendUserMessages).toEqual([
+      {
+        sessionId: "thread_001",
+        content: "Continue the runtime cutover",
+      },
+    ]);
+
+    const persistedMessage = database.db
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, "thread_001"))
+      .all();
+    expect(persistedMessage).toEqual([
+      expect.objectContaining({
+        sessionId: "thread_001",
+        role: "user",
+        content: "Continue the runtime cutover",
+        clientMessageId: "req_followup_002",
+      }),
+    ]);
+
+    const persistedThread = database.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.sessionId, "thread_001"))
+      .limit(1)
+      .all()[0];
+    expect(persistedThread).toMatchObject({
+      sessionId: "thread_001",
+      status: "running",
+      currentTurnId: "turn_001",
+      lastMessageAt: expect.any(String),
+    });
+
+    const persistedWorkspace = database.db
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.workspaceId, "ws_alpha"))
+      .limit(1)
+      .all()[0];
+    expect(persistedWorkspace.updatedAt).not.toBe("2026-04-09T00:00:00.000Z");
+
+    const storedEvents = database.db
+      .select()
+      .from(sessionEvents)
+      .where(eq(sessionEvents.sessionId, "thread_001"))
+      .orderBy(sessionEvents.sequence)
+      .all();
+    expect(storedEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "message.user",
+        }),
+        expect.objectContaining({
+          eventType: "session.status_changed",
+          payload: JSON.stringify({
+            from_status: "waiting_input",
+            to_status: "running",
+          }),
+        }),
+      ]),
+    );
 
     const viewResponse = await app.inject({
       method: "GET",

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-242-thread-orchestration-boundary](./archive/issue-242-thread-orchestration-boundary/README.md)
 - [issue-260-error-code-normalization](./archive/issue-260-error-code-normalization/README.md)
 - [issue-257-readme-v09-sync](./archive/issue-257-readme-v09-sync/README.md)
 - [issue-261-tracking-drift](./archive/issue-261-tracking-drift/README.md)

--- a/tasks/archive/issue-242-thread-orchestration-boundary/README.md
+++ b/tasks/archive/issue-242-thread-orchestration-boundary/README.md
@@ -1,0 +1,57 @@
+# Issue 242 Thread Orchestration Boundary
+
+## Purpose
+
+- Extract a clearer runtime thread/request orchestration boundary so active v0.9 thread entrypoints are understandable without reading the full legacy session service implementation.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/242
+
+## Source docs
+
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Identify one cohesive extraction from `apps/codex-runtime/src/domain/threads/thread-service.ts` or its immediate runtime collaborators.
+- Prefer behavior-preserving helper/service extraction for thread lifecycle, input submission, request response, or projection reads.
+- Keep public/internal API behavior unchanged.
+- Keep persistence/schema and broad session-service decomposition out of scope unless the bounded extraction requires a small local adapter.
+
+## Exit criteria
+
+- One active thread/request orchestration responsibility has a named runtime home outside the broad service method body.
+- Targeted runtime tests cover unchanged behavior for the extracted responsibility.
+- `apps/codex-runtime` validation passes.
+
+## Work plan
+
+- Use sprint planning to select the smallest high-value extraction.
+- Implement the extraction in the active worktree only.
+- Run runtime Biome, focused tests, and any required TypeScript/build checks before pre-push validation.
+
+## Artifacts / evidence
+
+- Sprint evaluator verdict: `approved`.
+- Dedicated pre-push validation: passed.
+- Validation:
+  - `cd apps/codex-runtime && npm run check`
+  - `cd apps/codex-runtime && npm test -- tests/thread-routes.test.ts`
+  - `cd apps/codex-runtime && npm test`
+  - `cd apps/codex-runtime && npm run build`
+  - `git diff --check`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-242-thread-orchestration-boundary`
+- Active worktree: `.worktrees/issue-242-thread-orchestration-boundary`
+- Notes: Extracted existing-thread input submission orchestration into `ThreadInputOrchestrator`, keeping route behavior and the broader session-service decomposition out of scope. Completion retrospective found the slice boundary worked well: planner narrowed the large refactor to one cohesive behavior-preserving extraction, and no durable skill/doc update is needed. PR merge, parent sync, worktree cleanup, Issue close, and Project `Done` remain pending.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate has passed, and these handoff notes are updated with final evidence.


### PR DESCRIPTION
## Summary

- Extract existing-thread input submission into `ThreadInputOrchestrator`.
- Keep `ThreadService` public methods and route behavior unchanged while delegating input orchestration.
- Strengthen runtime route coverage for persisted input, native send, running state, workspace timestamp, and emitted events.
- Archive the #242 task package after sprint approval and dedicated pre-push validation.

## Validation

- `cd apps/codex-runtime && npm run check`
- `cd apps/codex-runtime && npm test -- tests/thread-routes.test.ts`
- `cd apps/codex-runtime && npm test`
- `cd apps/codex-runtime && npm run build`
- `git diff --check`

Closes #242
