### PR TITLE
refactor: isolate request helper lifecycle

### DIFF
--- a/apps/codex-runtime/src/domain/threads/thread-request-helper-lifecycle.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-request-helper-lifecycle.ts
@@ -1,0 +1,64 @@
+import type { ThreadRequestRecord } from "./thread-request-persistence.js";
+import type { LatestResolvedRequestSummary, PendingRequestSummary } from "./types.js";
+
+export function buildThreadRequestHelperLifecycleState(threadRequests: ThreadRequestRecord[]): {
+  pending_request: PendingRequestSummary | null;
+  latest_resolved_request: LatestResolvedRequestSummary | null;
+} {
+  const pendingRequest = threadRequests.find((request) => request.status === "pending") ?? null;
+  const latestResolvedRequest =
+    pendingRequest === null ? selectLatestResolvedRequest(threadRequests) : null;
+
+  return {
+    pending_request: pendingRequest ? toPendingRequestSummary(pendingRequest) : null,
+    latest_resolved_request: latestResolvedRequest
+      ? toLatestResolvedRequestSummary(latestResolvedRequest)
+      : null,
+  };
+}
+
+function selectLatestResolvedRequest(
+  threadRequests: ThreadRequestRecord[],
+): ThreadRequestRecord | null {
+  return (
+    threadRequests
+      .filter(hasRespondedRequest)
+      .sort((left, right) => right.responded_at.localeCompare(left.responded_at))[0] ?? null
+  );
+}
+
+function hasRespondedRequest(
+  request: ThreadRequestRecord,
+): request is ThreadRequestRecord & { responded_at: string } {
+  return request.status !== "pending" && request.responded_at !== null;
+}
+
+function toPendingRequestSummary(request: ThreadRequestRecord): PendingRequestSummary {
+  return {
+    request_id: request.request_id,
+    thread_id: request.thread_id,
+    turn_id: null,
+    item_id: request.request_id,
+    request_kind: request.request_kind,
+    status: request.status,
+    risk_classification: request.risk_classification,
+    summary: request.summary,
+    requested_at: request.requested_at,
+  };
+}
+
+function toLatestResolvedRequestSummary(
+  request: ThreadRequestRecord,
+): LatestResolvedRequestSummary {
+  return {
+    request_id: request.request_id,
+    thread_id: request.thread_id,
+    turn_id: null,
+    item_id: request.request_id,
+    request_kind: request.request_kind,
+    status: "resolved",
+    decision: request.resolution!,
+    requested_at: request.requested_at,
+    responded_at: request.responded_at!,
+  };
+}

