### PR TITLE
refactor: extract app-server approval translation

### DIFF
--- a/apps/codex-runtime/src/domain/app-server/app-server-event-translation.ts
+++ b/apps/codex-runtime/src/domain/app-server/app-server-event-translation.ts
@@ -1,0 +1,91 @@
+import type { ApprovalCategory } from "../approvals/types.js";
+
+const COMMAND_APPROVAL_METHOD = "item/commandExecution/requestApproval" as const;
+
+type ApprovalRequestContext = Record<string, unknown> & {
+  thread_id: string;
+  turn_id: string;
+  item_id: unknown;
+  cwd: unknown;
+  command_actions: unknown;
+  available_decisions: unknown;
+};
+
+export interface NativeApprovalSinkInput {
+  turn_id: string;
+  approval_category: ApprovalCategory;
+  summary: string;
+  reason: string;
+  operation_summary: string;
+  context: ApprovalRequestContext;
+  native_request_kind: typeof COMMAND_APPROVAL_METHOD;
+}
+
+export interface NativeCommandApprovalTranslation {
+  sessionId: string;
+  requestId: number;
+  command: string;
+  sinkInput: NativeApprovalSinkInput;
+}
+
+interface RawNativeCommandApprovalEvent {
+  id?: unknown;
+  method?: unknown;
+  params?: {
+    threadId?: unknown;
+    turnId?: unknown;
+    command?: unknown;
+    itemId?: unknown;
+    cwd?: unknown;
+    commandActions?: unknown;
+    availableDecisions?: unknown;
+  };
+}
+
+function summarizeApprovalRequest(command: string) {
+  return `Approval requested to run: ${command}`;
+}
+
+function reasonForApprovalRequest(command: string) {
+  return `Codex requested permission to run the command: ${command}`;
+}
+
+export function translateNativeCommandApprovalEvent(
+  message: RawNativeCommandApprovalEvent,
+): NativeCommandApprovalTranslation | null {
+  if (String(message.method) !== COMMAND_APPROVAL_METHOD) {
+    return null;
+  }
+
+  const params = message.params ?? {};
+  const sessionId = String(params.threadId ?? "");
+  const turnId = String(params.turnId ?? "");
+  const command = String(params.command ?? "");
+  const requestId = Number(message.id);
+
+  if (!sessionId || !turnId || command.length === 0 || !Number.isFinite(requestId)) {
+    return null;
+  }
+
+  return {
+    sessionId,
+    requestId,
+    command,
+    sinkInput: {
+      turn_id: turnId,
+      approval_category: "external_side_effect",
+      summary: summarizeApprovalRequest(command),
+      reason: reasonForApprovalRequest(command),
+      operation_summary: command,
+      context: {
+        thread_id: sessionId,
+        turn_id: turnId,
+        item_id: params.itemId ?? null,
+        cwd: params.cwd ?? null,
+        command_actions: params.commandActions ?? [],
+        available_decisions: params.availableDecisions ?? [],
+      },
+      native_request_kind: COMMAND_APPROVAL_METHOD,
+    },
+  };
+}

--- a/apps/codex-runtime/src/domain/app-server/codex-app-server-gateway.ts
+++ b/apps/codex-runtime/src/domain/app-server/codex-app-server-gateway.ts
@@ -11,6 +11,7 @@ import type {
   NativeSessionGateway,
   SendNativeSessionMessageInput,
 } from "../sessions/native-session-gateway.js";
