### PR TITLE
Refactor BFF route boilerplate

### DIFF
--- a/apps/frontend-bff/app/api/v1/approvals/[approvalId]/approve/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/[approvalId]/approve/route.ts
@@ -1,5 +1,1 @@
-import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
-
-export function POST() {
-  return retiredLegacyRouteResponse("approvals");
-}
+export { retiredApprovalsRouteHandler as POST } from "../../../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/approvals/[approvalId]/deny/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/[approvalId]/deny/route.ts
@@ -1,5 +1,1 @@
-import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
-
-export function POST() {
-  return retiredLegacyRouteResponse("approvals");
-}
+export { retiredApprovalsRouteHandler as POST } from "../../../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/approvals/[approvalId]/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/[approvalId]/route.ts
@@ -1,5 +1,1 @@
-import { retiredLegacyRouteResponse } from "../../../../../src/retired-routes";
-
-export function GET() {
-  return retiredLegacyRouteResponse("approvals");
-}
+export { retiredApprovalsRouteHandler as GET } from "../../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/approvals/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/route.ts
@@ -1,5 +1,1 @@
-import { retiredLegacyRouteResponse } from "../../../../src/retired-routes";
-
-export function GET() {
-  return retiredLegacyRouteResponse("approvals");
-}
+export { retiredApprovalsRouteHandler as GET } from "../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/approvals/stream/route.ts
+++ b/apps/frontend-bff/app/api/v1/approvals/stream/route.ts
@@ -1,8 +1,4 @@
-import { retiredLegacyRouteResponse } from "../../../../../src/retired-routes";
+export { retiredApprovalsRouteHandler as GET } from "../../../../../src/retired-routes";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-export function GET() {
-  return retiredLegacyRouteResponse("approvals");
-}

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/events/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/events/route.ts
@@ -1,5 +1,1 @@
-import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
-
-export function GET() {
-  return retiredLegacyRouteResponse("sessions");
-}
+export { retiredSessionsRouteHandler as GET } from "../../../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/messages/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/messages/route.ts
@@ -1,9 +1,4 @@
-import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
-
-export function GET() {
-  return retiredLegacyRouteResponse("sessions");
-}
-
-export function POST() {
-  return retiredLegacyRouteResponse("sessions");
-}
+export {
+  retiredSessionsRouteHandler as GET,
+  retiredSessionsRouteHandler as POST,
+} from "../../../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/route.ts
@@ -1,5 +1,1 @@
-import { retiredLegacyRouteResponse } from "../../../../../src/retired-routes";
-
-export function GET() {
-  return retiredLegacyRouteResponse("sessions");
-}
+export { retiredSessionsRouteHandler as GET } from "../../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/start/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/start/route.ts
@@ -1,5 +1,1 @@
-import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
-
-export function POST() {
-  return retiredLegacyRouteResponse("sessions");
-}
+export { retiredSessionsRouteHandler as POST } from "../../../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stop/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stop/route.ts
@@ -1,5 +1,1 @@
-import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
-
-export function POST() {
-  return retiredLegacyRouteResponse("sessions");
-}
+export { retiredSessionsRouteHandler as POST } from "../../../../../../src/retired-routes";

--- a/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stream/route.ts
+++ b/apps/frontend-bff/app/api/v1/sessions/[sessionId]/stream/route.ts
@@ -1,8 +1,4 @@
-import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
+export { retiredSessionsRouteHandler as GET } from "../../../../../../src/retired-routes";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-export function GET() {
-  return retiredLegacyRouteResponse("sessions");
-}

--- a/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/sessions/route.ts
+++ b/apps/frontend-bff/app/api/v1/workspaces/[workspaceId]/sessions/route.ts
@@ -1,9 +1,4 @@
-import { retiredLegacyRouteResponse } from "../../../../../../src/retired-routes";
-
-export function GET() {
-  return retiredLegacyRouteResponse("sessions");
-}
-
-export function POST() {
-  return retiredLegacyRouteResponse("sessions");
-}
+export {
+  retiredSessionsRouteHandler as GET,
+  retiredSessionsRouteHandler as POST,
+} from "../../../../../../src/retired-routes";

--- a/apps/frontend-bff/src/handlers/requests.ts
+++ b/apps/frontend-bff/src/handlers/requests.ts
@@ -1,11 +1,11 @@
-import { isErrorEnvelope, toErrorResponse } from "../errors";
+import { toErrorResponse } from "../errors";
 import { mapPendingRequestView, mapRequestDetail, mapRequestResponseResult } from "../mappings";
 import type {
   RuntimeRequestDetailView,
   RuntimeRequestResponseResult,
   RuntimeThreadPendingRequestView,
 } from "../runtime-types";