--- a/apps/codex-runtime/src/domain/threads/thread-service.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-service.ts
@@ -22,14 +22,13 @@ import type {
 import type { WorkspaceFilesystem } from "../workspaces/workspace-filesystem.js";
 import type { WorkspaceRegistry } from "../workspaces/workspace-registry.js";
 import { ThreadInputOrchestrator } from "./thread-input-orchestrator.js";
+import { buildThreadRequestHelperLifecycleState } from "./thread-request-helper-lifecycle.js";
 import {
   ThreadRequestPersistence,
   type ThreadRequestRecord,
 } from "./thread-request-persistence.js";
 import type {
-  LatestResolvedRequestSummary,
   NotificationEvent,
-  PendingRequestSummary,
   RequestDetailView,
   ThreadSummary,
   ThreadViewHelper,
@@ -121,44 +120,6 @@ function toTimelineItem(event: SessionEventProjection): TimelineItem {
     summary: summarizeTimelineEvent(event),
     content,
     request_id: requestId,
-  };
-}
-
-function toPendingRequestSummary(request: ThreadRequestRecord): PendingRequestSummary {
-  return {
-    request_id: request.request_id,
-    thread_id: request.thread_id,
-    turn_id: null,
-    item_id: request.request_id,
-    request_kind: request.request_kind,
-    status: request.status,
-    risk_classification: request.risk_classification,
-    summary: request.summary,
-    requested_at: request.requested_at,
-  };
-}
-
-function toLatestResolvedRequestSummary(
-  request: ThreadRequestRecord,
-): LatestResolvedRequestSummary | null {
-  if (
-    request.status === "pending" ||
-    request.resolution === null ||
-    request.responded_at === null
-  ) {
-    return null;
-  }
-
-  return {
-    request_id: request.request_id,
-    thread_id: request.thread_id,
-    turn_id: null,
-    item_id: request.request_id,
-    request_kind: request.request_kind,
-    status: "resolved",
-    decision: request.resolution,
-    requested_at: request.requested_at,
-    responded_at: request.responded_at,
   };
 }
 
@@ -512,19 +473,12 @@ export class ThreadService {
     await this.getThread(threadId);
 
     const threadRequests = this.threadRequestPersistence.listThreadRequests(threadId);
-    const pending = threadRequests.find((request) => request.status === "pending") ?? null;
-    const latestResolved =
-      threadRequests
-        .filter((request) => request.status !== "pending" && request.responded_at !== null)
-        .sort((left, right) =>
-          (right.responded_at ?? "").localeCompare(left.responded_at ?? ""),
-        )[0] ?? null;
+    const helperState = buildThreadRequestHelperLifecycleState(threadRequests);
 
     return {
       thread_id: threadId,
-      pending_request: pending ? toPendingRequestSummary(pending) : null,
-      latest_resolved_request:
-        pending || latestResolved === null ? null : toLatestResolvedRequestSummary(latestResolved),
+      pending_request: helperState.pending_request,
+      latest_resolved_request: helperState.latest_resolved_request,
       checked_at: this.now().toISOString(),
     };
   }

--- a/apps/codex-runtime/tests/thread-routes.test.ts
+++ b/apps/codex-runtime/tests/thread-routes.test.ts
@@ -610,6 +610,246 @@ describe("thread routes", () => {
     await app.close();
   });
 
+  it("returns the newest resolved request when no pending helper is reachable", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+    });
+
+    database.db
+      .insert(workspaces)
+      .values({
+        workspaceId: "ws_alpha",
+        workspaceName: "alpha",
+        directoryName: "alpha",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:00:00.000Z",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: "thread_001",
+        workspaceId: "ws_alpha",
+        title: "Existing thread",
+        status: "waiting_input",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:03:00.000Z",
+        startedAt: "2026-04-09T00:00:00.000Z",
+        lastMessageAt: "2026-04-09T00:02:00.000Z",
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    database.db
+      .insert(approvals)
+      .values([
+        {
+          approvalId: "apr_old",
+          sessionId: "thread_001",
+          workspaceId: "ws_alpha",
+          status: "denied",
+          resolution: "denied",
+          approvalCategory: "external_side_effect",
+          summary: "Declined old request",
+          reason: "Older helper request.",
+          operationSummary: "git push origin old-branch",
+          context: null,
+          createdAt: "2026-04-09T00:01:00.000Z",
+          resolvedAt: "2026-04-09T00:02:00.000Z",
+          nativeRequestKind: "approval",
+        },
+        {
+          approvalId: "apr_new",
+          sessionId: "thread_001",
+          workspaceId: "ws_alpha",
+          status: "approved",
+          resolution: "approved",
+          approvalCategory: "external_side_effect",
+          summary: "Accepted newer request",
+          reason: "Newer helper request.",
+          operationSummary: "git push origin main",
+          context: null,
+          createdAt: "2026-04-09T00:01:30.000Z",
+          resolvedAt: "2026-04-09T00:02:30.000Z",
+          nativeRequestKind: "approval",
+        },
+      ])
+      .run();
+
+    const pendingResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001/pending_request",
+    });
+
+    expect(pendingResponse.statusCode).toBe(200);
+    expect(pendingResponse.json()).toMatchObject({
+      thread_id: "thread_001",
+      pending_request: null,
+      latest_resolved_request: {
+        request_id: "apr_new",
+        thread_id: "thread_001",
+        status: "resolved",
+        decision: "approved",
+        requested_at: "2026-04-09T00:01:30.000Z",
+        responded_at: "2026-04-09T00:02:30.000Z",
+      },
+    });
+
+    const viewResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001/view",
+    });
+
+    expect(viewResponse.statusCode).toBe(200);
+    expect(viewResponse.json()).toMatchObject({
+      thread: {
+        thread_id: "thread_001",
+      },
+      pending_request: null,
+      latest_resolved_request: {
+        request_id: "apr_new",
+        thread_id: "thread_001",
+        status: "resolved",
+        decision: "approved",
+      },
+    });
+
+    await app.close();
+  });
+
+  it("suppresses retained latest-resolved helpers when any pending request exists", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+    });
+
+    database.db
+      .insert(workspaces)
+      .values({
+        workspaceId: "ws_alpha",
+        workspaceName: "alpha",
+        directoryName: "alpha",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:00:00.000Z",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: "thread_001",
+        workspaceId: "ws_alpha",
+        title: "Existing thread",
+        status: "waiting_approval",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:03:00.000Z",
+        startedAt: "2026-04-09T00:00:00.000Z",
+        lastMessageAt: "2026-04-09T00:02:30.000Z",
+        activeApprovalId: "apr_pending",
+        currentTurnId: "turn_001",
+        pendingAssistantMessageId: "msg_assistant_pending_001",
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    database.db
+      .insert(approvals)
+      .values([
+        {
+          approvalId: "apr_resolved",
+          sessionId: "thread_001",
+          workspaceId: "ws_alpha",
+          status: "approved",
+          resolution: "approved",
+          approvalCategory: "external_side_effect",
+          summary: "Accepted earlier request",
+          reason: "Earlier helper request.",
+          operationSummary: "git push origin main",
+          context: null,
+          createdAt: "2026-04-09T00:01:00.000Z",
+          resolvedAt: "2026-04-09T00:02:00.000Z",
+          nativeRequestKind: "approval",
+        },
+        {
+          approvalId: "apr_pending",
+          sessionId: "thread_001",
+          workspaceId: "ws_alpha",
+          status: "pending",
+          resolution: null,
+          approvalCategory: "external_side_effect",
+          summary: "Pending retained request",
+          reason: "Current helper request.",
+          operationSummary: "git push origin feature",
+          context: null,
+          createdAt: "2026-04-09T00:02:30.000Z",
+          resolvedAt: null,
+          nativeRequestKind: "approval",
+        },
+      ])
+      .run();
+
+    const pendingResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001/pending_request",
+    });
+
+    expect(pendingResponse.statusCode).toBe(200);
+    expect(pendingResponse.json()).toMatchObject({
+      thread_id: "thread_001",
+      pending_request: {
+        request_id: "apr_pending",
+        thread_id: "thread_001",
+        summary: "Pending retained request",
+        status: "pending",
+      },
+      latest_resolved_request: null,
+    });
+
+    const viewResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001/view",
+    });
+
+    expect(viewResponse.statusCode).toBe(200);
+    expect(viewResponse.json()).toMatchObject({
+      thread: {
+        thread_id: "thread_001",
+      },
+      pending_request: {
+        request_id: "apr_pending",
+        summary: "Pending retained request",
+      },
+      latest_resolved_request: null,
+    });
+
+    await app.close();
+  });
+
   it("resolves denied requests through thread routes and clears turn-tracking state", async () => {
     const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
     const database = await createTempDatabase("thread-routes-db");

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-245-request-helper-lifecycle](./archive/issue-245-request-helper-lifecycle/README.md)
 - [issue-244-gateway-event-translation](./archive/issue-244-gateway-event-translation/README.md)
 - [issue-243-persistence-boundary](./archive/issue-243-persistence-boundary/README.md)
 - [issue-242-thread-orchestration-boundary](./archive/issue-242-thread-orchestration-boundary/README.md)

--- a/tasks/archive/issue-245-request-helper-lifecycle/README.md
+++ b/tasks/archive/issue-245-request-helper-lifecycle/README.md
@@ -1,0 +1,55 @@
+# Issue 245 Request Helper Lifecycle
+
+## Purpose
+
+- Isolate request-helper lifecycle and just-resolved recovery rules from broad runtime thread/session services.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/245
+
+## Source docs
+
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Extract one cohesive request-helper lifecycle responsibility from runtime thread/request code.
+- Preserve current internal/public shapes and request response behavior.
+- Add or preserve targeted pending/resolved/missing request coverage.
+
+## Exit criteria
+
+- One request-helper lifecycle rule has a named runtime home.
+- Targeted runtime tests document pending/latest-resolved or missing/resolved behavior after extraction.
+- Runtime validation passes.
+
+## Work plan
+
+- Use sprint planning to select the smallest high-value request-helper lifecycle slice.
+- Implement the extraction in the active worktree only.
+- Run runtime validation and dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Sprint evaluator verdict: `approved`.
+- Dedicated pre-push validation: passed.
+- Validation:
+  - `cd apps/codex-runtime && npm run check`
+  - `cd apps/codex-runtime && npm test -- thread-routes.test.ts`
+  - `cd apps/codex-runtime && npm run build`
+  - `git diff --check`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-245-request-helper-lifecycle`
+- Active worktree: `.worktrees/issue-245-request-helper-lifecycle`
+- Notes: Extracted pending/latest-resolved helper lifecycle selection into `thread-request-helper-lifecycle`. `ThreadService` still validates thread existence and sets `checked_at`, while the helper owns pending-wins and newest-resolved selection. Completion retrospective found no durable skill/doc update needed. PR merge, parent sync, worktree cleanup, Issue close, and Project `Done` remain pending.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate has passed, and these handoff notes are updated with final evidence.


### PR DESCRIPTION
## Summary

- Extract pending/latest-resolved request helper lifecycle into a named runtime helper.
- Keep `ThreadService` responsible for thread validation and `checked_at`, delegating helper-state construction.
- Add focused route coverage for latest-resolved recovery and pending-request suppression across `/pending_request` and `/view`.
- Archive the #245 task package after sprint approval and dedicated pre-push validation.

## Validation

- `cd apps/codex-runtime && npm run check`
- `cd apps/codex-runtime && npm test -- thread-routes.test.ts`
- `cd apps/codex-runtime && npm run build`
- `git diff --check`

Closes #245
