### PR TITLE
Refactor selected thread bundle hook

### DIFF
--- a/apps/frontend-bff/src/chat-page-client.tsx
+++ b/apps/frontend-bff/src/chat-page-client.tsx
@@ -8,7 +8,6 @@ import {
   interruptThreadFromChat,
   listChatWorkspaces,
   listWorkspaceThreads,
-  loadChatThreadBundle,
   type PublicWorkspaceSummary,
   respondToPendingRequest,
   sendThreadInput,
@@ -18,11 +17,10 @@ import { ChatView } from "./chat-view";
 import { logLiveChatDebug } from "./debug";
 import type {
   PublicNotificationEvent,
-  PublicRequestDetail,
   PublicThreadListItem,
   PublicThreadStreamEvent,
-  PublicThreadView,
 } from "./thread-types";
+import { useSelectedThreadBundle } from "./use-selected-thread-bundle";
 
 function createClientId(prefix: string) {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -48,13 +46,6 @@ function upsertStreamEvent(
 const ACTIVE_THREAD_REFRESH_INTERVAL_MS = 1500;
 const POST_START_READY_REFRESH_INTERVAL_MS = 400;
 const POST_START_READY_REFRESH_ATTEMPTS = 8;
-
-function selectRequestDetail(bundle: {
-  latestResolvedRequestDetail?: PublicRequestDetail | null;
-  pendingRequestDetail: PublicRequestDetail | null;
-}) {
-  return bundle.pendingRequestDetail ?? bundle.latestResolvedRequestDetail ?? null;
-}
 
 function hasStreamSequenceInconsistency(
   events: PublicThreadStreamEvent[],
@@ -119,10 +110,6 @@ export function ChatPageClient() {
   const [workspaceId, setWorkspaceId] = useState<string | null>(initialWorkspaceId);
   const [threads, setThreads] = useState<PublicThreadListItem[]>([]);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(initialThreadId);
-  const [selectedThreadView, setSelectedThreadView] = useState<PublicThreadView | null>(null);
-  const [selectedRequestDetail, setSelectedRequestDetail] = useState<PublicRequestDetail | null>(
-    null,
-  );
   const [streamEvents, setStreamEvents] = useState<PublicThreadStreamEvent[]>([]);
   const [draftAssistantMessages, setDraftAssistantMessages] = useState<Record<string, string>>({});
   const [composerDraft, setComposerDraft] = useState("");
@@ -136,7 +123,6 @@ export function ChatPageClient() {
   const [isLoadingWorkspaces, setIsLoadingWorkspaces] = useState(false);
   const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
   const [workspaceName, setWorkspaceName] = useState("");
-  const [isLoadingThread, setIsLoadingThread] = useState(false);
   const [isCreatingThread, setIsCreatingThread] = useState(false);
   const [isSendingMessage, setIsSendingMessage] = useState(false);
   const [isInterruptingThread, setIsInterruptingThread] = useState(false);
@@ -146,9 +132,22 @@ export function ChatPageClient() {
   const reconnectTimerRef = useRef<number | null>(null);
   const activeThreadRefreshTimerRef = useRef<number | null>(null);
   const threadListRefreshIdRef = useRef(0);
-  const selectedThreadRefreshIdRef = useRef(0);
   const selectedThreadIdRef = useRef<string | null>(initialThreadId);
   const streamEventsRef = useRef<PublicThreadStreamEvent[]>([]);
+  const {
+    isLoadingThread,
+    selectedRequestDetail,
+    selectedThreadView,
+    refreshSelectedThreadBundle,
+  } = useSelectedThreadBundle({
+    selectedThreadId,
+    onLoadStart: () => {
+      setErrorMessage(null);
+    },
+    onLoadError: (message) => {
+      setErrorMessage(message);
+    },
+  });
 
   function updateSelectedThreadId(
     nextThreadId: string | null,
@@ -196,7 +195,7 @@ export function ChatPageClient() {
         return;
       }
 
-      const bundle = await refreshSelectedThread(threadId);
+      const bundle = await refreshSelectedThreadBundle(threadId);
       if (!bundle) {
         return;
       }
@@ -267,50 +266,8 @@ export function ChatPageClient() {
     }
   }
 
-  async function refreshSelectedThread(threadId: string) {
-    const refreshId = selectedThreadRefreshIdRef.current + 1;
-    selectedThreadRefreshIdRef.current = refreshId;
-    setIsLoadingThread(true);
-    setErrorMessage(null);
-    logLiveChatDebug("chat-refresh", "refreshing selected thread bundle", {
-      thread_id: threadId,
-      refresh_id: refreshId,
-    });
-
-    try {
-      const bundle = await loadChatThreadBundle(threadId);
-      if (selectedThreadRefreshIdRef.current !== refreshId) {
-        logLiveChatDebug("chat-refresh", "discarding stale selected thread bundle", {
-          thread_id: threadId,
-          refresh_id: refreshId,
-        });
-        return null;
-      }
-
-      setSelectedThreadView(bundle.view);
-      setSelectedRequestDetail(selectRequestDetail(bundle));
-      return bundle;
-    } catch (error) {
-      if (selectedThreadRefreshIdRef.current === refreshId) {
-        logLiveChatDebug("chat-refresh", "failed to load selected thread bundle", {
-          thread_id: threadId,
-          refresh_id: refreshId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        setErrorMessage(
-          error instanceof Error ? error.message : "Failed to load the selected thread.",
-        );
-      }
-      return null;
-    } finally {
-      if (selectedThreadRefreshIdRef.current === refreshId) {
-        setIsLoadingThread(false);
-      }
-    }
-  }
-
   async function refreshSelectedThreadAndList(threadId: string) {
-    await Promise.all([refreshSelectedThread(threadId), refreshThreads(threadId)]);
+    await Promise.all([refreshSelectedThreadBundle(threadId), refreshThreads(threadId)]);
   }
 
   useEffect(() => {
@@ -330,11 +287,6 @@ export function ChatPageClient() {
       thread_id: selectedThreadId,
     });
     if (!selectedThreadId) {
-      logLiveChatDebug("chat-stream", "selected thread cleared", {
-        previous_thread_id: selectedThreadView?.thread.thread_id ?? null,
-      });
-      setSelectedThreadView(null);
-      setSelectedRequestDetail(null);
       setStreamEvents([]);
       streamEventsRef.current = [];
       setDraftAssistantMessages({});
@@ -343,14 +295,9 @@ export function ChatPageClient() {
       return;
     }
 
-    logLiveChatDebug("chat-stream", "selected thread changed", {
-      thread_id: selectedThreadId,
-      previous_thread_id: selectedThreadView?.thread.thread_id ?? null,
-    });
     setStreamEvents([]);
     streamEventsRef.current = [];
     setDraftAssistantMessages({});
-    void refreshSelectedThread(selectedThreadId);
   }, [selectedThreadId]);
 
   useEffect(() => {
@@ -617,8 +564,6 @@ export function ChatPageClient() {
     updateSelectedThreadId(null, "user_select_workspace", {
       workspace_id: nextWorkspaceId,
     });
-    setSelectedThreadView(null);
-    setSelectedRequestDetail(null);
     setStreamEvents([]);
     streamEventsRef.current = [];
     setDraftAssistantMessages({});

--- a/apps/frontend-bff/src/use-selected-thread-bundle.ts
+++ b/apps/frontend-bff/src/use-selected-thread-bundle.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { loadChatThreadBundle } from "./chat-data";
+import { logLiveChatDebug } from "./debug";
+import type { PublicRequestDetail, PublicThreadView } from "./thread-types";
+
+type SelectedThreadBundle = Awaited<ReturnType<typeof loadChatThreadBundle>>;
+
+function selectRequestDetail(bundle: {
+  latestResolvedRequestDetail?: PublicRequestDetail | null;
+  pendingRequestDetail: PublicRequestDetail | null;
+}) {
+  return bundle.pendingRequestDetail ?? bundle.latestResolvedRequestDetail ?? null;
+}
+
+interface UseSelectedThreadBundleOptions {
+  selectedThreadId: string | null;
+  onLoadStart?: () => void;
+  onLoadError?: (message: string) => void;
+}
+
+export function useSelectedThreadBundle({
+  selectedThreadId,
+  onLoadStart,
+  onLoadError,
+}: UseSelectedThreadBundleOptions) {
+  const [selectedThreadView, setSelectedThreadView] = useState<PublicThreadView | null>(null);
+  const [selectedRequestDetail, setSelectedRequestDetail] = useState<PublicRequestDetail | null>(
+    null,
+  );
+  const [isLoadingThread, setIsLoadingThread] = useState(false);
+  const selectedThreadRefreshIdRef = useRef(0);
+
+  function clearSelectedThreadBundle() {
+    selectedThreadRefreshIdRef.current += 1;
+    setSelectedThreadView(null);
+    setSelectedRequestDetail(null);
+    setIsLoadingThread(false);
+  }
+
+  async function refreshSelectedThreadBundle(threadId: string | null = selectedThreadId) {
+    if (!threadId) {
+      clearSelectedThreadBundle();
+      return null;
+    }
+
+    const refreshId = selectedThreadRefreshIdRef.current + 1;
+    selectedThreadRefreshIdRef.current = refreshId;
+    setIsLoadingThread(true);
+    onLoadStart?.();
+    logLiveChatDebug("chat-refresh", "refreshing selected thread bundle", {
+      thread_id: threadId,
+      refresh_id: refreshId,
+    });
+
+    try {
+      const bundle = await loadChatThreadBundle(threadId);
+      if (selectedThreadRefreshIdRef.current !== refreshId) {
+        logLiveChatDebug("chat-refresh", "discarding stale selected thread bundle", {
+          thread_id: threadId,
+          refresh_id: refreshId,
+        });
+        return null;
+      }
+
+      setSelectedThreadView(bundle.view);
+      setSelectedRequestDetail(selectRequestDetail(bundle));
+      return bundle satisfies SelectedThreadBundle;
+    } catch (error) {
+      if (selectedThreadRefreshIdRef.current === refreshId) {
+        logLiveChatDebug("chat-refresh", "failed to load selected thread bundle", {
+          thread_id: threadId,
+          refresh_id: refreshId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        onLoadError?.(
+          error instanceof Error ? error.message : "Failed to load the selected thread.",
+        );
+      }
+      return null;
+    } finally {
+      if (selectedThreadRefreshIdRef.current === refreshId) {
+        setIsLoadingThread(false);
+      }
+    }
+  }
+
+  useEffect(() => {
+    logLiveChatDebug("chat-stream", "selectedThreadId effect fired", {
+      thread_id: selectedThreadId,
+    });
+
+    if (!selectedThreadId) {
+      logLiveChatDebug("chat-stream", "selected thread cleared", {
+        previous_thread_id: selectedThreadView?.thread.thread_id ?? null,
+      });
+      clearSelectedThreadBundle();
+      return;
+    }
+
+    logLiveChatDebug("chat-stream", "selected thread changed", {
+      thread_id: selectedThreadId,
+      previous_thread_id: selectedThreadView?.thread.thread_id ?? null,
+    });
+    void refreshSelectedThreadBundle(selectedThreadId);
+  }, [selectedThreadId]);
+
+  return {
+    isLoadingThread,
+    selectedRequestDetail,
+    selectedThreadView,
+    clearSelectedThreadBundle,
+    refreshSelectedThreadBundle,
+  };
+}

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -230,6 +230,12 @@ function createDeferred<T>() {
   };
 }
 
+function expectSelectedThreadTitle(title: string) {
+  const selectedThreadButton = document.querySelector('button[aria-current="page"]');
+  expect(selectedThreadButton).not.toBeNull();
+  expect(selectedThreadButton?.textContent).toContain(title);
+}
+
 async function flushUi() {
   await act(async () => {
     await Promise.resolve();
@@ -397,7 +403,7 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     expect(container.textContent).toContain("Investigate build");
-    expect(container.textContent).toContain("Selected");
+    expectSelectedThreadTitle("Investigate build");
     expect(container.textContent).toContain("Waiting for your input");
     expect(MockEventSource.instances[0]?.url).toBe("/api/v1/threads/thread_001/stream");
 
@@ -526,6 +532,100 @@ describe("ChatPageClient", () => {
       "Start workspace-scoped work.",
       expect.stringMatching(/^input_start_/),
     );
+  });
+
+  it("does not restore stale thread view or request detail after Ask Codex clears a pending selected thread load", async () => {
+    const pendingThread = createDeferred<{
+      view: PublicThreadView;
+      pendingRequestDetail: PublicRequestDetail | null;
+    }>();
+
+    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
+      items: [
+        buildThreadListItem({
+          title: "Navigation thread",
+          current_activity: {
+            kind: "running",
+            label: "Running",
+          },
+        }),
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+    chatDataMocks.loadChatThreadBundle.mockReturnValue(pendingThread.promise);
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("Opening thread");
+    expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(1);
+
+    const askCodexButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Ask Codex",
+    );
+    expect(askCodexButton).not.toBeUndefined();
+
+    await act(async () => {
+      askCodexButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushUi();
+
+    expect(window.location.search).toBe("?workspaceId=ws_alpha");
+    expect(container.textContent).toContain("Ask Codex in alpha");
+    expect(container.textContent).toContain("Ready for workspace input");
+    expect(container.textContent).not.toContain("Opening thread");
+
+    await act(async () => {
+      pendingThread.resolve({
+        view: buildThreadView({
+          thread: {
+            thread_id: "thread_001",
+            workspace_id: "ws_alpha",
+            title: "Delayed selected thread",
+            native_status: {
+              thread_status: "waiting_input",
+              active_flags: [],
+              latest_turn_status: null,
+            },
+            updated_at: "2026-03-27T05:26:00Z",
+          },
+          current_activity: {
+            kind: "waiting_on_approval",
+            label: "Approval required",
+          },
+          pending_request: {
+            request_id: "req_001",
+            thread_id: "thread_001",
+            turn_id: "turn_001",
+            item_id: "item_001",
+            request_kind: "approval",
+            status: "pending",
+            risk_category: "external_side_effect",
+            summary: "Run git push",
+            requested_at: "2026-03-27T05:25:00Z",
+          },
+          composer: {
+            accepting_user_input: false,
+            interrupt_available: true,
+            blocked_by_request: true,
+            input_unavailable_reason: null,
+          },
+        }),
+        pendingRequestDetail: buildPendingRequestDetail(),
+      });
+    });
+    await flushUi();
+
+    expect(container.textContent).toContain("Ask Codex in alpha");
+    expect(container.textContent).toContain("Ready for workspace input");
+    expect(container.textContent).not.toContain("Delayed selected thread");
+    expect(container.textContent).not.toContain("Approval required");
+    expect(container.textContent).not.toContain("Approve request");
+    expect(container.textContent).not.toContain("Deny request");
+    expect(document.querySelector('button[aria-current="page"]')).toBeNull();
   });
 
   it("selects an existing thread from first-input mode and keeps the same composer on follow-up path", async () => {
@@ -1488,7 +1588,7 @@ describe("ChatPageClient", () => {
     expect(chatDataMocks.listWorkspaceThreads).toHaveBeenCalledTimes(2);
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Investigate build");
-    expect(container.textContent).toContain("Selected");
+    expectSelectedThreadTitle("Investigate build");
     expect(container.textContent).toContain("High-priority background thread needs attention.");
     expect(container.textContent).toContain("Background thread needs attention");
     expect(container.textContent).toContain("Reason: Needs response");

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-250-chat-page-hooks](./archive/issue-250-chat-page-hooks/README.md)
 - [issue-249-bff-route-boilerplate](./archive/issue-249-bff-route-boilerplate/README.md)
 - [issue-248-bff-mapping-boundaries](./archive/issue-248-bff-mapping-boundaries/README.md)
 - [issue-247-bff-type-boundaries](./archive/issue-247-bff-type-boundaries/README.md)

--- a/tasks/archive/issue-250-chat-page-hooks/README.md
+++ b/tasks/archive/issue-250-chat-page-hooks/README.md
@@ -1,0 +1,81 @@
+# issue-250-chat-page-hooks
+
+## Purpose
+
+Extract state/effect orchestration from `apps/frontend-bff/src/chat-page-client.tsx` into focused hooks while keeping the rendered chat experience unchanged.
+
+## Primary issue
+
+- GitHub Issue: #250
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Extract a bounded subset of chat page state/effect logic into named hooks.
+- Keep visual JSX behavior unchanged.
+- Preserve chat-page-client tests or update focused tests only when the extracted behavior needs clearer coverage.
+
+## Exit criteria
+
+- Render logic is smaller and selected state transitions live in named hooks.
+- Existing chat-page-client coverage remains meaningful and passes, or any baseline drift is explicitly resolved in this Issue.
+- BFF check, TypeScript, focused tests, build, evaluator, and pre-push validation pass.
+
+## Work plan
+
+1. Map current state/effect clusters in `chat-page-client.tsx`.
+2. Let the sprint planner choose a small hook-extraction slice.
+3. Implement the approved hook extraction from this worktree.
+4. Run focused UI validation and evaluator review.
+5. Run dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Sprint planner selected a narrow selected-thread bundle hook extraction.
+- Worker extracted `useSelectedThreadBundle` into `apps/frontend-bff/src/use-selected-thread-bundle.ts` and wired `apps/frontend-bff/src/chat-page-client.tsx` to consume it.
+- Worker repaired two stale `Selected` assertions by checking `button[aria-current="page"]` selection state instead of visible copy.
+- First evaluator verdict: changes required. Clearing selection did not invalidate an in-flight selected-thread bundle refresh.
+- Follow-up worker fix advanced the selected-thread refresh generation during clear and added a regression test for clearing via Ask Codex while an initial selected-thread bundle load is pending.
+- Final evaluator verdict: approved.
+- Validation evidence before pre-push:
+  - `cd apps/frontend-bff && npm run check`: pass.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: pass.
+  - `cd apps/frontend-bff && npm test -- --run tests/chat-page-client.test.tsx`: pass, 19 tests.
+  - `cd apps/frontend-bff && npm test`: pass, 99 tests across 11 files.
+  - `cd apps/frontend-bff && npm run build`: pass.
+  - `git diff --check`: pass.
+- Dedicated pre-push validation evidence:
+  - `cd apps/frontend-bff && npm run check`: pass.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: pass.
+  - `cd apps/frontend-bff && npm test -- --run tests/chat-page-client.test.tsx`: pass, 19 tests.
+  - `cd apps/frontend-bff && npm test`: pass, 99 tests across 11 files.
+  - `cd apps/frontend-bff && npm run build`: pass.
+  - `rg` checks confirm `useSelectedThreadBundle`, the selected-thread refresh id, and ARIA-based selected-thread assertions are present.
+  - `git diff --check`: pass.
+
+## Status / handoff notes
+
+- Status: locally complete; ready for archive and PR follow-through.
+- Active branch: `issue-250-chat-page-hooks`.
+- Active worktree: `.worktrees/issue-250-chat-page-hooks`.
+- Completion tracking, PR merge, worktree cleanup, Project `Done`, and Issue close remain pending.
+- Completion retrospective:
+  - Completion boundary: package archive before PR publication.
+  - Contract check: selected-thread bundle state/effects now live in `useSelectedThreadBundle`, the page client render/orchestration stayed intact, stale load clearing is covered by regression test, and chat-page/full BFF tests pass.
+  - What worked: the evaluator caught a real stale-clear bug before publish, and the follow-up regression test made the hook boundary safer.
+  - Workflow problems: none beyond the expected multi-pass review cycle for stateful UI extraction.
+  - Improvements to adopt: when extracting hooks around async state, include a clear/unmount stale-response case in the initial acceptance tests.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: publish PR, merge to `main`, remove the worktree, clear Issue execution links, set Project status to `Done`, and close #250.
+
+## Archive conditions
+
+- Sprint evaluator returns `approved`.
+- Dedicated pre-push validation passes.
+- Package evidence and handoff notes are updated.
+- Package is moved to `tasks/archive/issue-250-chat-page-hooks/` before PR completion tracking.


### PR DESCRIPTION
## Summary

- Extracted selected-thread bundle loading/state into `useSelectedThreadBundle`.
- Kept page-level workspace, stream, notification, composer, request, and interrupt orchestration in `ChatPageClient`.
- Repaired stale `Selected` assertions by checking the selected thread via `aria-current`.
- Added regression coverage for clearing selection while a selected-thread bundle load is still pending.
- Archived the #250 task package.

Closes #250

## Validation

- `cd apps/frontend-bff && npm run check`
- `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `cd apps/frontend-bff && npm test -- --run tests/chat-page-client.test.tsx`
- `cd apps/frontend-bff && npm test`
- `cd apps/frontend-bff && npm run build`
- `git diff --check`