-import { jsonResponse, passthroughRuntimeError, readJsonBody, runtimeClient } from "./shared";
+import { mapRuntimeJsonResult, readJsonBody, runtimeClient } from "./shared";
 
 export async function getPendingRequest(_request: Request, threadId: string) {
   try {
@@ -13,14 +13,10 @@ export async function getPendingRequest(_request: Request, threadId: string) {
       `/api/v1/threads/${threadId}/pending_request`,
     );
 
-    if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body, {
-        sessionNotFoundCode: "thread_not_found",
-        threadId,
-      });
-    }
-
-    return jsonResponse(result.status, mapPendingRequestView(result.body));
+    return mapRuntimeJsonResult(result, (body) => mapPendingRequestView(body), {
+      sessionNotFoundCode: "thread_not_found",
+      threadId,
+    });
   } catch (error) {
     return toErrorResponse(error);
   }
@@ -32,14 +28,10 @@ export async function getRequestDetail(_request: Request, requestId: string) {
       `/api/v1/requests/${requestId}`,
     );
 
-    if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body, {
-        requestId,
-        sessionNotFoundCode: "request_not_found",
-      });
-    }
-
-    return jsonResponse(result.status, mapRequestDetail(result.body));
+    return mapRuntimeJsonResult(result, (body) => mapRequestDetail(body), {
+      requestId,
+      sessionNotFoundCode: "request_not_found",
+    });
   } catch (error) {
     return toErrorResponse(error);
   }
@@ -55,15 +47,11 @@ export async function postRequestResponse(request: Request, requestId: string) {
       },
     );
 
-    if (isErrorEnvelope(result.body)) {
-      return passthroughRuntimeError(result.status, result.body, {
-        requestId,
-        sessionInvalidStateCode: "request_not_pending",
-        sessionNotFoundCode: "request_not_found",
-      });
-    }
-
-    return jsonResponse(result.status, mapRequestResponseResult(result.body));
+    return mapRuntimeJsonResult(result, (body) => mapRequestResponseResult(body), {
+      requestId,
+      sessionInvalidStateCode: "request_not_pending",
+      sessionNotFoundCode: "request_not_found",
+    });
   } catch (error) {
     return toErrorResponse(error);
   }

--- a/apps/frontend-bff/src/handlers/shared.ts
+++ b/apps/frontend-bff/src/handlers/shared.ts
@@ -215,3 +215,15 @@ export function passthroughRuntimeError(
 
   throw new Error("expected runtime error envelope");
 }
+
+export function mapRuntimeJsonResult<TBody, TMapped>(
+  result: { status: number; body: TBody | ErrorEnvelope },
+  mapper: (body: TBody) => TMapped,
+  mapping?: ActiveRuntimeErrorMapping,
+) {
+  if (isErrorEnvelope(result.body)) {
+    return passthroughRuntimeError(result.status, result.body, mapping);
+  }
+
+  return jsonResponse(result.status, mapper(result.body));
+}

--- a/apps/frontend-bff/src/retired-routes.ts
+++ b/apps/frontend-bff/src/retired-routes.ts
@@ -23,3 +23,7 @@ export function retiredLegacyRouteResponse(routeFamily: RetiredLegacyRouteFamily
     },
   });
 }
+
+export const retiredApprovalsRouteHandler = () => retiredLegacyRouteResponse("approvals");
+
+export const retiredSessionsRouteHandler = () => retiredLegacyRouteResponse("sessions");

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-249-bff-route-boilerplate](./archive/issue-249-bff-route-boilerplate/README.md)
 - [issue-248-bff-mapping-boundaries](./archive/issue-248-bff-mapping-boundaries/README.md)
 - [issue-247-bff-type-boundaries](./archive/issue-247-bff-type-boundaries/README.md)
 - [issue-246-bff-resource-handlers](./archive/issue-246-bff-resource-handlers/README.md)