+import { translateNativeCommandApprovalEvent } from "./app-server-event-translation.js";
 import type { AppServerController, AppServerSnapshot } from "./app-server-supervisor.js";
 
 export interface CodexAppServerGatewayConfig {
@@ -95,14 +96,6 @@ function turnStateKey(sessionId: string, turnId: string) {
 
 function mapApprovalDecision(resolution: "approved" | "denied") {
   return resolution === "approved" ? "accept" : "cancel";
-}
-
-function summarizeApprovalRequest(command: string) {
-  return `Approval requested to run: ${command}`;
-}
-
-function reasonForApprovalRequest(command: string) {
-  return `Codex requested permission to run the command: ${command}`;
 }
 
 export class CodexAppServerGateway implements NativeSessionGateway, AppServerController {
@@ -512,40 +505,30 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
     }
 
     if (method === "item/commandExecution/requestApproval") {
-      const command = String(params.command ?? "");
-      const requestId = Number(message.id);
-      if (!sessionId || !turnId || !Number.isFinite(requestId) || command.length === 0) {
+      const translatedApproval = translateNativeCommandApprovalEvent(message);
+      if (!translatedApproval) {
         return;
       }
 
-      const state = this.ensureTurnState(sessionId, turnId);
+      const state = this.ensureTurnState(
+        translatedApproval.sessionId,
+        translatedApproval.sinkInput.turn_id,
+      );
       state.waitingForApproval = true;
 
       logLiveChatDebug("app-server", "forwarding approval request", {
-        session_id: sessionId,
-        turn_id: turnId,
-        command,
+        session_id: translatedApproval.sessionId,
+        turn_id: translatedApproval.sinkInput.turn_id,
+        command: translatedApproval.command,
       });
 
-      const approval = await this.eventSink.ingestApprovalRequest(sessionId, {
-        turn_id: turnId,
-        approval_category: "external_side_effect",
-        summary: summarizeApprovalRequest(command),
-        reason: reasonForApprovalRequest(command),
-        operation_summary: command,
-        context: {
-          thread_id: sessionId,
-          turn_id: turnId,
-          item_id: params.itemId ?? null,
-          cwd: params.cwd ?? null,
-          command_actions: params.commandActions ?? [],
-          available_decisions: params.availableDecisions ?? [],
-        },
-        native_request_kind: "item/commandExecution/requestApproval",
-      });
+      const approval = await this.eventSink.ingestApprovalRequest(
+        translatedApproval.sessionId,
+        translatedApproval.sinkInput,
+      );
 
       this.pendingApprovals.set(approval.approval_id, {
-        requestId,
+        requestId: translatedApproval.requestId,
       });
       return;
     }

--- a/apps/codex-runtime/tests/app-server-event-translation.test.ts
+++ b/apps/codex-runtime/tests/app-server-event-translation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { translateNativeCommandApprovalEvent } from "../src/domain/app-server/app-server-event-translation.js";
+
+describe("translateNativeCommandApprovalEvent", () => {
+  it("returns the normalized approval translation for a valid native command approval event", () => {
+    expect(
+      translateNativeCommandApprovalEvent({
+        id: 42,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread_001",
+          turnId: "turn_001",
+          command: "git push origin main",
+          itemId: "item_001",
+          cwd: "/workspace/project",
+          commandActions: ["run"],
+          availableDecisions: ["approve", "deny"],
+        },
+      }),
+    ).toEqual({
+      sessionId: "thread_001",
+      requestId: 42,
+      command: "git push origin main",
+      sinkInput: {
+        turn_id: "turn_001",
+        approval_category: "external_side_effect",
+        summary: "Approval requested to run: git push origin main",
+        reason: "Codex requested permission to run the command: git push origin main",
+        operation_summary: "git push origin main",
+        context: {
+          thread_id: "thread_001",
+          turn_id: "turn_001",
+          item_id: "item_001",
+          cwd: "/workspace/project",
+          command_actions: ["run"],
+          available_decisions: ["approve", "deny"],
+        },
+        native_request_kind: "item/commandExecution/requestApproval",
+      },
+    });
+  });
+
+  it("returns null when the thread id is missing", () => {
+    expect(
+      translateNativeCommandApprovalEvent({
+        id: 42,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          turnId: "turn_001",
+          command: "git push origin main",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the turn id is missing", () => {
+    expect(
+      translateNativeCommandApprovalEvent({
+        id: 42,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread_001",
+          command: "git push origin main",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the command is missing or empty", () => {
+    expect(
+      translateNativeCommandApprovalEvent({
+        id: 42,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread_001",
+          turnId: "turn_001",
+        },
+      }),
+    ).toBeNull();
+
+    expect(
+      translateNativeCommandApprovalEvent({
+        id: 42,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread_001",
+          turnId: "turn_001",
+          command: "",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the request id is not finite", () => {
+    expect(
+      translateNativeCommandApprovalEvent({
+        id: Number.NaN,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread_001",
+          turnId: "turn_001",
+          command: "git push origin main",
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-244-gateway-event-translation](./archive/issue-244-gateway-event-translation/README.md)
 - [issue-243-persistence-boundary](./archive/issue-243-persistence-boundary/README.md)
 - [issue-242-thread-orchestration-boundary](./archive/issue-242-thread-orchestration-boundary/README.md)
 - [issue-260-error-code-normalization](./archive/issue-260-error-code-normalization/README.md)

--- a/tasks/archive/issue-244-gateway-event-translation/README.md
+++ b/tasks/archive/issue-244-gateway-event-translation/README.md
@@ -1,0 +1,55 @@
+# Issue 244 Gateway Event Translation
+
+## Purpose
+
+- Separate native app-server process/RPC mechanics from event translation helpers in the runtime gateway without changing gateway behavior.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/244
+
+## Source docs
+
+- `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Extract one cohesive pure event translation/convergence helper from `codex-app-server-gateway.ts`.
+- Keep gateway public interface, process lifecycle, RPC transport, and runtime behavior unchanged.
+- Add or preserve focused runtime coverage for the extracted helper where useful.
+
+## Exit criteria
+
+- One event translation responsibility has a named runtime home outside the process/RPC gateway body.
+- Existing gateway/runtime validation passes.
+- No app-server transport contract or runtime API behavior changes.
+
+## Work plan
+
+- Use sprint planning to select the smallest high-value extraction.
+- Implement the extraction in the active worktree only.
+- Run runtime validation and dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Sprint evaluator verdict: `approved`.
+- Dedicated pre-push validation: passed.
+- Validation:
+  - `cd apps/codex-runtime && npm run check`
+  - `cd apps/codex-runtime && npm test -- tests/app-server-event-translation.test.ts tests/thread-routes.test.ts`
+  - `cd apps/codex-runtime && npm run build`
+  - `git diff --check`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-244-gateway-event-translation`
+- Active worktree: `.worktrees/issue-244-gateway-event-translation`
+- Notes: Extracted native command approval event translation into a pure `app-server-event-translation` helper. Gateway process lifecycle, JSON-RPC transport, request sending, notification sending, approval resolution, and turn convergence remain unchanged. Completion retrospective found no durable skill/doc update needed. PR merge, parent sync, worktree cleanup, Issue close, and Project `Done` remain pending.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate has passed, and these handoff notes are updated with final evidence.


### PR DESCRIPTION
## Summary

- Extract command approval event translation into a pure app-server helper.
- Keep gateway side effects in place: waiting state, approval sink ingestion, and pending approval request id storage.
- Add focused helper coverage for valid and ignored native approval events.
- Archive the #244 task package after sprint approval and dedicated pre-push validation.

## Validation

- `cd apps/codex-runtime && npm run check`
- `cd apps/codex-runtime && npm test -- tests/app-server-event-translation.test.ts tests/thread-routes.test.ts`
- `cd apps/codex-runtime && npm run build`
- `git diff --check`

Closes #244
