### PR TITLE
refactor: split bff public type boundaries

### DIFF
--- a/apps/frontend-bff/src/chat-data.ts
+++ b/apps/frontend-bff/src/chat-data.ts
@@ -1,6 +1,5 @@
-import type { PublicListResponse } from "./chat-types";
 import { isErrorEnvelope } from "./errors";
-import type { HomeResponse } from "./runtime-types";
+import type { PublicListResponse, PublicWorkspaceSummary } from "./public-types";
 import type {
   PublicRequestDetail,
   PublicRequestResponseResult,
@@ -10,8 +9,9 @@ import type {
   PublicThreadView,
 } from "./thread-types";
 
+export type { PublicWorkspaceSummary } from "./public-types";
+
 type FetchLike = typeof fetch;
-export type PublicWorkspaceSummary = HomeResponse["workspaces"][number];
 
 async function readJson<T>(response: Response) {
   const payload = (await response.json()) as unknown;

--- a/apps/frontend-bff/src/chat-send-recovery.ts
+++ b/apps/frontend-bff/src/chat-send-recovery.ts
@@ -1,4 +1,4 @@
-import type { PublicMessage, PublicSessionEvent, PublicSessionSummary } from "./chat-types";
+import type { PublicMessage, PublicSessionEvent, PublicSessionSummary } from "./legacy-types";
 
 export interface ChatSessionSnapshot {
   session: PublicSessionSummary | null;

--- a/apps/frontend-bff/src/handlers/workspaces.ts
+++ b/apps/frontend-bff/src/handlers/workspaces.ts
@@ -1,11 +1,7 @@
 import { isErrorEnvelope, toErrorResponse } from "../errors";
 import { mapThreadListItem, mapWorkspace, mapWorkspaceList } from "../mappings";
-import type {
-  HomeResponse,
-  ListResponse,
-  RuntimeThreadSummary,
-  RuntimeWorkspaceSummary,
-} from "../runtime-types";
+import type { HomeResponse } from "../public-types";
+import type { ListResponse, RuntimeThreadSummary, RuntimeWorkspaceSummary } from "../runtime-types";
 import type { PublicThreadListItem } from "../thread-types";
 import {
   forwardSearch,

--- a/apps/frontend-bff/src/home-data.ts
+++ b/apps/frontend-bff/src/home-data.ts
@@ -1,5 +1,6 @@
 import { isErrorEnvelope } from "./errors";
-import type { HomeResponse, RuntimeWorkspaceSummary } from "./runtime-types";
+import type { HomeResponse } from "./public-types";
+import type { RuntimeWorkspaceSummary } from "./runtime-types";
 
 type FetchLike = typeof fetch;
 

--- a/apps/frontend-bff/src/home-page-client.tsx
+++ b/apps/frontend-bff/src/home-page-client.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 
 import { createWorkspaceFromHome, fetchHomeData } from "./home-data";
 import { HomeView } from "./home-view";
-import type { HomeResponse } from "./runtime-types";
+import type { HomeResponse } from "./public-types";
 import type { PublicNotificationEvent } from "./thread-types";
 
 function chooseDefaultWorkspaceId(home: HomeResponse | null) {

--- a/apps/frontend-bff/src/home-view.tsx
+++ b/apps/frontend-bff/src/home-view.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import type { HomeResponse } from "./runtime-types";
+import type { HomeResponse } from "./public-types";
 import type { PublicThreadListItem } from "./thread-types";
 
 export interface HomeViewProps {

--- a/apps/frontend-bff/src/legacy-types.ts
+++ b/apps/frontend-bff/src/legacy-types.ts
@@ -65,9 +65,3 @@ export interface PublicStopResult {
   session: PublicSessionSummary;
   canceled_approval: PublicApprovalSummary | null;
 }
-
-export interface PublicListResponse<T> {
-  items: T[];
-  next_cursor: string | null;
-  has_more: boolean;
-}

--- a/apps/frontend-bff/src/public-types.ts
+++ b/apps/frontend-bff/src/public-types.ts
@@ -1,0 +1,26 @@
+import type { PublicThreadListItem } from "./thread-types";
+
+export interface PublicWorkspaceSummary {
+  workspace_id: string;
+  workspace_name: string;
+  created_at: string;
+  updated_at: string;
+  active_session_summary: {
+    session_id: string;
+    status: string;
+    last_message_at: string | null;
+  } | null;
+  pending_approval_count: number;
+}
+
+export interface HomeResponse {
+  workspaces: PublicWorkspaceSummary[];
+  resume_candidates: PublicThreadListItem[];
+  updated_at: string;
+}
+
+export interface PublicListResponse<T> {
+  items: T[];
+  next_cursor: string | null;
+  has_more: boolean;
+}

--- a/apps/frontend-bff/src/runtime-types.ts
+++ b/apps/frontend-bff/src/runtime-types.ts
@@ -1,5 +1,3 @@
-import type { PublicThreadListItem } from "./thread-types";
-
 export interface RuntimeWorkspaceSummary {
   workspace_id: string;
   workspace_name: string;
@@ -232,23 +230,6 @@ export interface RuntimeApprovalStreamEventProjection {
   occurred_at: string;
   payload: Record<string, unknown>;
   native_event_name: string | null;
-}
-
-export interface HomeResponse {
-  workspaces: Array<{
-    workspace_id: string;
-    workspace_name: string;
-    created_at: string;
-    updated_at: string;
-    active_session_summary: {
-      session_id: string;
-      status: string;
-      last_message_at: string | null;
-    } | null;
-    pending_approval_count: number;
-  }>;
-  resume_candidates: PublicThreadListItem[];
-  updated_at: string;
 }
 
 export interface ListResponse<T> {

--- a/apps/frontend-bff/src/session-status.ts
+++ b/apps/frontend-bff/src/session-status.ts
@@ -1,4 +1,4 @@
-import type { PublicSessionSummary } from "./chat-types";
+import type { PublicSessionSummary } from "./legacy-types";
 
 function canStopForStatus(status: PublicSessionSummary["status"]) {
   return status === "running" || status === "waiting_input" || status === "waiting_approval";

--- a/apps/frontend-bff/tests/home-page-client.test.tsx
+++ b/apps/frontend-bff/tests/home-page-client.test.tsx
@@ -5,7 +5,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { HomeResponse } from "../src/runtime-types";
+import type { HomeResponse } from "../src/public-types";
 
 const homeDataMocks = vi.hoisted(() => ({
   createWorkspaceFromHome: vi.fn(),

--- a/apps/frontend-bff/tests/session-status.test.ts
+++ b/apps/frontend-bff/tests/session-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { PublicSessionSummary } from "../src/chat-types";
+import type { PublicSessionSummary } from "../src/legacy-types";
 import { applySessionStatus } from "../src/session-status";
 
 function buildSession(overrides: Partial<PublicSessionSummary> = {}): PublicSessionSummary {

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-247-bff-type-boundaries](./archive/issue-247-bff-type-boundaries/README.md)
 - [issue-246-bff-resource-handlers](./archive/issue-246-bff-resource-handlers/README.md)
 - [issue-245-request-helper-lifecycle](./archive/issue-245-request-helper-lifecycle/README.md)
 - [issue-244-gateway-event-translation](./archive/issue-244-gateway-event-translation/README.md)

--- a/tasks/archive/issue-247-bff-type-boundaries/README.md
+++ b/tasks/archive/issue-247-bff-type-boundaries/README.md
@@ -1,0 +1,66 @@
+# issue-247-bff-type-boundaries
+
+## Purpose
+
+Separate BFF runtime contract types from public browser read models so v0.9 code paths do not depend on session-centric UI aliases or retired legacy types.
+
+## Primary issue
+
+- GitHub Issue: #247
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Clarify the boundary between `runtime-types.ts`, public API/browser models, and UI-local view models.
+- Keep route URLs, response bodies, and mapper behavior unchanged.
+- Quarantine or split legacy session/approval types only where route/test references still need compatibility.
+
+## Exit criteria
+
+- Active v0.9 BFF code paths have a clear public model import boundary separate from runtime contract types.
+- Legacy session/approval types are isolated or explicitly retained as compatibility-only.
+- BFF check, TypeScript, targeted tests, and pre-push validation pass, allowing the known baseline UI test drift only when reproduced on `main`.
+
+## Work plan
+
+1. Map imports of `runtime-types.ts`, `thread-types.ts`, and `chat-types.ts`.
+2. Let the sprint planner define one bounded type-boundary slice.
+3. Implement the approved type/module split from this worktree.
+4. Run BFF validation and evaluator review.
+5. Run dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Sprint 1 public Home/list type boundary: evaluator verdict `approved`.
+- Sprint 2 legacy session/approval type quarantine: evaluator verdict `approved`.
+- Dedicated pre-push validation: `passed`.
+- Validation evidence:
+  - `cd apps/frontend-bff && npm run check` passed.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - targeted BFF tests passed with 39 tests.
+  - `cd apps/frontend-bff && npm run build` passed.
+  - `git diff --check` passed.
+  - full `cd apps/frontend-bff && npm test` still fails only the known baseline `tests/chat-page-client.test.tsx` `Selected` assertions reproduced on parent `main`.
+
+## Status / handoff notes
+
+- Status: locally complete.
+- Active branch: `issue-247-bff-type-boundaries`.
+- Active worktree: `.worktrees/issue-247-bff-type-boundaries`.
+- `runtime-types.ts` no longer imports public thread models or exports `HomeResponse`.
+- Public Home/list models now live in `public-types.ts`.
+- Legacy session/approval public models now live in `legacy-types.ts`; `chat-types.ts` was removed.
+- Completion retrospective found no durable skill or docs update needed. The known full-suite UI baseline drift remains outside this type-boundary package.
+- Completion tracking, PR merge, worktree cleanup, Project `Done`, and Issue close remain pending.
+
+## Archive conditions
+
+- Sprint evaluator returns `approved`.
+- Dedicated pre-push validation passes.
+- Package evidence and handoff notes are updated.
+- Package is moved to `tasks/archive/issue-247-bff-type-boundaries/` before PR completion tracking.


### PR DESCRIPTION
## Summary

- move public Home/list browser models into `public-types.ts`
- remove public-model imports from `runtime-types.ts`
- quarantine legacy session/approval browser models in `legacy-types.ts`
- archive the completed #247 task package

## Validation

- `cd apps/frontend-bff && npm run check`
- `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- targeted BFF tests for home, chat-data, session status, routes, and send recovery
- `cd apps/frontend-bff && npm run build`
- `git diff --check`

Known baseline drift:

- `cd apps/frontend-bff && npm test` still fails only two `tests/chat-page-client.test.tsx` `Selected` assertions reproduced on parent `main`; this is outside the type-boundary scope.

Closes #247