--- a/tasks/archive/issue-249-bff-route-boilerplate/README.md
+++ b/tasks/archive/issue-249-bff-route-boilerplate/README.md
@@ -1,0 +1,80 @@
+# issue-249-bff-route-boilerplate
+
+## Purpose
+
+Reduce duplicated BFF route mechanics around runtime calls, JSON passthrough, SSE relay errors, and retired route responses while keeping endpoint-specific behavior explicit.
+
+## Primary issue
+
+- GitHub Issue: #249
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Identify repeated route-level passthrough, retired-response, and SSE error mechanics in `apps/frontend-bff/app/api/v1/**/route.ts` and BFF helper modules.
+- Extract concrete helpers only where duplication is mechanical.
+- Preserve public URLs, response status codes, error payload shapes, SSE event behavior, and endpoint-specific mapping logic.
+
+## Exit criteria
+
+- Duplicated passthrough/retired/SSE helper code is reduced.
+- Route files remain simple and explicit.
+- BFF checks, TypeScript, targeted route tests, and pre-push validation pass, allowing the known baseline UI test drift only when reproduced on `main`.
+
+## Work plan
+
+1. Map duplicated route mechanics and existing helper boundaries.
+2. Let the sprint planner define a bounded refactor slice.
+3. Implement the approved route-helper extraction from this worktree.
+4. Run BFF validation and evaluator review.
+5. Run dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Sprint 1 extracted `mapRuntimeJsonResult` in `apps/frontend-bff/src/handlers/shared.ts` and applied it to request-helper handlers in `apps/frontend-bff/src/handlers/requests.ts`.
+- Sprint 1 evaluator verdict: approved. Request route paths, methods, body reading, mapper calls, and active error mappings remain explicit.
+- Sprint 2 added shared retired route handlers in `apps/frontend-bff/src/retired-routes.ts` and replaced duplicated retired route `GET`/`POST` wrappers with direct exports.
+- Sprint 2 evaluator verdict: approved. Retired route 410 payloads and stream route config exports are preserved.
+- Validation evidence before pre-push:
+  - `cd apps/frontend-bff && npm run check`: pass.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: pass.
+  - `cd apps/frontend-bff && npm test -- tests/routes.test.ts`: pass, 22 tests.
+  - `cd apps/frontend-bff && npm test`: only known baseline drift remains in `tests/chat-page-client.test.tsx`, two assertions expecting `Selected`.
+  - `cd apps/frontend-bff && npm run build`: pass.
+  - `git diff --check`: pass.
+- Dedicated pre-push validation evidence:
+  - `git status --short --branch`: dirty only from this package/code slice.
+  - `cd apps/frontend-bff && npm run check`: pass.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: pass.
+  - `cd apps/frontend-bff && npm test -- tests/routes.test.ts`: pass.
+  - `cd apps/frontend-bff && npm test`: only known baseline drift remains in `tests/chat-page-client.test.tsx`, two assertions expecting `Selected`.
+  - `cd apps/frontend-bff && npm run build`: pass.
+  - `rg` checks confirm retired route wrappers no longer call `retiredLegacyRouteResponse` from route files and request helpers flow through `mapRuntimeJsonResult`.
+  - `git diff --check`: pass.
+
+## Status / handoff notes
+
+- Status: locally complete; ready for archive and PR follow-through.
+- Active branch: `issue-249-bff-route-boilerplate`.
+- Active worktree: `.worktrees/issue-249-bff-route-boilerplate`.
+- Completion tracking, PR merge, worktree cleanup, Project `Done`, and Issue close remain pending.
+- Completion retrospective:
+  - Completion boundary: package archive before PR publication.
+  - Contract check: passthrough, retired response wrapper, and route behavior validation conditions are satisfied by the helper extraction, retired route direct exports, route tests, and build evidence above.
+  - What worked: splitting runtime JSON passthrough and retired route wrapper cleanup into two small slices kept endpoint behavior reviewable.
+  - Workflow problems: full `npm test` remains blocked by the known `Selected` UI baseline drift outside this Issue.
+  - Improvements to adopt: continue using focused `rg` checks for mechanical refactor acceptance.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: publish PR, merge to `main`, remove the worktree, clear Issue execution links, set Project status to `Done`, and close #249.
+
+## Archive conditions
+
+- Sprint evaluator returns `approved`.
+- Dedicated pre-push validation passes.
+- Package evidence and handoff notes are updated.
+- Package is moved to `tasks/archive/issue-249-bff-route-boilerplate/` before PR completion tracking.


### PR DESCRIPTION
## Summary

- Added `mapRuntimeJsonResult` for mapped runtime JSON success/error passthrough.
- Applied it to request-helper REST handlers while keeping endpoint-specific paths, body handling, mappers, and error mappings explicit.
- Added shared retired route handlers and replaced duplicated retired route one-line wrappers with direct route exports.
- Archived the #249 task package.

Closes #249

## Validation

- `cd apps/frontend-bff && npm run check`
- `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `cd apps/frontend-bff && npm test -- tests/routes.test.ts`
- `cd apps/frontend-bff && npm test` fails only the known baseline drift in `tests/chat-page-client.test.tsx`, two assertions expecting `Selected`
- `cd apps/frontend-bff && npm run build`
- `git diff --check`
