### PR TITLE
Refactor chat view surfaces

### DIFF
--- a/apps/frontend-bff/src/chat-view-composer.tsx
+++ b/apps/frontend-bff/src/chat-view-composer.tsx
@@ -1,0 +1,67 @@
+import type { RefObject } from "react";
+
+export interface ChatViewComposerProps {
+  composerDraft: string;
+  composerGuidance: string | null;
+  composerLabel: string;
+  composerPlaceholder: string;
+  composerSubmitLabel: string;
+  defaultGuidance: string;
+  isComposerDisabled: boolean;
+  isStartingThread: boolean;
+  isTextareaDisabled: boolean;
+  onComposerDraftChange: (value: string) => void;
+  onSubmitComposer: () => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+}
+
+export function ChatViewComposer({
+  composerDraft,
+  composerGuidance,
+  composerLabel,
+  composerPlaceholder,
+  composerSubmitLabel,
+  defaultGuidance,
+  isComposerDisabled,
+  isStartingThread,
+  isTextareaDisabled,
+  onComposerDraftChange,
+  onSubmitComposer,
+  textareaRef,
+}: ChatViewComposerProps) {
+  return (
+    <div className="chat-composer" data-composer-mode={isStartingThread ? "start" : "send"}>
+      <label className="form-label" htmlFor="thread-composer-input">
+        {composerLabel}
+        <textarea
+          className="chat-textarea"
+          disabled={isTextareaDisabled}
+          id="thread-composer-input"
+          name="thread-composer-input"
+          onChange={(event) => onComposerDraftChange(event.target.value)}
+          placeholder={composerPlaceholder}
+          ref={textareaRef}
+          rows={4}
+          value={composerDraft}
+        />
+      </label>
+      {composerGuidance ? (
+        <p className="composer-guidance" role="status">
+          {composerGuidance}
+        </p>
+      ) : (
+        <p className="composer-guidance" role="status">
+          {defaultGuidance}
+        </p>
+      )}
+      <button
+        className="submit-button"
+        disabled={isComposerDisabled}
+        onClick={onSubmitComposer}
+        type="button"
+      >
+        {composerSubmitLabel}
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend-bff/src/chat-view-details.tsx
+++ b/apps/frontend-bff/src/chat-view-details.tsx
@@ -1,0 +1,415 @@
+import type { ReactNode } from "react";
+import type { PublicRequestDetail, PublicThreadView, PublicTimelineItem } from "./thread-types";
+import type { TimelineDisplayGroup } from "./timeline-display-model";
+import type { TimelineItemDetail } from "./timeline-item-detail";
+
+export type ThreadDetailSelection =
+  | { kind: "thread_details" }
+  | { kind: "request_detail" }
+  | { kind: "timeline_item_detail"; timelineItemId: string };
+
+export type ThreadFeedbackAction =
+  | { kind: "refresh"; label: string }
+  | { kind: "focus_composer"; label: string }
+  | { kind: "interrupt"; label: string }
+  | { kind: "approve"; label: string }
+  | { kind: "deny"; label: string }
+  | { kind: "request_detail"; label: string };
+
+export type ThreadFeedbackDescriptor = {
+  badgeTone: "default" | "success" | "warning";
+  isVisible: boolean;
+  title: string;
+  summary: string;
+  actions: ThreadFeedbackAction[];
+};
+
+export interface ChatViewDetailsProps {
+  selection: ThreadDetailSelection;
+  workspaceId: string | null;
+  selectedThreadId: string | null;
+  selectedWorkspaceName: string | null;
+  selectedThreadView: PublicThreadView | null;
+  selectedRequestDetail: PublicRequestDetail | null;
+  selectedTimelineItem: PublicTimelineItem | null;
+  selectedTimelineItemDetail: TimelineItemDetail | null;
+  isOpeningSelectedThread: boolean;
+  connectionState: "idle" | "live" | "reconnecting";
+  composerGuidance: string | null;
+  threadActivitySummary: string;
+  threadFeedback: ThreadFeedbackDescriptor;
+  timelineGroups: TimelineDisplayGroup[];
+  isRespondingToRequest: boolean;
+  formatTimestamp: (value: string | null) => string;
+  formatMachineLabel: (value: string | null | undefined) => string;
+  requestBadgeClass: (request: PublicRequestDetail | null) => string;
+  renderThreadFeedbackAction: (action: ThreadFeedbackAction) => ReactNode;
+  onClose: () => void;
+  onSelectRequestDetail: () => void;
+  onSelectTimelineItemDetail: (timelineItemId: string) => void;
+  onApproveRequest: () => void;
+  onDenyRequest: () => void;
+}
+
+function isCodeLikeFieldLabel(label: string) {
+  return (
+    label === "Request ID" ||
+    label === "Operation" ||
+    label === "Thread" ||
+    label === "Turn" ||
+    label === "Item"
+  );
+}
+
+function detailFieldClass(label: string) {
+  return isCodeLikeFieldLabel(label)
+    ? "request-detail-field request-detail-field-code"
+    : "request-detail-field";
+}
+
+function renderDetailFieldValue(
+  field: { label: string; value: string; href?: string } | { label: string; value: string | null },
+) {
+  const isCodeLike = isCodeLikeFieldLabel(field.label);
+  const content = isCodeLike ? <code className="artifact-inline">{field.value}</code> : field.value;
+
+  if ("href" in field && field.href) {
+    return (
+      <a className="detail-link" href={field.href} rel="noreferrer" target="_blank">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+}
+
+export function ChatViewDetails({
+  selection,
+  workspaceId,
+  selectedThreadId,
+  selectedWorkspaceName,
+  selectedThreadView,
+  selectedRequestDetail,
+  selectedTimelineItem,
+  selectedTimelineItemDetail,
+  isOpeningSelectedThread,
+  connectionState,
+  composerGuidance,
+  threadActivitySummary,
+  threadFeedback,
+  timelineGroups,
+  isRespondingToRequest,
+  formatTimestamp,
+  formatMachineLabel,
+  requestBadgeClass,
+  renderThreadFeedbackAction,
+  onClose,
+  onSelectRequestDetail,
+  onSelectTimelineItemDetail,
+  onApproveRequest,
+  onDenyRequest,
+}: ChatViewDetailsProps) {
+  const artifactRows = timelineGroups.flatMap((group) =>
+    group.rows
+      .filter((row) => row.showDetailButton && row.timelineItemId)
+      .map((row) => ({ ...row, timelineItemId: row.timelineItemId ?? "" })),
+  );
+
+  return (
+    <aside className="chat-panel workspace-card thread-detail-surface">
+      <header>
+        <div className="workspace-meta-row">
+          <p className="eyebrow">Detail</p>
+          <button
+            className="secondary-link action-button compact-button"
+            onClick={onClose}
+            type="button"
+          >
+            Close
+          </button>
+        </div>
+        <h2>
+          {selection.kind === "thread_details"
+            ? "Thread details"
+            : selection.kind === "request_detail"
+              ? "Request detail"
+              : (selectedTimelineItemDetail?.title ?? "Timeline detail")}
+        </h2>
+      </header>
+
+      {selection.kind === "thread_details" ? (
+        <div className="detail-stack">
+          <section className="thread-detail-section detail-text-section">
+            <strong>Overview</strong>
+            <dl className="request-detail-list">
+              <div>
+                <dt>Title</dt>
+                <dd>
+                  {selectedThreadView?.thread.title ??
+                    (workspaceId ? "New workspace input" : "No workspace selected")}
+                </dd>
+              </div>
+              <div className={detailFieldClass("Thread")}>
+                <dt>Thread</dt>
+                <dd>
+                  {selectedThreadView?.thread.thread_id ? (
+                    <code className="artifact-inline">{selectedThreadView.thread.thread_id}</code>
+                  ) : (
+                    "Not started"
+                  )}
+                </dd>
+              </div>
+              <div>
+                <dt>Workspace</dt>
+                <dd>{selectedWorkspaceName ?? workspaceId ?? "Not selected"}</dd>
+              </div>
+              <div>
+                <dt>Updated</dt>
+                <dd>{formatTimestamp(selectedThreadView?.thread.updated_at ?? null)}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="thread-detail-section detail-text-section">
+            <strong>Status</strong>
+            <dl className="request-detail-list">
+              <div>
+                <dt>Current activity</dt>
+                <dd>
+                  {selectedThreadView?.current_activity.label ??
+                    (isOpeningSelectedThread
+                      ? "Opening"
+                      : workspaceId
+                        ? "Ready for first input"
+                        : "Workspace required")}
+                </dd>
+              </div>
+              <div>
+                <dt>Activity summary</dt>
+                <dd>
+                  {workspaceId
+                    ? threadActivitySummary
+                    : "Choose a workspace to enable the composer."}
+                </dd>
+              </div>
+              <div>
+                <dt>Stream</dt>
+                <dd>{connectionState}</dd>
+              </div>
+              <div>
+                <dt>Composer</dt>
+                <dd>
+                  {selectedThreadView?.composer.accepting_user_input
+                    ? "Accepting input"
+                    : composerGuidance}
+                </dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="thread-detail-section detail-text-section">
+            <strong>Next action</strong>
+            <p>{threadFeedback.summary}</p>
+            {threadFeedback.actions.length > 0 ? (
+              <div className="workspace-actions thread-feedback-actions">
+                {threadFeedback.actions.map((action) => renderThreadFeedbackAction(action))}
+              </div>
+            ) : null}
+          </section>
+
+          <section className="thread-detail-section detail-text-section">
+            <strong>Requests</strong>
+            <p>
+              {selectedThreadView?.pending_request
+                ? selectedThreadView.pending_request.summary
+                : selectedThreadView?.latest_resolved_request
+                  ? `Latest resolved request: ${selectedThreadView.latest_resolved_request.decision}`
+                  : "No pending or recently resolved request."}
+            </p>
+            {selectedRequestDetail ? (
+              <button
+                className="secondary-link action-button compact-button"
+                onClick={onSelectRequestDetail}
+                type="button"
+              >
+                Request detail
+              </button>
+            ) : null}
+          </section>
+
+          <section className="thread-detail-section detail-text-section">
+            <strong>Artifacts</strong>
+            {artifactRows.length > 0 ? (
+              <ul className="detail-list">
+                {artifactRows.map((row) => (
+                  <li key={row.id}>
+                    <strong>{row.label}</strong>
+                    <span>{row.content}</span>
+                    <button
+                      className="secondary-link action-button inline-detail-button"
+                      onClick={() => onSelectTimelineItemDetail(row.timelineItemId)}
+                      type="button"
+                    >
+                      {row.detailActionLabel ?? "Inspect details"}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>No extracted artifacts are available for this thread yet.</p>
+            )}
+          </section>
+
+          <details className="detail-debug">
+            <summary>Debug: raw thread view JSON</summary>
+            <pre className="detail-json">
+              {JSON.stringify(selectedThreadView ?? { workspaceId, selectedThreadId }, null, 2)}
+            </pre>
+          </details>
+        </div>
+      ) : null}
+
+      {selection.kind === "request_detail" && selectedRequestDetail ? (
+        <div className="detail-stack">
+          <div className="workspace-meta-row">
+            <span className={requestBadgeClass(selectedRequestDetail)}>
+              {selectedRequestDetail.status}
+            </span>
+            <span className="status-badge">
+              {formatMachineLabel(selectedRequestDetail.risk_category)}
+            </span>
+          </div>
+          <p>{selectedRequestDetail.summary}</p>
+          <dl className="request-detail-list">
+            <div>
+              <dt>Reason</dt>
+              <dd>{selectedRequestDetail.reason}</dd>
+            </div>
+            {selectedRequestDetail.operation_summary ? (
+              <div className={detailFieldClass("Operation")}>
+                <dt>Operation</dt>
+                <dd>
+                  <code className="artifact-inline">{selectedRequestDetail.operation_summary}</code>
+                </dd>
+              </div>
+            ) : null}
+            <div>
+              <dt>Requested</dt>
+              <dd>{formatTimestamp(selectedRequestDetail.requested_at)}</dd>
+            </div>
+            <div className={`request-context-field ${detailFieldClass("Thread")}`}>
+              <dt>Thread</dt>
+              <dd>
+                <code className="artifact-inline">{selectedRequestDetail.thread_id}</code>
+              </dd>
+            </div>
+            <div className={`request-context-field ${detailFieldClass("Turn")}`}>
+              <dt>Turn</dt>
+              <dd>
+                {selectedRequestDetail.turn_id ? (
+                  <code className="artifact-inline">{selectedRequestDetail.turn_id}</code>
+                ) : (
+                  "Not available"
+                )}
+              </dd>
+            </div>
+            <div className={`request-context-field ${detailFieldClass("Item")}`}>
+              <dt>Item</dt>
+              <dd>
+                <code className="artifact-inline">{selectedRequestDetail.item_id}</code>
+              </dd>
+            </div>
+            {selectedRequestDetail.decision ? (
+              <div>
+                <dt>Decision</dt>
+                <dd>{selectedRequestDetail.decision}</dd>
+              </div>
+            ) : null}
+            {selectedRequestDetail.responded_at ? (
+              <div>
+                <dt>Responded</dt>
+                <dd>{formatTimestamp(selectedRequestDetail.responded_at)}</dd>
+              </div>
+            ) : null}
+          </dl>
+          {selectedRequestDetail.operation_summary ? (
+            <p className="request-operation-summary">
+              Operation:{" "}
+              <code className="artifact-inline">{selectedRequestDetail.operation_summary}</code>
+            </p>
+          ) : null}
+          {selectedRequestDetail.status === "pending" ? (
+            <div className="workspace-actions request-detail-actions">
+              <button
+                className="approve-button action-button compact-button"
+                disabled={isRespondingToRequest}
+                onClick={onApproveRequest}
+                type="button"
+              >
+                {isRespondingToRequest ? "Submitting..." : "Approve request"}
+              </button>
+              <button
+                className="danger-button action-button compact-button"
+                disabled={isRespondingToRequest}
+                onClick={onDenyRequest}
+                type="button"
+              >
+                Deny request
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {selection.kind === "timeline_item_detail" &&
+      selectedTimelineItem &&
+      selectedTimelineItemDetail ? (
+        <div className="detail-stack">
+          <p className="workspace-meta">
+            {selectedTimelineItem.kind} at {formatTimestamp(selectedTimelineItem.occurred_at)}
+          </p>
+          <p>{selectedTimelineItemDetail.summary}</p>
+          {selectedTimelineItemDetail.sections.map((section) => (
+            <div
+              className={
+                section.code
+                  ? "request-operation-summary detail-artifact-section"
+                  : "request-operation-summary detail-text-section"
+              }
+              key={section.title}
+            >
+              <strong>{section.title}</strong>
+              <ul className={section.code ? "detail-list detail-artifact-list" : "detail-list"}>
+                {section.items.map((entry) => (
+                  <li key={entry}>
+                    {section.code ? <code className="artifact-inline">{entry}</code> : entry}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+          {selectedTimelineItemDetail.fields.length > 0 ? (
+            <dl className="request-detail-list">
+              {selectedTimelineItemDetail.fields.map((field) => (
+                <div
+                  className={detailFieldClass(field.label)}
+                  key={`${field.label}:${field.value}`}
+                >
+                  <dt>{field.label}</dt>
+                  <dd>{renderDetailFieldValue(field)}</dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+          <details className="detail-debug">
+            <summary>Debug: raw timeline payload JSON</summary>
+            <pre className="detail-json">
+              {JSON.stringify(selectedTimelineItem.payload, null, 2)}
+            </pre>
+          </details>
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/frontend-bff/src/chat-view-navigation.tsx
+++ b/apps/frontend-bff/src/chat-view-navigation.tsx
@@ -1,0 +1,537 @@
+import { useEffect, useState } from "react";
+
+import type { PublicWorkspaceSummary } from "./chat-data";
+import type { PublicThreadListItem } from "./thread-types";
+
+type ThreadFilterId = "all" | "active" | "waiting_approval" | "errors_failed" | "recent";
+export type SidebarMode = "full" | "mini";
+
+const SIDEBAR_MODE_STORAGE_KEY = "codex-webui.sidebar-mode";
+
+function isActiveThread(thread: PublicThreadListItem) {
+  return thread.current_activity.kind === "running";
+}
+
+function isWaitingApprovalThread(thread: PublicThreadListItem) {
+  return (
+    thread.current_activity.kind === "waiting_on_approval" ||
+    thread.blocked_cue?.kind === "approval_required" ||
+    thread.badge?.kind === "approval"
+  );
+}
+
+function isErrorOrFailedThread(thread: PublicThreadListItem) {
+  return (
+    thread.current_activity.kind === "system_error" ||
+    thread.current_activity.kind === "latest_turn_failed" ||
+    thread.native_status.latest_turn_status === "failed"
+  );
+}
+
+function isRecentThread(thread: PublicThreadListItem) {
+  return (
+    !isActiveThread(thread) && !isWaitingApprovalThread(thread) && !isErrorOrFailedThread(thread)
+  );
+}
+
+function filterThreads(threads: PublicThreadListItem[], filterId: ThreadFilterId) {
+  switch (filterId) {
+    case "active":
+      return threads.filter(isActiveThread);
+    case "waiting_approval":
+      return threads.filter(isWaitingApprovalThread);
+    case "errors_failed":
+      return threads.filter(isErrorOrFailedThread);
+    case "recent":
+      return threads.filter(isRecentThread);
+    default:
+      return threads;
+  }
+}
+
+function threadCueLabel(thread: PublicThreadListItem) {
+  return thread.blocked_cue?.label ?? thread.resume_cue?.label ?? thread.badge?.label ?? null;
+}
+
+function threadBadgeClass(thread: PublicThreadListItem) {
+  if (thread.resume_cue?.priority_band === "highest" || thread.blocked_cue) {
+    return "status-badge warning";
+  }
+
+  if (thread.current_activity.kind === "running") {
+    return "status-badge success";
+  }
+
+  return "status-badge";
+}
+
+function threadStatusSymbol(thread: PublicThreadListItem) {
+  if (isWaitingApprovalThread(thread)) {
+    return "!";
+  }
+
+  if (isErrorOrFailedThread(thread)) {
+    return "x";
+  }
+
+  if (isActiveThread(thread)) {
+    return ">";
+  }
+
+  return ".";
+}
+
+function threadStatusLabel(thread: PublicThreadListItem) {
+  if (isWaitingApprovalThread(thread)) {
+    return "Waiting approval";
+  }
+
+  if (isErrorOrFailedThread(thread)) {
+    return "Needs review";
+  }
+
+  if (isActiveThread(thread)) {
+    return "Running";
+  }
+
+  return "Idle";
+}
+
+function compactWorkspaceLabel(value: string | null | undefined) {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return "--";
+  }
+
+  const initials = normalized
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("");
+
+  return (initials || normalized.slice(0, 2)).toUpperCase();
+}
+
+export function readStoredSidebarMode() {
+  try {
+    const storage = window.localStorage;
+    if (typeof storage.getItem !== "function") {
+      return null;
+    }
+
+    const storedMode = storage.getItem(SIDEBAR_MODE_STORAGE_KEY);
+    return storedMode === "full" || storedMode === "mini" ? storedMode : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredSidebarMode(nextMode: SidebarMode) {
+  try {
+    const storage = window.localStorage;
+    if (typeof storage.setItem === "function") {
+      storage.setItem(SIDEBAR_MODE_STORAGE_KEY, nextMode);
+    }
+  } catch {
+    // Sidebar preference should never block Navigation controls.
+  }
+}
+
+function workspaceSummary(
+  workspace: PublicWorkspaceSummary,
+  {
+    formatMachineLabel,
+    formatTimestamp,
+  }: {
+    formatMachineLabel: (value: string | null | undefined) => string;
+    formatTimestamp: (value: string | null) => string;
+  },
+) {
+  if (workspace.pending_approval_count > 0) {
+    return `${workspace.pending_approval_count} approval${
+      workspace.pending_approval_count === 1 ? "" : "s"
+    }`;
+  }
+
+  if (workspace.active_session_summary) {
+    return `${formatMachineLabel(workspace.active_session_summary.status)} activity`;
+  }
+
+  return `Updated ${formatTimestamp(workspace.updated_at)}`;
+}
+
+export interface ChatViewNavigationProps {
+  workspaceId: string | null;
+  workspaces: PublicWorkspaceSummary[];
+  threads: PublicThreadListItem[];
+  backgroundPriorityNotice: {
+    threadId: string;
+    reason: string;
+  } | null;
+  selectedThreadId: string | null;
+  workspaceName: string;
+  isLoadingThreads: boolean;
+  isLoadingWorkspaces: boolean;
+  isCreatingWorkspace: boolean;
+  isNavigationOpen: boolean;
+  sidebarMode: SidebarMode;
+  formatTimestamp: (value: string | null) => string;
+  formatMachineLabel: (value: string | null | undefined) => string;
+  onWorkspaceNameChange: (value: string) => void;
+  onCreateWorkspace: () => void;
+  onSelectWorkspace: (workspaceId: string) => void;
+  onSelectThread: (threadId: string) => void;
+  onAskCodex: () => void;
+  onOpenBackgroundPriorityThread: (threadId: string) => void;
+  onSidebarModeChange: (mode: SidebarMode) => void;
+}
+
+export function ChatViewNavigation({
+  workspaceId,
+  workspaces,
+  threads,
+  backgroundPriorityNotice,
+  selectedThreadId,
+  workspaceName,
+  isLoadingThreads,
+  isLoadingWorkspaces,
+  isCreatingWorkspace,
+  isNavigationOpen,
+  sidebarMode,
+  formatTimestamp,
+  formatMachineLabel,
+  onWorkspaceNameChange,
+  onCreateWorkspace,
+  onSelectWorkspace,
+  onSelectThread,
+  onAskCodex,
+  onOpenBackgroundPriorityThread,
+  onSidebarModeChange,
+}: ChatViewNavigationProps) {
+  const [selectedFilterId, setSelectedFilterId] = useState<ThreadFilterId>("all");
+  const selectedWorkspace =
+    workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
+  const selectedThreadSummary =
+    threads.find((thread) => thread.thread_id === selectedThreadId) ?? null;
+  const visibleThreads = filterThreads(threads, selectedFilterId);
+  const attentionThreads = threads.filter(
+    (thread) =>
+      isWaitingApprovalThread(thread) ||
+      isErrorOrFailedThread(thread) ||
+      backgroundPriorityNotice?.threadId === thread.thread_id,
+  );
+  const threadFilters: Array<{ id: ThreadFilterId; label: string; count: number }> = [
+    { id: "all", label: "All", count: threads.length },
+    { id: "active", label: "Active", count: threads.filter(isActiveThread).length },
+    {
+      id: "waiting_approval",
+      label: "Waiting approval",
+      count: threads.filter(isWaitingApprovalThread).length,
+    },
+    {
+      id: "errors_failed",
+      label: "Errors / Failed",
+      count: threads.filter(isErrorOrFailedThread).length,
+    },
+    { id: "recent", label: "Recent", count: threads.filter(isRecentThread).length },
+  ];
+  const hasSelectedThread = selectedThreadId !== null;
+  const isSidebarMinibar = sidebarMode === "mini" && !isNavigationOpen;
+
+  useEffect(() => {
+    setSelectedFilterId("all");
+  }, [workspaceId]);
+
+  return (
+    <>
+      {backgroundPriorityNotice ? (
+        <section aria-live="polite" className="background-priority-notice" role="status">
+          <div className="workspace-meta-row">
+            <strong>Background thread needs attention</strong>
+            <span className="status-badge warning">High priority</span>
+          </div>
+          <p>
+            <strong>
+              <code className="artifact-inline">{backgroundPriorityNotice.threadId}</code>
+            </strong>
+            {" needs attention now."}
+          </p>
+          <p className="workspace-meta">Reason: {backgroundPriorityNotice.reason}</p>
+          <div className="workspace-actions">
+            <button
+              className="primary-link action-button compact-button"
+              onClick={() => onOpenBackgroundPriorityThread(backgroundPriorityNotice.threadId)}
+              type="button"
+            >
+              Open thread
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      <section
+        aria-label="Navigation"
+        className={[
+          "chat-panel create-card thread-navigation",
+          isNavigationOpen ? "open" : "",
+          isSidebarMinibar ? "minibar" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {isSidebarMinibar ? (
+          <div className="navigation-minibar-stack">
+            <button
+              aria-label="Expand Navigation"
+              className="secondary-link action-button minibar-button"
+              onClick={() => onSidebarModeChange("full")}
+              title="Expand Navigation"
+              type="button"
+            >
+              Nav
+            </button>
+            {workspaceId ? (
+              <button
+                aria-label={`Start new thread in ${selectedWorkspace?.workspace_name ?? workspaceId}`}
+                className="primary-link action-button minibar-button"
+                onClick={onAskCodex}
+                title="Ask Codex"
+                type="button"
+              >
+                New
+              </button>
+            ) : null}
+            <button
+              aria-label={`Current workspace: ${
+                selectedWorkspace?.workspace_name ?? workspaceId ?? "none"
+              }`}
+              className="secondary-link action-button minibar-button"
+              onClick={() => onSidebarModeChange("full")}
+              title={selectedWorkspace?.workspace_name ?? workspaceId ?? "Select workspace"}
+              type="button"
+            >
+              {compactWorkspaceLabel(selectedWorkspace?.workspace_name ?? workspaceId)}
+            </button>
+            {selectedThreadSummary ? (
+              <button
+                aria-current="page"
+                aria-label={`Current thread: ${selectedThreadSummary.title}`}
+                className="secondary-link action-button minibar-button active"
+                onClick={() => onSelectThread(selectedThreadSummary.thread_id)}
+                title={selectedThreadSummary.title}
+                type="button"
+              >
+                {threadStatusSymbol(selectedThreadSummary)}
+              </button>
+            ) : null}
+            {attentionThreads
+              .filter((thread) => thread.thread_id !== selectedThreadId)
+              .slice(0, 4)
+              .map((thread) => (
+                <button
+                  aria-label={`${threadStatusLabel(thread)}: ${thread.title}`}
+                  className="secondary-link action-button minibar-button attention"
+                  key={thread.thread_id}
+                  onClick={() => onSelectThread(thread.thread_id)}
+                  title={thread.title}
+                  type="button"
+                >
+                  {threadStatusSymbol(thread)}
+                </button>
+              ))}
+          </div>
+        ) : (
+          <>
+            <header>
+              <div className="workspace-meta-row navigation-header-row">
+                <h2>{selectedWorkspace?.workspace_name ?? "Select workspace"}</h2>
+                <button
+                  aria-label="Collapse Navigation to minibar"
+                  className="secondary-link action-button compact-button sidebar-mode-toggle"
+                  onClick={() => onSidebarModeChange("mini")}
+                  type="button"
+                >
+                  Minimize
+                </button>
+              </div>
+              <p className="workspace-meta">
+                {workspaceId ? "Workspace scope active" : "Choose or create a workspace."}
+              </p>
+            </header>
+
+            {workspaceId ? (
+              <button
+                className={
+                  hasSelectedThread
+                    ? "primary-link action-button navigation-ask-codex"
+                    : "secondary-link action-button navigation-ask-codex"
+                }
+                onClick={onAskCodex}
+                type="button"
+              >
+                Ask Codex
+              </button>
+            ) : null}
+
+            <details className="workspace-switcher">
+              <summary>Switch workspace</summary>
+              <div className="workspace-switcher-control">
+                {isLoadingWorkspaces ? (
+                  <p className="workspace-status">Loading workspaces...</p>
+                ) : null}
+                {workspaces.length > 0 ? (
+                  <div className="workspace-option-list">
+                    {workspaces.map((workspace) => (
+                      <button
+                        className={
+                          workspace.workspace_id === workspaceId
+                            ? "workspace-option-card active"
+                            : "workspace-option-card"
+                        }
+                        key={workspace.workspace_id}
+                        onClick={() => onSelectWorkspace(workspace.workspace_id)}
+                        type="button"
+                      >
+                        <strong>{workspace.workspace_name}</strong>
+                        <span className="workspace-meta">{workspace.workspace_id}</span>
+                        <span className="workspace-meta">
+                          {workspaceSummary(workspace, {
+                            formatMachineLabel,
+                            formatTimestamp,
+                          })}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                ) : !isLoadingWorkspaces ? (
+                  <p className="empty-state">Create a workspace to start scoped work.</p>
+                ) : null}
+
+                <div className="create-form workspace-create-form">
+                  <label className="form-label" htmlFor="workspace-name">
+                    New workspace
+                    <input
+                      id="workspace-name"
+                      name="workspace-name"
+                      onChange={(event) => onWorkspaceNameChange(event.target.value)}
+                      placeholder="Workspace name"
+                      value={workspaceName}
+                    />
+                  </label>
+                  <button
+                    className="submit-button"
+                    disabled={isCreatingWorkspace || workspaceName.trim().length === 0}
+                    onClick={onCreateWorkspace}
+                    type="button"
+                  >
+                    {isCreatingWorkspace ? "Creating..." : "Create workspace"}
+                  </button>
+                </div>
+              </div>
+            </details>
+
+            <div className="thread-list">
+              {isLoadingThreads ? <p className="workspace-status">Loading threads...</p> : null}
+
+              {!workspaceId && !isLoadingWorkspaces ? (
+                <p className="empty-state">Select a workspace to show its threads.</p>
+              ) : null}
+
+              {workspaceId && !isLoadingThreads && threads.length === 0 ? (
+                <p className="empty-state">No threads yet. Use Ask Codex in Thread View.</p>
+              ) : null}
+
+              {workspaceId && threads.length > 0 ? (
+                <div aria-label="Thread filters" className="thread-filter-bar" role="tablist">
+                  {threadFilters.map((filter) => (
+                    <button
+                      aria-selected={selectedFilterId === filter.id}
+                      className={
+                        selectedFilterId === filter.id
+                          ? "thread-filter-chip active"
+                          : "thread-filter-chip"
+                      }
+                      key={filter.id}
+                      onClick={() => setSelectedFilterId(filter.id)}
+                      role="tab"
+                      type="button"
+                    >
+                      <span>{filter.label}</span>
+                      <span className="thread-filter-count">{filter.count}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
+              {workspaceId &&
+              !isLoadingThreads &&
+              threads.length > 0 &&
+              visibleThreads.length === 0 ? (
+                <p className="empty-state">No threads match this filter.</p>
+              ) : null}
+
+              {visibleThreads.map((thread) => {
+                const isSelected = selectedThreadId === thread.thread_id;
+                const rowCueLabel = threadCueLabel(thread);
+                const hasBackgroundNotice =
+                  backgroundPriorityNotice?.threadId === thread.thread_id && !isSelected;
+                const isAttention = rowCueLabel !== null || hasBackgroundNotice;
+
+                return (
+                  <button
+                    aria-current={isSelected ? "page" : undefined}
+                    className={isSelected ? "thread-summary-card active" : "thread-summary-card"}
+                    key={thread.thread_id}
+                    onClick={() => onSelectThread(thread.thread_id)}
+                    type="button"
+                  >
+                    <div className="workspace-meta-row thread-summary-header">
+                      <span
+                        aria-label={threadStatusLabel(thread)}
+                        className={threadBadgeClass(thread).replace(
+                          "status-badge",
+                          "thread-status-mark",
+                        )}
+                        role="img"
+                        title={threadStatusLabel(thread)}
+                      >
+                        {threadStatusSymbol(thread)}
+                      </span>
+                      <div className="thread-summary-title-block">
+                        <strong>{thread.title}</strong>
+                        <span className="workspace-meta">
+                          Updated {formatTimestamp(thread.updated_at)}
+                        </span>
+                      </div>
+                    </div>
+                    {isAttention ? (
+                      <div className="thread-summary-cues">
+                        {rowCueLabel ? (
+                          <span className="status-badge">{formatMachineLabel(rowCueLabel)}</span>
+                        ) : null}
+                        {hasBackgroundNotice ? (
+                          <span className="status-badge warning">Needs attention now</span>
+                        ) : null}
+                        {thread.badge && rowCueLabel !== thread.badge.label ? (
+                          <span className="status-badge">
+                            {formatMachineLabel(thread.badge.label)}
+                          </span>
+                        ) : null}
+                      </div>
+                    ) : null}
+                    {hasBackgroundNotice ? (
+                      <p className="thread-summary-notice">
+                        Background notice: {backgroundPriorityNotice?.reason}
+                      </p>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </section>
+    </>
+  );
+}

--- a/apps/frontend-bff/src/chat-view-timeline.tsx
+++ b/apps/frontend-bff/src/chat-view-timeline.tsx
@@ -1,0 +1,136 @@
+import type { TimelineDisplayGroup, TimelineDisplayRow } from "./timeline-display-model";
+
+export interface ChatViewTimelineProps {
+  isLoadingThread: boolean;
+  selectedThreadId: string | null;
+  hasLoadedThreadView: boolean;
+  groups: TimelineDisplayGroup[];
+  expandedRowIds: ReadonlySet<string>;
+  formatTimestamp: (value: string | null) => string;
+  onToggleRowExpansion: (rowId: string) => void;
+  onOpenDetail: (timelineItemId: string) => void;
+}
+
+function timelineRowClass(row: TimelineDisplayRow) {
+  return `timeline-row timeline-row-${row.density} timeline-row-${row.role}`;
+}
+
+const TIMELINE_PREVIEW_LINE_LIMIT = 8;
+const TIMELINE_PREVIEW_CHARACTER_LIMIT = 520;
+
+function timelineContentPreview(content: string) {
+  const lines = content.split(/\r?\n/);
+  const lineFolded = lines.length > TIMELINE_PREVIEW_LINE_LIMIT;
+  const linePreview = lineFolded ? lines.slice(0, TIMELINE_PREVIEW_LINE_LIMIT).join("\n") : content;
+
+  if (linePreview.length <= TIMELINE_PREVIEW_CHARACTER_LIMIT) {
+    return {
+      isFoldable: lineFolded,
+      preview: lineFolded ? `${linePreview.trimEnd()}\n...` : content,
+    };
+  }
+
+  const clipped = linePreview.slice(0, TIMELINE_PREVIEW_CHARACTER_LIMIT);
+  const lastWhitespace = clipped.search(/\s+\S*$/);
+  const preview =
+    lastWhitespace > TIMELINE_PREVIEW_CHARACTER_LIMIT * 0.72
+      ? clipped.slice(0, lastWhitespace)
+      : clipped;
+
+  return {
+    isFoldable: true,
+    preview: `${preview.trimEnd()}...`,
+  };
+}
+
+export function ChatViewTimeline({
+  isLoadingThread,
+  selectedThreadId,
+  hasLoadedThreadView,
+  groups,
+  expandedRowIds,
+  formatTimestamp,
+  onToggleRowExpansion,
+  onOpenDetail,
+}: ChatViewTimelineProps) {
+  return (
+    <section aria-label="Timeline" className="timeline-section">
+      {isLoadingThread ? (
+        <p className="workspace-status">
+          {selectedThreadId
+            ? "Opening this thread and restoring its latest timeline..."
+            : "Preparing thread view..."}
+        </p>
+      ) : null}
+
+      <div className="chat-message-list">
+        {!isLoadingThread && hasLoadedThreadView && groups.length === 0 ? (
+          <p className="empty-state">
+            No timeline items yet. Start the thread or send follow-up input to continue.
+          </p>
+        ) : null}
+
+        {groups.map((group) => (
+          <section
+            className={group.turnId ? "timeline-turn-group" : "timeline-ungrouped-item"}
+            data-turn-id={group.turnId ?? undefined}
+            key={group.id}
+          >
+            {group.turnId ? (
+              <div className="timeline-turn-label">
+                <span>Turn</span>
+                <strong>{group.turnId}</strong>
+              </div>
+            ) : null}
+            {group.rows.map((row) => {
+              const contentPreview = timelineContentPreview(row.content);
+              const isExpanded = expandedRowIds.has(row.id);
+              const displayedContent =
+                contentPreview.isFoldable && !isExpanded ? contentPreview.preview : row.content;
+
+              return (
+                <article
+                  className={`${timelineRowClass(row)}${
+                    contentPreview.isFoldable && !isExpanded ? " timeline-row-folded" : ""
+                  }`}
+                  key={row.id}
+                >
+                  <div className="workspace-meta-row timeline-row-meta">
+                    <strong>{row.label}</strong>
+                    <span className="workspace-meta">
+                      {row.isLive ? "Live" : formatTimestamp(row.occurredAt)}
+                    </span>
+                  </div>
+                  <p className="timeline-row-content">{displayedContent}</p>
+                  {contentPreview.isFoldable || row.showDetailButton ? (
+                    <div className="timeline-row-actions">
+                      {contentPreview.isFoldable ? (
+                        <button
+                          aria-expanded={isExpanded}
+                          className="secondary-link action-button inline-detail-button"
+                          onClick={() => onToggleRowExpansion(row.id)}
+                          type="button"
+                        >
+                          {isExpanded ? "Show less" : "Show more"}
+                        </button>
+                      ) : null}
+                      {row.showDetailButton && row.timelineItemId ? (
+                        <button
+                          className="secondary-link action-button inline-detail-button"
+                          onClick={() => onOpenDetail(row.timelineItemId ?? "")}
+                          type="button"
+                        >
+                          {row.detailActionLabel ?? "Inspect details"}
+                        </button>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })}
+          </section>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -2,13 +2,27 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
 import type { PublicWorkspaceSummary } from "./chat-data";
+import { ChatViewComposer } from "./chat-view-composer";
+import {
+  ChatViewDetails,
+  type ThreadDetailSelection,
+  type ThreadFeedbackAction,
+  type ThreadFeedbackDescriptor,
+} from "./chat-view-details";
+import {
+  ChatViewNavigation,
+  readStoredSidebarMode,
+  type SidebarMode,
+  writeStoredSidebarMode,
+} from "./chat-view-navigation";
+import { ChatViewTimeline } from "./chat-view-timeline";
 import type {
   PublicRequestDetail,
   PublicThreadListItem,
   PublicThreadStreamEvent,
   PublicThreadView,
 } from "./thread-types";
-import { buildTimelineDisplayModel, type TimelineDisplayRow } from "./timeline-display-model";
+import { buildTimelineDisplayModel } from "./timeline-display-model";
 import { getTimelineItemDetail } from "./timeline-item-detail";
 
 export interface ChatViewProps {
@@ -73,18 +87,6 @@ function threadChatHref(workspaceId: string, threadId?: string) {
   return `/chat?${params.toString()}`;
 }
 
-function threadBadgeClass(thread: PublicThreadListItem) {
-  if (thread.resume_cue?.priority_band === "highest" || thread.blocked_cue) {
-    return "status-badge warning";
-  }
-
-  if (thread.current_activity.kind === "running") {
-    return "status-badge success";
-  }
-
-  return "status-badge";
-}
-
 function activityBadgeClass(activityKind: PublicThreadListItem["current_activity"]["kind"] | null) {
   if (activityKind === "waiting_on_approval") {
     return "status-badge warning";
@@ -107,196 +109,6 @@ function requestBadgeClass(request: PublicRequestDetail | null) {
 
 function formatMachineLabel(value: string | null | undefined) {
   return value ? value.replaceAll("_", " ") : "Not available";
-}
-
-function isActiveThread(thread: PublicThreadListItem) {
-  return thread.current_activity.kind === "running";
-}
-
-function isWaitingApprovalThread(thread: PublicThreadListItem) {
-  return (
-    thread.current_activity.kind === "waiting_on_approval" ||
-    thread.blocked_cue?.kind === "approval_required" ||
-    thread.badge?.kind === "approval"
-  );
-}
-
-function isErrorOrFailedThread(thread: PublicThreadListItem) {
-  return (
-    thread.current_activity.kind === "system_error" ||
-    thread.current_activity.kind === "latest_turn_failed" ||
-    thread.native_status.latest_turn_status === "failed"
-  );
-}
-
-function isRecentThread(thread: PublicThreadListItem) {
-  return (
-    !isActiveThread(thread) && !isWaitingApprovalThread(thread) && !isErrorOrFailedThread(thread)
-  );
-}
-
-type ThreadFilterId = "all" | "active" | "waiting_approval" | "errors_failed" | "recent";
-type SidebarMode = "full" | "mini";
-
-const SIDEBAR_MODE_STORAGE_KEY = "codex-webui.sidebar-mode";
-
-function filterThreads(threads: PublicThreadListItem[], filterId: ThreadFilterId) {
-  switch (filterId) {
-    case "active":
-      return threads.filter(isActiveThread);
-    case "waiting_approval":
-      return threads.filter(isWaitingApprovalThread);
-    case "errors_failed":
-      return threads.filter(isErrorOrFailedThread);
-    case "recent":
-      return threads.filter(isRecentThread);
-    default:
-      return threads;
-  }
-}
-
-function threadCueLabel(thread: PublicThreadListItem) {
-  return thread.blocked_cue?.label ?? thread.resume_cue?.label ?? thread.badge?.label ?? null;
-}
-
-function threadStatusSymbol(thread: PublicThreadListItem) {
-  if (isWaitingApprovalThread(thread)) {
-    return "!";
-  }
-
-  if (isErrorOrFailedThread(thread)) {
-    return "x";
-  }
-
-  if (isActiveThread(thread)) {
-    return ">";
-  }
-
-  return ".";
-}
-
-function threadStatusLabel(thread: PublicThreadListItem) {
-  if (isWaitingApprovalThread(thread)) {
-    return "Waiting approval";
-  }
-
-  if (isErrorOrFailedThread(thread)) {
-    return "Needs review";
-  }
-
-  if (isActiveThread(thread)) {
-    return "Running";
-  }
-
-  return "Idle";
-}
-
-function compactName(value: string | null | undefined) {
-  const normalized = value?.trim();
-  if (!normalized) {
-    return "--";
-  }
-
-  const initials = normalized
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((part) => part[0])
-    .join("");
-
-  return (initials || normalized.slice(0, 2)).toUpperCase();
-}
-
-function readStoredSidebarMode() {
-  try {
-    const storage = window.localStorage;
-    if (typeof storage.getItem !== "function") {
-      return null;
-    }
-
-    const storedMode = storage.getItem(SIDEBAR_MODE_STORAGE_KEY);
-    return storedMode === "full" || storedMode === "mini" ? storedMode : null;
-  } catch {
-    return null;
-  }
-}
-
-function writeStoredSidebarMode(nextMode: SidebarMode) {
-  try {
-    const storage = window.localStorage;
-    if (typeof storage.setItem === "function") {
-      storage.setItem(SIDEBAR_MODE_STORAGE_KEY, nextMode);
-    }
-  } catch {
-    // Sidebar preference should never block Navigation controls.
-  }
-}
-
-function workspaceSummary(workspace: PublicWorkspaceSummary) {
-  if (workspace.pending_approval_count > 0) {
-    return `${workspace.pending_approval_count} approval${
-      workspace.pending_approval_count === 1 ? "" : "s"
-    }`;
-  }
-
-  if (workspace.active_session_summary) {
-    return `${formatMachineLabel(workspace.active_session_summary.status)} activity`;
-  }
-
-  return `Updated ${formatTimestamp(workspace.updated_at)}`;
-}
-
-type ThreadDetailSelection =
-  | { kind: "thread_details" }
-  | { kind: "request_detail" }
-  | { kind: "timeline_item_detail"; timelineItemId: string };
-
-type ThreadFeedbackAction =
-  | { kind: "refresh"; label: string }
-  | { kind: "focus_composer"; label: string }
-  | { kind: "interrupt"; label: string }
-  | { kind: "approve"; label: string }
-  | { kind: "deny"; label: string }
-  | { kind: "request_detail"; label: string };
-
-type ThreadFeedbackDescriptor = {
-  badgeTone: "default" | "success" | "warning";
-  isVisible: boolean;
-  title: string;
-  summary: string;
-  actions: ThreadFeedbackAction[];
-};
-
-function timelineRowClass(row: TimelineDisplayRow) {
-  return `timeline-row timeline-row-${row.density} timeline-row-${row.role}`;
-}
-
-const TIMELINE_PREVIEW_LINE_LIMIT = 8;
-const TIMELINE_PREVIEW_CHARACTER_LIMIT = 520;
-
-function timelineContentPreview(content: string) {
-  const lines = content.split(/\r?\n/);
-  const lineFolded = lines.length > TIMELINE_PREVIEW_LINE_LIMIT;
-  const linePreview = lineFolded ? lines.slice(0, TIMELINE_PREVIEW_LINE_LIMIT).join("\n") : content;
-
-  if (linePreview.length <= TIMELINE_PREVIEW_CHARACTER_LIMIT) {
-    return {
-      isFoldable: lineFolded,
-      preview: lineFolded ? `${linePreview.trimEnd()}\n...` : content,
-    };
-  }
-
-  const clipped = linePreview.slice(0, TIMELINE_PREVIEW_CHARACTER_LIMIT);
-  const lastWhitespace = clipped.search(/\s+\S*$/);
-  const preview =
-    lastWhitespace > TIMELINE_PREVIEW_CHARACTER_LIMIT * 0.72
-      ? clipped.slice(0, lastWhitespace)
-      : clipped;
-
-  return {
-    isFoldable: true,
-    preview: `${preview.trimEnd()}...`,
-  };
 }
 
 function composerUnavailableReason(threadView: PublicThreadView | null) {
@@ -361,39 +173,6 @@ function threadFeedbackBadgeClass(descriptor: ThreadFeedbackDescriptor) {
   }
 
   return "status-badge";
-}
-
-function isCodeLikeFieldLabel(label: string) {
-  return (
-    label === "Request ID" ||
-    label === "Operation" ||
-    label === "Thread" ||
-    label === "Turn" ||
-    label === "Item"
-  );
-}
-
-function detailFieldClass(label: string) {
-  return isCodeLikeFieldLabel(label)
-    ? "request-detail-field request-detail-field-code"
-    : "request-detail-field";
-}
-
-function renderDetailFieldValue(
-  field: { label: string; value: string; href?: string } | { label: string; value: string | null },
-) {
-  const isCodeLike = isCodeLikeFieldLabel(field.label);
-  const content = isCodeLike ? <code className="artifact-inline">{field.value}</code> : field.value;
-
-  if ("href" in field && field.href) {
-    return (
-      <a className="detail-link" href={field.href} rel="noreferrer" target="_blank">
-        {content}
-      </a>
-    );
-  }
-
-  return content;
 }
 
 function buildThreadFeedbackDescriptor({
@@ -640,7 +419,6 @@ export function ChatView({
 }: ChatViewProps) {
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
-  const [selectedFilterId, setSelectedFilterId] = useState<ThreadFilterId>("all");
   const [sidebarMode, setSidebarMode] = useState<SidebarMode>("full");
   const [expandedTimelineRows, setExpandedTimelineRows] = useState<Set<string>>(() => new Set());
   const [followLatestActivity, setFollowLatestActivity] = useState(true);
@@ -650,30 +428,6 @@ export function ChatView({
   const latestActivitySignatureRef = useRef<string | null>(null);
   const selectedWorkspace =
     workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
-  const selectedThreadSummary =
-    threads.find((thread) => thread.thread_id === selectedThreadId) ?? null;
-  const visibleThreads = filterThreads(threads, selectedFilterId);
-  const attentionThreads = threads.filter(
-    (thread) =>
-      isWaitingApprovalThread(thread) ||
-      isErrorOrFailedThread(thread) ||
-      backgroundPriorityNotice?.threadId === thread.thread_id,
-  );
-  const threadFilters: Array<{ id: ThreadFilterId; label: string; count: number }> = [
-    { id: "all", label: "All", count: threads.length },
-    { id: "active", label: "Active", count: threads.filter(isActiveThread).length },
-    {
-      id: "waiting_approval",
-      label: "Waiting approval",
-      count: threads.filter(isWaitingApprovalThread).length,
-    },
-    {
-      id: "errors_failed",
-      label: "Errors / Failed",
-      count: threads.filter(isErrorOrFailedThread).length,
-    },
-    { id: "recent", label: "Recent", count: threads.filter(isRecentThread).length },
-  ];
   const hasSelectedThread = selectedThreadId !== null;
   const isOpeningSelectedThread = hasSelectedThread && !selectedThreadView;
   const isStartingThread = !hasSelectedThread;
@@ -704,6 +458,11 @@ export function ChatView({
     : isOpeningSelectedThread
       ? "Opening this thread and restoring its latest context."
       : unavailableReason;
+  const composerDefaultGuidance = isStartingThread
+    ? "First input starts a new thread in this workspace."
+    : "Input will continue the selected thread.";
+  const isComposerTextareaDisabled =
+    !workspaceId || isOpeningSelectedThread || isSubmittingComposer || Boolean(unavailableReason);
   const selectedTimelineItem =
     detailSelection?.kind === "timeline_item_detail"
       ? (selectedThreadView?.timeline.items.find(
@@ -718,10 +477,6 @@ export function ChatView({
     streamEvents,
     draftAssistantMessages,
   });
-  const timelineArtifactCount = timelineModel.groups.reduce(
-    (count, group) => count + group.rows.filter((row) => row.showDetailButton).length,
-    0,
-  );
   const hasRequestDetailAffordance = selectedRequestDetail !== null;
   const latestTimelineGroup = timelineModel.groups[timelineModel.groups.length - 1] ?? null;
   const latestTimelineRow = latestTimelineGroup?.rows[latestTimelineGroup.rows.length - 1] ?? null;
@@ -752,6 +507,9 @@ export function ChatView({
     selectedThreadView,
     workspaceId,
   });
+  const threadActivitySummary = workspaceId
+    ? currentActivitySummary(selectedThreadView, isOpeningSelectedThread)
+    : "Choose a workspace to enable the composer.";
   const isSidebarMinibar = sidebarMode === "mini" && !isNavigationOpen;
 
   useEffect(() => {
@@ -766,10 +524,6 @@ export function ChatView({
     setDetailSelection(null);
     setExpandedTimelineRows(new Set());
   }, [selectedThreadId]);
-
-  useEffect(() => {
-    setSelectedFilterId("all");
-  }, [workspaceId]);
 
   useEffect(() => {
     latestActivitySignatureRef.current = null;
@@ -965,288 +719,28 @@ export function ChatView({
             ) : null}
           </div>
         ) : null}
-        {backgroundPriorityNotice ? (
-          <section aria-live="polite" className="background-priority-notice" role="status">
-            <div className="workspace-meta-row">
-              <strong>Background thread needs attention</strong>
-              <span className="status-badge warning">High priority</span>
-            </div>
-            <p>
-              <strong>
-                <code className="artifact-inline">{backgroundPriorityNotice.threadId}</code>
-              </strong>
-              {" needs attention now."}
-            </p>
-            <p className="workspace-meta">Reason: {backgroundPriorityNotice.reason}</p>
-            <div className="workspace-actions">
-              <button
-                className="primary-link action-button compact-button"
-                onClick={() => onOpenBackgroundPriorityThread(backgroundPriorityNotice.threadId)}
-                type="button"
-              >
-                Open thread
-              </button>
-            </div>
-          </section>
-        ) : null}
-
-        <section
-          aria-label="Navigation"
-          className={[
-            "chat-panel create-card thread-navigation",
-            isNavigationOpen ? "open" : "",
-            isSidebarMinibar ? "minibar" : "",
-          ]
-            .filter(Boolean)
-            .join(" ")}
-        >
-          {isSidebarMinibar ? (
-            <div className="navigation-minibar-stack">
-              <button
-                aria-label="Expand Navigation"
-                className="secondary-link action-button minibar-button"
-                onClick={() => updateSidebarMode("full")}
-                title="Expand Navigation"
-                type="button"
-              >
-                Nav
-              </button>
-              {workspaceId ? (
-                <button
-                  aria-label={`Start new thread in ${selectedWorkspace?.workspace_name ?? workspaceId}`}
-                  className="primary-link action-button minibar-button"
-                  onClick={askCodex}
-                  title="Ask Codex"
-                  type="button"
-                >
-                  New
-                </button>
-              ) : null}
-              <button
-                aria-label={`Current workspace: ${
-                  selectedWorkspace?.workspace_name ?? workspaceId ?? "none"
-                }`}
-                className="secondary-link action-button minibar-button"
-                onClick={() => updateSidebarMode("full")}
-                title={selectedWorkspace?.workspace_name ?? workspaceId ?? "Select workspace"}
-                type="button"
-              >
-                {compactName(selectedWorkspace?.workspace_name ?? workspaceId)}
-              </button>
-              {selectedThreadSummary ? (
-                <button
-                  aria-label={`Current thread: ${selectedThreadSummary.title}`}
-                  aria-current="page"
-                  className="secondary-link action-button minibar-button active"
-                  onClick={() => selectThread(selectedThreadSummary.thread_id)}
-                  title={selectedThreadSummary.title}
-                  type="button"
-                >
-                  {threadStatusSymbol(selectedThreadSummary)}
-                </button>
-              ) : null}
-              {attentionThreads
-                .filter((thread) => thread.thread_id !== selectedThreadId)
-                .slice(0, 4)
-                .map((thread) => (
-                  <button
-                    aria-label={`${threadStatusLabel(thread)}: ${thread.title}`}
-                    className="secondary-link action-button minibar-button attention"
-                    key={thread.thread_id}
-                    onClick={() => selectThread(thread.thread_id)}
-                    title={thread.title}
-                    type="button"
-                  >
-                    {threadStatusSymbol(thread)}
-                  </button>
-                ))}
-            </div>
-          ) : (
-            <>
-              <header>
-                <div className="workspace-meta-row navigation-header-row">
-                  <h2>{selectedWorkspace?.workspace_name ?? "Select workspace"}</h2>
-                  <button
-                    aria-label="Collapse Navigation to minibar"
-                    className="secondary-link action-button compact-button sidebar-mode-toggle"
-                    onClick={() => updateSidebarMode("mini")}
-                    type="button"
-                  >
-                    Minimize
-                  </button>
-                </div>
-                <p className="workspace-meta">
-                  {workspaceId ? "Workspace scope active" : "Choose or create a workspace."}
-                </p>
-              </header>
-
-              {workspaceId ? (
-                <button
-                  className={
-                    hasSelectedThread
-                      ? "primary-link action-button navigation-ask-codex"
-                      : "secondary-link action-button navigation-ask-codex"
-                  }
-                  onClick={askCodex}
-                  type="button"
-                >
-                  Ask Codex
-                </button>
-              ) : null}
-
-              <details className="workspace-switcher">
-                <summary>Switch workspace</summary>
-                <div className="workspace-switcher-control">
-                  {isLoadingWorkspaces ? (
-                    <p className="workspace-status">Loading workspaces...</p>
-                  ) : null}
-                  {workspaces.length > 0 ? (
-                    <div className="workspace-option-list">
-                      {workspaces.map((workspace) => (
-                        <button
-                          className={
-                            workspace.workspace_id === workspaceId
-                              ? "workspace-option-card active"
-                              : "workspace-option-card"
-                          }
-                          key={workspace.workspace_id}
-                          onClick={() => onSelectWorkspace(workspace.workspace_id)}
-                          type="button"
-                        >
-                          <strong>{workspace.workspace_name}</strong>
-                          <span className="workspace-meta">{workspace.workspace_id}</span>
-                          <span className="workspace-meta">{workspaceSummary(workspace)}</span>
-                        </button>
-                      ))}
-                    </div>
-                  ) : !isLoadingWorkspaces ? (
-                    <p className="empty-state">Create a workspace to start scoped work.</p>
-                  ) : null}
-
-                  <div className="create-form workspace-create-form">
-                    <label className="form-label" htmlFor="workspace-name">
-                      New workspace
-                      <input
-                        id="workspace-name"
-                        name="workspace-name"
-                        onChange={(event) => onWorkspaceNameChange(event.target.value)}
-                        placeholder="Workspace name"
-                        value={workspaceName}
-                      />
-                    </label>
-                    <button
-                      className="submit-button"
-                      disabled={isCreatingWorkspace || workspaceName.trim().length === 0}
-                      onClick={onCreateWorkspace}
-                      type="button"
-                    >
-                      {isCreatingWorkspace ? "Creating..." : "Create workspace"}
-                    </button>
-                  </div>
-                </div>
-              </details>
-
-              <div className="thread-list">
-                {isLoadingThreads ? <p className="workspace-status">Loading threads...</p> : null}
-
-                {!workspaceId && !isLoadingWorkspaces ? (
-                  <p className="empty-state">Select a workspace to show its threads.</p>
-                ) : null}
-
-                {workspaceId && !isLoadingThreads && threads.length === 0 ? (
-                  <p className="empty-state">No threads yet. Use Ask Codex in Thread View.</p>
-                ) : null}
-
-                {workspaceId && threads.length > 0 ? (
-                  <div className="thread-filter-bar" role="tablist" aria-label="Thread filters">
-                    {threadFilters.map((filter) => (
-                      <button
-                        className={
-                          selectedFilterId === filter.id
-                            ? "thread-filter-chip active"
-                            : "thread-filter-chip"
-                        }
-                        key={filter.id}
-                        onClick={() => setSelectedFilterId(filter.id)}
-                        role="tab"
-                        aria-selected={selectedFilterId === filter.id}
-                        type="button"
-                      >
-                        <span>{filter.label}</span>
-                        <span className="thread-filter-count">{filter.count}</span>
-                      </button>
-                    ))}
-                  </div>
-                ) : null}
-
-                {workspaceId &&
-                !isLoadingThreads &&
-                threads.length > 0 &&
-                visibleThreads.length === 0 ? (
-                  <p className="empty-state">No threads match this filter.</p>
-                ) : null}
-
-                {visibleThreads.map((thread) => {
-                  const isSelected = selectedThreadId === thread.thread_id;
-                  const rowCueLabel = threadCueLabel(thread);
-                  const hasBackgroundNotice =
-                    backgroundPriorityNotice?.threadId === thread.thread_id && !isSelected;
-                  const isAttention = rowCueLabel !== null || hasBackgroundNotice;
-
-                  return (
-                    <button
-                      aria-current={isSelected ? "page" : undefined}
-                      className={isSelected ? "thread-summary-card active" : "thread-summary-card"}
-                      key={thread.thread_id}
-                      onClick={() => selectThread(thread.thread_id)}
-                      type="button"
-                    >
-                      <div className="workspace-meta-row thread-summary-header">
-                        <span
-                          aria-label={threadStatusLabel(thread)}
-                          className={threadBadgeClass(thread).replace(
-                            "status-badge",
-                            "thread-status-mark",
-                          )}
-                          role="img"
-                          title={threadStatusLabel(thread)}
-                        >
-                          {threadStatusSymbol(thread)}
-                        </span>
-                        <div className="thread-summary-title-block">
-                          <strong>{thread.title}</strong>
-                          <span className="workspace-meta">
-                            Updated {formatTimestamp(thread.updated_at)}
-                          </span>
-                        </div>
-                      </div>
-                      {isAttention ? (
-                        <div className="thread-summary-cues">
-                          {rowCueLabel ? (
-                            <span className="status-badge">{formatMachineLabel(rowCueLabel)}</span>
-                          ) : null}
-                          {hasBackgroundNotice ? (
-                            <span className="status-badge warning">Needs attention now</span>
-                          ) : null}
-                          {thread.badge && rowCueLabel !== thread.badge.label ? (
-                            <span className="status-badge">
-                              {formatMachineLabel(thread.badge.label)}
-                            </span>
-                          ) : null}
-                        </div>
-                      ) : null}
-                      {hasBackgroundNotice ? (
-                        <p className="thread-summary-notice">
-                          Background notice: {backgroundPriorityNotice?.reason}
-                        </p>
-                      ) : null}
-                    </button>
-                  );
-                })}
-              </div>
-            </>
-          )}
-        </section>
+        <ChatViewNavigation
+          backgroundPriorityNotice={backgroundPriorityNotice}
+          formatMachineLabel={formatMachineLabel}
+          formatTimestamp={formatTimestamp}
+          isCreatingWorkspace={isCreatingWorkspace}
+          isLoadingThreads={isLoadingThreads}
+          isLoadingWorkspaces={isLoadingWorkspaces}
+          isNavigationOpen={isNavigationOpen}
+          onAskCodex={askCodex}
+          onCreateWorkspace={onCreateWorkspace}
+          onOpenBackgroundPriorityThread={onOpenBackgroundPriorityThread}
+          onSelectThread={selectThread}
+          onSelectWorkspace={onSelectWorkspace}
+          onSidebarModeChange={updateSidebarMode}
+          onWorkspaceNameChange={onWorkspaceNameChange}
+          selectedThreadId={selectedThreadId}
+          sidebarMode={sidebarMode}
+          threads={threads}
+          workspaceId={workspaceId}
+          workspaceName={workspaceName}
+          workspaces={workspaces}
+        />
 
         <section aria-label="Thread View" className="chat-panel workspace-card thread-view-card">
           <div className="thread-view-header-stack">
@@ -1428,95 +922,21 @@ export function ChatView({
                 </div>
               ) : null}
 
-              <section className="timeline-section" aria-label="Timeline">
-                {isLoadingThread ? (
-                  <p className="workspace-status">
-                    {selectedThreadId
-                      ? "Opening this thread and restoring its latest timeline..."
-                      : "Preparing thread view..."}
-                  </p>
-                ) : null}
-
-                <div className="chat-message-list">
-                  {!isLoadingThread && selectedThreadView && timelineModel.groups.length === 0 ? (
-                    <p className="empty-state">
-                      No timeline items yet. Start the thread or send follow-up input to continue.
-                    </p>
-                  ) : null}
-
-                  {timelineModel.groups.map((group) => (
-                    <section
-                      className={group.turnId ? "timeline-turn-group" : "timeline-ungrouped-item"}
-                      data-turn-id={group.turnId ?? undefined}
-                      key={group.id}
-                    >
-                      {group.turnId ? (
-                        <div className="timeline-turn-label">
-                          <span>Turn</span>
-                          <strong>{group.turnId}</strong>
-                        </div>
-                      ) : null}
-                      {group.rows.map((row) =>
-                        (() => {
-                          const contentPreview = timelineContentPreview(row.content);
-                          const isExpanded = expandedTimelineRows.has(row.id);
-                          const displayedContent =
-                            contentPreview.isFoldable && !isExpanded
-                              ? contentPreview.preview
-                              : row.content;
-
-                          return (
-                            <article
-                              className={`${timelineRowClass(row)}${
-                                contentPreview.isFoldable && !isExpanded
-                                  ? " timeline-row-folded"
-                                  : ""
-                              }`}
-                              key={row.id}
-                            >
-                              <div className="workspace-meta-row timeline-row-meta">
-                                <strong>{row.label}</strong>
-                                <span className="workspace-meta">
-                                  {row.isLive ? "Live" : formatTimestamp(row.occurredAt)}
-                                </span>
-                              </div>
-                              <p className="timeline-row-content">{displayedContent}</p>
-                              {contentPreview.isFoldable || row.showDetailButton ? (
-                                <div className="timeline-row-actions">
-                                  {contentPreview.isFoldable ? (
-                                    <button
-                                      aria-expanded={isExpanded}
-                                      className="secondary-link action-button inline-detail-button"
-                                      onClick={() => toggleTimelineRowExpansion(row.id)}
-                                      type="button"
-                                    >
-                                      {isExpanded ? "Show less" : "Show more"}
-                                    </button>
-                                  ) : null}
-                                  {row.showDetailButton && row.timelineItemId ? (
-                                    <button
-                                      className="secondary-link action-button inline-detail-button"
-                                      onClick={() =>
-                                        setDetailSelection({
-                                          kind: "timeline_item_detail",
-                                          timelineItemId: row.timelineItemId ?? "",
-                                        })
-                                      }
-                                      type="button"
-                                    >
-                                      {row.detailActionLabel ?? "Inspect details"}
-                                    </button>
-                                  ) : null}
-                                </div>
-                              ) : null}
-                            </article>
-                          );
-                        })(),
-                      )}
-                    </section>
-                  ))}
-                </div>
-              </section>
+              <ChatViewTimeline
+                expandedRowIds={expandedTimelineRows}
+                formatTimestamp={formatTimestamp}
+                groups={timelineModel.groups}
+                hasLoadedThreadView={selectedThreadView !== null}
+                isLoadingThread={isLoadingThread}
+                onOpenDetail={(timelineItemId) =>
+                  setDetailSelection({
+                    kind: "timeline_item_detail",
+                    timelineItemId,
+                  })
+                }
+                onToggleRowExpansion={toggleTimelineRowExpansion}
+                selectedThreadId={selectedThreadId}
+              />
             </div>
 
             <div className="thread-mobile-footer-actions">
@@ -1543,365 +963,55 @@ export function ChatView({
               </button>
             </div>
 
-            <div className="chat-composer" data-composer-mode={isStartingThread ? "start" : "send"}>
-              <label className="form-label" htmlFor="thread-composer-input">
-                {composerLabel}
-                <textarea
-                  className="chat-textarea"
-                  disabled={
-                    !workspaceId ||
-                    isOpeningSelectedThread ||
-                    isSubmittingComposer ||
-                    Boolean(unavailableReason)
-                  }
-                  id="thread-composer-input"
-                  name="thread-composer-input"
-                  onChange={(event) => onComposerDraftChange(event.target.value)}
-                  placeholder={composerPlaceholder}
-                  ref={composerRef}
-                  rows={4}
-                  value={composerDraft}
-                />
-              </label>
-              {composerGuidance ? (
-                <p className="composer-guidance" role="status">
-                  {composerGuidance}
-                </p>
-              ) : (
-                <p className="composer-guidance" role="status">
-                  {isStartingThread
-                    ? "First input starts a new thread in this workspace."
-                    : "Input will continue the selected thread."}
-                </p>
-              )}
-              <button
-                className="submit-button"
-                disabled={isComposerDisabled}
-                onClick={onSubmitComposer}
-                type="button"
-              >
-                {composerSubmitLabel}
-              </button>
-            </div>
+            <ChatViewComposer
+              composerDraft={composerDraft}
+              composerGuidance={composerGuidance}
+              composerLabel={composerLabel}
+              composerPlaceholder={composerPlaceholder}
+              composerSubmitLabel={composerSubmitLabel}
+              defaultGuidance={composerDefaultGuidance}
+              isComposerDisabled={isComposerDisabled}
+              isStartingThread={isStartingThread}
+              isTextareaDisabled={isComposerTextareaDisabled}
+              onComposerDraftChange={onComposerDraftChange}
+              onSubmitComposer={onSubmitComposer}
+              textareaRef={composerRef}
+            />
           </div>
         </section>
 
         {detailSelection ? (
-          <aside className="chat-panel workspace-card thread-detail-surface">
-            <header>
-              <div className="workspace-meta-row">
-                <p className="eyebrow">Detail</p>
-                <button
-                  className="secondary-link action-button compact-button"
-                  onClick={() => setDetailSelection(null)}
-                  type="button"
-                >
-                  Close
-                </button>
-              </div>
-              <h2>
-                {detailSelection.kind === "thread_details"
-                  ? "Thread details"
-                  : detailSelection.kind === "request_detail"
-                    ? "Request detail"
-                    : (selectedTimelineItemDetail?.title ?? "Timeline detail")}
-              </h2>
-            </header>
-
-            {detailSelection.kind === "thread_details" ? (
-              <div className="detail-stack">
-                <section className="thread-detail-section detail-text-section">
-                  <strong>Overview</strong>
-                  <dl className="request-detail-list">
-                    <div>
-                      <dt>Title</dt>
-                      <dd>
-                        {selectedThreadView?.thread.title ??
-                          (workspaceId ? "New workspace input" : "No workspace selected")}
-                      </dd>
-                    </div>
-                    <div className={detailFieldClass("Thread")}>
-                      <dt>Thread</dt>
-                      <dd>
-                        {selectedThreadView?.thread.thread_id ? (
-                          <code className="artifact-inline">
-                            {selectedThreadView.thread.thread_id}
-                          </code>
-                        ) : (
-                          "Not started"
-                        )}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Workspace</dt>
-                      <dd>{selectedWorkspace?.workspace_name ?? workspaceId ?? "Not selected"}</dd>
-                    </div>
-                    <div>
-                      <dt>Updated</dt>
-                      <dd>{formatTimestamp(selectedThreadView?.thread.updated_at ?? null)}</dd>
-                    </div>
-                  </dl>
-                </section>
-
-                <section className="thread-detail-section detail-text-section">
-                  <strong>Status</strong>
-                  <dl className="request-detail-list">
-                    <div>
-                      <dt>Current activity</dt>
-                      <dd>
-                        {selectedThreadView?.current_activity.label ??
-                          (isOpeningSelectedThread
-                            ? "Opening"
-                            : workspaceId
-                              ? "Ready for first input"
-                              : "Workspace required")}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Activity summary</dt>
-                      <dd>
-                        {workspaceId
-                          ? currentActivitySummary(selectedThreadView, isOpeningSelectedThread)
-                          : "Choose a workspace to enable the composer."}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Stream</dt>
-                      <dd>{connectionState}</dd>
-                    </div>
-                    <div>
-                      <dt>Composer</dt>
-                      <dd>
-                        {selectedThreadView?.composer.accepting_user_input
-                          ? "Accepting input"
-                          : composerGuidance}
-                      </dd>
-                    </div>
-                  </dl>
-                </section>
-
-                <section className="thread-detail-section detail-text-section">
-                  <strong>Next action</strong>
-                  <p>{threadFeedback.summary}</p>
-                  {threadFeedback.actions.length > 0 ? (
-                    <div className="workspace-actions thread-feedback-actions">
-                      {threadFeedback.actions.map((action) => renderThreadFeedbackAction(action))}
-                    </div>
-                  ) : null}
-                </section>
-
-                <section className="thread-detail-section detail-text-section">
-                  <strong>Requests</strong>
-                  <p>
-                    {selectedThreadView?.pending_request
-                      ? selectedThreadView.pending_request.summary
-                      : selectedThreadView?.latest_resolved_request
-                        ? `Latest resolved request: ${selectedThreadView.latest_resolved_request.decision}`
-                        : "No pending or recently resolved request."}
-                  </p>
-                  {selectedRequestDetail ? (
-                    <button
-                      className="secondary-link action-button compact-button"
-                      onClick={() => setDetailSelection({ kind: "request_detail" })}
-                      type="button"
-                    >
-                      Request detail
-                    </button>
-                  ) : null}
-                </section>
-
-                <section className="thread-detail-section detail-text-section">
-                  <strong>Artifacts</strong>
-                  {timelineArtifactCount > 0 ? (
-                    <ul className="detail-list">
-                      {timelineModel.groups.flatMap((group) =>
-                        group.rows
-                          .filter((row) => row.showDetailButton && row.timelineItemId)
-                          .map((row) => (
-                            <li key={row.id}>
-                              <strong>{row.label}</strong>
-                              <span>{row.content}</span>
-                              <button
-                                className="secondary-link action-button inline-detail-button"
-                                onClick={() =>
-                                  setDetailSelection({
-                                    kind: "timeline_item_detail",
-                                    timelineItemId: row.timelineItemId ?? "",
-                                  })
-                                }
-                                type="button"
-                              >
-                                {row.detailActionLabel ?? "Inspect details"}
-                              </button>
-                            </li>
-                          )),
-                      )}
-                    </ul>
-                  ) : (
-                    <p>No extracted artifacts are available for this thread yet.</p>
-                  )}
-                </section>
-
-                <details className="detail-debug">
-                  <summary>Debug: raw thread view JSON</summary>
-                  <pre className="detail-json">
-                    {JSON.stringify(
-                      selectedThreadView ?? { workspaceId, selectedThreadId },
-                      null,
-                      2,
-                    )}
-                  </pre>
-                </details>
-              </div>
-            ) : null}
-
-            {detailSelection.kind === "request_detail" && selectedRequestDetail ? (
-              <div className="detail-stack">
-                <div className="workspace-meta-row">
-                  <span className={requestBadgeClass(selectedRequestDetail)}>
-                    {selectedRequestDetail.status}
-                  </span>
-                  <span className="status-badge">
-                    {formatMachineLabel(selectedRequestDetail.risk_category)}
-                  </span>
-                </div>
-                <p>{selectedRequestDetail.summary}</p>
-                <dl className="request-detail-list">
-                  <div>
-                    <dt>Reason</dt>
-                    <dd>{selectedRequestDetail.reason}</dd>
-                  </div>
-                  {selectedRequestDetail.operation_summary ? (
-                    <div className={detailFieldClass("Operation")}>
-                      <dt>Operation</dt>
-                      <dd>
-                        <code className="artifact-inline">
-                          {selectedRequestDetail.operation_summary}
-                        </code>
-                      </dd>
-                    </div>
-                  ) : null}
-                  <div>
-                    <dt>Requested</dt>
-                    <dd>{formatTimestamp(selectedRequestDetail.requested_at)}</dd>
-                  </div>
-                  <div className={`request-context-field ${detailFieldClass("Thread")}`}>
-                    <dt>Thread</dt>
-                    <dd>
-                      <code className="artifact-inline">{selectedRequestDetail.thread_id}</code>
-                    </dd>
-                  </div>
-                  <div className={`request-context-field ${detailFieldClass("Turn")}`}>
-                    <dt>Turn</dt>
-                    <dd>
-                      {selectedRequestDetail.turn_id ? (
-                        <code className="artifact-inline">{selectedRequestDetail.turn_id}</code>
-                      ) : (
-                        "Not available"
-                      )}
-                    </dd>
-                  </div>
-                  <div className={`request-context-field ${detailFieldClass("Item")}`}>
-                    <dt>Item</dt>
-                    <dd>
-                      <code className="artifact-inline">{selectedRequestDetail.item_id}</code>
-                    </dd>
-                  </div>
-                  {selectedRequestDetail.decision ? (
-                    <div>
-                      <dt>Decision</dt>
-                      <dd>{selectedRequestDetail.decision}</dd>
-                    </div>
-                  ) : null}
-                  {selectedRequestDetail.responded_at ? (
-                    <div>
-                      <dt>Responded</dt>
-                      <dd>{formatTimestamp(selectedRequestDetail.responded_at)}</dd>
-                    </div>
-                  ) : null}
-                </dl>
-                {selectedRequestDetail.operation_summary ? (
-                  <p className="request-operation-summary">
-                    Operation:{" "}
-                    <code className="artifact-inline">
-                      {selectedRequestDetail.operation_summary}
-                    </code>
-                  </p>
-                ) : null}
-                {selectedRequestDetail.status === "pending" ? (
-                  <div className="workspace-actions request-detail-actions">
-                    <button
-                      className="approve-button action-button compact-button"
-                      disabled={isRespondingToRequest}
-                      onClick={onApproveRequest}
-                      type="button"
-                    >
-                      {isRespondingToRequest ? "Submitting..." : "Approve request"}
-                    </button>
-                    <button
-                      className="danger-button action-button compact-button"
-                      disabled={isRespondingToRequest}
-                      onClick={onDenyRequest}
-                      type="button"
-                    >
-                      Deny request
-                    </button>
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
-
-            {detailSelection.kind === "timeline_item_detail" &&
-            selectedTimelineItem &&
-            selectedTimelineItemDetail ? (
-              <div className="detail-stack">
-                <p className="workspace-meta">
-                  {selectedTimelineItem.kind} at {formatTimestamp(selectedTimelineItem.occurred_at)}
-                </p>
-                <p>{selectedTimelineItemDetail.summary}</p>
-                {selectedTimelineItemDetail.sections.map((section) => (
-                  <div
-                    className={
-                      section.code
-                        ? "request-operation-summary detail-artifact-section"
-                        : "request-operation-summary detail-text-section"
-                    }
-                    key={section.title}
-                  >
-                    <strong>{section.title}</strong>
-                    <ul
-                      className={section.code ? "detail-list detail-artifact-list" : "detail-list"}
-                    >
-                      {section.items.map((entry) => (
-                        <li key={entry}>
-                          {section.code ? <code className="artifact-inline">{entry}</code> : entry}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-                {selectedTimelineItemDetail.fields.length > 0 ? (
-                  <dl className="request-detail-list">
-                    {selectedTimelineItemDetail.fields.map((field) => (
-                      <div
-                        className={detailFieldClass(field.label)}
-                        key={`${field.label}:${field.value}`}
-                      >
-                        <dt>{field.label}</dt>
-                        <dd>{renderDetailFieldValue(field)}</dd>
-                      </div>
-                    ))}
-                  </dl>
-                ) : null}
-                <details className="detail-debug">
-                  <summary>Debug: raw timeline payload JSON</summary>
-                  <pre className="detail-json">
-                    {JSON.stringify(selectedTimelineItem.payload, null, 2)}
-                  </pre>
-                </details>
-              </div>
-            ) : null}
-          </aside>
+          <ChatViewDetails
+            composerGuidance={composerGuidance}
+            connectionState={connectionState}
+            formatMachineLabel={formatMachineLabel}
+            formatTimestamp={formatTimestamp}
+            isOpeningSelectedThread={isOpeningSelectedThread}
+            isRespondingToRequest={isRespondingToRequest}
+            onApproveRequest={onApproveRequest}
+            onClose={() => setDetailSelection(null)}
+            onDenyRequest={onDenyRequest}
+            onSelectRequestDetail={() => setDetailSelection({ kind: "request_detail" })}
+            onSelectTimelineItemDetail={(timelineItemId) =>
+              setDetailSelection({
+                kind: "timeline_item_detail",
+                timelineItemId,
+              })
+            }
+            renderThreadFeedbackAction={renderThreadFeedbackAction}
+            requestBadgeClass={requestBadgeClass}
+            selectedRequestDetail={selectedRequestDetail}
+            selectedThreadId={selectedThreadId}
+            selectedThreadView={selectedThreadView}
+            selectedTimelineItem={selectedTimelineItem}
+            selectedTimelineItemDetail={selectedTimelineItemDetail}
+            selectedWorkspaceName={selectedWorkspace?.workspace_name ?? null}
+            selection={detailSelection}
+            threadActivitySummary={threadActivitySummary}
+            threadFeedback={threadFeedback}
+            timelineGroups={timelineModel.groups}
+            workspaceId={workspaceId}
+          />
         ) : null}
       </div>
     </main>

--- a/apps/frontend-bff/tests/chat-view-details.test.tsx
+++ b/apps/frontend-bff/tests/chat-view-details.test.tsx
@@ -1,0 +1,328 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ChatViewDetails,
+  type ChatViewDetailsProps,
+  type ThreadFeedbackAction,
+} from "../src/chat-view-details";
+import type {
+  PublicRequestDetail,
+  PublicThreadView,
+  PublicTimelineItem,
+} from "../src/thread-types";
+import type { TimelineItemDetail } from "../src/timeline-item-detail";
+
+function formatTimestamp(value: string | null) {
+  return value ? `formatted:${value}` : "Not available";
+}
+
+function formatMachineLabel(value: string | null | undefined) {
+  return value ? value.replaceAll("_", " ") : "Not available";
+}
+
+function requestBadgeClass(request: PublicRequestDetail | null) {
+  if (!request) {
+    return "status-badge";
+  }
+
+  return request.status === "pending" ? "status-badge warning" : "status-badge success";
+}
+
+function renderThreadFeedbackAction(action: ThreadFeedbackAction) {
+  return (
+    <button
+      className="secondary-link action-button compact-button"
+      key={action.label}
+      type="button"
+    >
+      {action.label}
+    </button>
+  );
+}
+
+function buildThreadView(): PublicThreadView {
+  return {
+    thread: {
+      thread_id: "thread_001",
+      workspace_id: "ws_001",
+      title: "Timeline detail extraction",
+      native_status: {
+        thread_status: "running",
+        active_flags: ["live"],
+        latest_turn_status: "in_progress",
+      },
+      updated_at: "2026-03-27T06:30:00Z",
+    },
+    current_activity: {
+      kind: "waiting_on_approval",
+      label: "Waiting on approval",
+    },
+    pending_request: {
+      request_id: "req_001",
+      thread_id: "thread_001",
+      turn_id: "turn_001",
+      item_id: "item_approval_001",
+      request_kind: "approval",
+      status: "pending",
+      risk_category: "network_access",
+      summary: "Approval is required before Codex can continue.",
+      requested_at: "2026-03-27T06:20:00Z",
+    },
+    latest_resolved_request: null,
+    composer: {
+      accepting_user_input: false,
+      interrupt_available: true,
+      blocked_by_request: true,
+      input_unavailable_reason: "waiting_on_approval",
+    },
+    timeline: {
+      items: [],
+      next_cursor: null,
+      has_more: false,
+    },
+  };
+}
+
+function buildRequestDetail(overrides: Partial<PublicRequestDetail> = {}): PublicRequestDetail {
+  return {
+    request_id: "req_001",
+    thread_id: "thread_001",
+    turn_id: "turn_001",
+    item_id: "item_approval_001",
+    request_kind: "approval",
+    status: "pending",
+    risk_category: "network_access",
+    summary: "Approval request for pushing the branch.",
+    reason: "The action would write to a remote repository.",
+    operation_summary: "git push origin main",
+    requested_at: "2026-03-27T06:20:00Z",
+    responded_at: null,
+    decision: null,
+    decision_options: {
+      policy_scope_supported: false,
+      default_policy_scope: "once",
+    },
+    context: {
+      repo: "origin",
+    },
+    ...overrides,
+  };
+}
+
+function buildTimelineItem(): PublicTimelineItem {
+  return {
+    timeline_item_id: "timeline_001",
+    thread_id: "thread_001",
+    turn_id: "turn_001",
+    item_id: "item_001",
+    sequence: 7,
+    occurred_at: "2026-03-27T06:25:00Z",
+    kind: "tool.result.failed",
+    payload: {
+      output: "artifacts/visual-inspection/issue-219-failure.txt",
+      operation: "Validate timeline detail surface",
+      request_id: "req_001",
+      error: "Expected contextual detail button",
+    },
+  };
+}
+
+function buildTimelineDetail(): TimelineItemDetail {
+  return {
+    actionLabel: "Inspect failure",
+    title: "Failure detail",
+    summary: "Validation evidence failed for the requested artifact surface.",
+    sections: [
+      {
+        title: "Generated outputs",
+        items: ["artifacts/visual-inspection/issue-219-failure.txt"],
+      },
+      {
+        title: "Errors",
+        items: ["Expected contextual detail button"],
+      },
+    ],
+    fields: [
+      { label: "Request ID", value: "req_001" },
+      { label: "Operation", value: "Validate timeline detail surface" },
+      {
+        label: "Issue",
+        value: "https://github.com/example/repo/issues/219",
+        href: "https://github.com/example/repo/issues/219",
+      },
+    ],
+    hasContext: true,
+  };
+}
+
+function buildProps(overrides: Partial<ChatViewDetailsProps> = {}): ChatViewDetailsProps {
+  return {
+    selection: { kind: "thread_details" },
+    workspaceId: "ws_001",
+    selectedThreadId: "thread_001",
+    selectedWorkspaceName: "Primary workspace",
+    selectedThreadView: buildThreadView(),
+    selectedRequestDetail: buildRequestDetail(),
+    selectedTimelineItem: buildTimelineItem(),
+    selectedTimelineItemDetail: buildTimelineDetail(),
+    isOpeningSelectedThread: false,
+    connectionState: "live",
+    composerGuidance: "Input is paused while this thread waits for your approval response.",
+    threadActivitySummary: "Codex is paused until you approve or deny the request below.",
+    threadFeedback: {
+      badgeTone: "warning",
+      isVisible: true,
+      title: "Approval required",
+      summary: "Codex is blocked until you approve or deny the pending request in this thread.",
+      actions: [{ kind: "request_detail", label: "Request detail" }],
+    },
+    timelineGroups: [
+      {
+        id: "group_001",
+        turnId: "turn_001",
+        rows: [
+          {
+            id: "row_approval",
+            turnId: "turn_001",
+            sequence: 7,
+            occurredAt: "2026-03-27T06:25:00Z",
+            label: "Approval context",
+            content: "Push requires approval",
+            density: "compact",
+            role: "event",
+            timelineItemId: "timeline_approval_001",
+            isLive: false,
+            showDetailButton: true,
+            detailActionLabel: "Inspect request",
+          },
+        ],
+      },
+    ],
+    isRespondingToRequest: false,
+    formatTimestamp,
+    formatMachineLabel,
+    requestBadgeClass,
+    renderThreadFeedbackAction,
+    onClose: vi.fn(),
+    onSelectRequestDetail: vi.fn(),
+    onSelectTimelineItemDetail: vi.fn(),
+    onApproveRequest: vi.fn(),
+    onDenyRequest: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("ChatViewDetails", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders thread details with request and artifact actions plus debug JSON", async () => {
+    const onClose = vi.fn();
+    const onSelectRequestDetail = vi.fn();
+    const onSelectTimelineItemDetail = vi.fn();
+    const props = buildProps({
+      onClose,
+      onSelectRequestDetail,
+      onSelectTimelineItemDetail,
+    });
+
+    const markup = renderToStaticMarkup(<ChatViewDetails {...props} />);
+    expect(markup).toContain("Thread details");
+    expect(markup).toContain("Primary workspace");
+    expect(markup).toContain("Approval context");
+    expect(markup).toContain("Debug: raw thread view JSON");
+    expect(markup).toContain("&quot;thread_id&quot;: &quot;thread_001&quot;");
+
+    await act(async () => {
+      root.render(<ChatViewDetails {...props} />);
+    });
+
+    const buttons = Array.from(container.querySelectorAll("button"));
+    const closeButton = buttons.find((button) => button.textContent === "Close");
+    const requestDetailButton = buttons.filter(
+      (button) => button.textContent === "Request detail",
+    )[1];
+    const artifactButton = buttons.find((button) => button.textContent === "Inspect request");
+
+    await act(async () => {
+      closeButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      requestDetailButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      artifactButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSelectRequestDetail).toHaveBeenCalledTimes(1);
+    expect(onSelectTimelineItemDetail).toHaveBeenCalledWith("timeline_approval_001");
+  });
+
+  it("renders pending request detail actions and wires approve and deny", async () => {
+    const onApproveRequest = vi.fn();
+    const onDenyRequest = vi.fn();
+    const props = buildProps({
+      selection: { kind: "request_detail" },
+      onApproveRequest,
+      onDenyRequest,
+    });
+
+    const markup = renderToStaticMarkup(<ChatViewDetails {...props} />);
+    expect(markup).toContain("Request detail");
+    expect(markup).toContain('class="request-detail-field request-detail-field-code"');
+    expect(markup).toContain(
+      'Operation: <code class="artifact-inline">git push origin main</code>',
+    );
+
+    await act(async () => {
+      root.render(<ChatViewDetails {...props} />);
+    });
+
+    const approveButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Approve request",
+    );
+    const denyButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Deny request",
+    );
+
+    await act(async () => {
+      approveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      denyButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onApproveRequest).toHaveBeenCalledTimes(1);
+    expect(onDenyRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders structured timeline detail with artifact sections, linked fields, and debug JSON", () => {
+    const props = buildProps({
+      selection: { kind: "timeline_item_detail", timelineItemId: "timeline_001" },
+    });
+
+    const markup = renderToStaticMarkup(<ChatViewDetails {...props} />);
+    expect(markup).toContain("Failure detail");
+    expect(markup).toContain("Generated outputs");
+    expect(markup).toContain("Expected contextual detail button");
+    expect(markup).toContain('class="detail-link"');
+    expect(markup).toContain("Debug: raw timeline payload JSON");
+    expect(markup).toContain("&quot;operation&quot;: &quot;Validate timeline detail surface&quot;");
+  });
+});

--- a/apps/frontend-bff/tests/chat-view-timeline.test.tsx
+++ b/apps/frontend-bff/tests/chat-view-timeline.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChatViewTimeline } from "../src/chat-view-timeline";
+import type { TimelineDisplayGroup } from "../src/timeline-display-model";
+
+function formatTimestamp(value: string | null) {
+  return value ? `formatted:${value}` : "Not available";
+}
+
+describe("ChatViewTimeline", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders grouped timeline rows with preserved labels, classes, timestamps, and detail action", () => {
+    const groups: TimelineDisplayGroup[] = [
+      {
+        id: "group-turn-001",
+        turnId: "turn_001",
+        rows: [
+          {
+            id: "row-live",
+            turnId: "turn_001",
+            sequence: 1,
+            occurredAt: "2026-03-27T05:20:00Z",
+            label: "Codex",
+            content: "Streaming answer",
+            density: "primary",
+            role: "assistant",
+            timelineItemId: null,
+            isLive: true,
+            showDetailButton: false,
+            detailActionLabel: null,
+          },
+          {
+            id: "row-detail",
+            turnId: "turn_001",
+            sequence: 2,
+            occurredAt: "2026-03-27T05:21:00Z",
+            label: "Request needs attention",
+            content: "Approval required",
+            density: "prominent",
+            role: "event",
+            timelineItemId: "timeline_002",
+            isLive: false,
+            showDetailButton: true,
+            detailActionLabel: "Inspect approval context",
+          },
+        ],
+      },
+    ];
+
+    const markup = renderToStaticMarkup(
+      <ChatViewTimeline
+        expandedRowIds={new Set()}
+        formatTimestamp={formatTimestamp}
+        groups={groups}
+        hasLoadedThreadView
+        isLoadingThread={false}
+        onOpenDetail={() => {}}
+        onToggleRowExpansion={() => {}}
+        selectedThreadId="thread_001"
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Timeline"');
+    expect(markup).toContain('class="timeline-turn-group"');
+    expect(markup).toContain('data-turn-id="turn_001"');
+    expect(markup).toContain('class="timeline-row timeline-row-primary timeline-row-assistant"');
+    expect(markup).toContain("Live");
+    expect(markup).toContain("formatted:2026-03-27T05:21:00Z");
+    expect(markup).toContain("Inspect approval context");
+  });
+
+  it("preserves folded row affordance and aria-expanded state from props", async () => {
+    const longContent = Array.from({ length: 10 }, (_, index) => `Line ${index + 1}`).join("\n");
+    const groups: TimelineDisplayGroup[] = [
+      {
+        id: "group-turn-001",
+        turnId: "turn_001",
+        rows: [
+          {
+            id: "row-folded",
+            turnId: "turn_001",
+            sequence: 1,
+            occurredAt: "2026-03-27T05:20:00Z",
+            label: "You",
+            content: longContent,
+            density: "primary",
+            role: "user",
+            timelineItemId: null,
+            isLive: false,
+            showDetailButton: false,
+            detailActionLabel: null,
+          },
+        ],
+      },
+    ];
+    const onToggleRowExpansion = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <ChatViewTimeline
+          expandedRowIds={new Set()}
+          formatTimestamp={formatTimestamp}
+          groups={groups}
+          hasLoadedThreadView
+          isLoadingThread={false}
+          onOpenDetail={() => {}}
+          onToggleRowExpansion={onToggleRowExpansion}
+          selectedThreadId="thread_001"
+        />,
+      );
+    });
+
+    const foldedToggle = container.querySelector(
+      'button[aria-expanded="false"]',
+    ) as HTMLButtonElement | null;
+    expect(foldedToggle?.textContent).toBe("Show more");
+    expect(container.querySelector(".timeline-row-folded")).not.toBeNull();
+
+    await act(async () => {
+      foldedToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onToggleRowExpansion).toHaveBeenCalledWith("row-folded");
+
+    await act(async () => {
+      root.render(
+        <ChatViewTimeline
+          expandedRowIds={new Set(["row-folded"])}
+          formatTimestamp={formatTimestamp}
+          groups={groups}
+          hasLoadedThreadView
+          isLoadingThread={false}
+          onOpenDetail={() => {}}
+          onToggleRowExpansion={onToggleRowExpansion}
+          selectedThreadId="thread_001"
+        />,
+      );
+    });
+
+    const expandedToggle = container.querySelector(
+      'button[aria-expanded="true"]',
+    ) as HTMLButtonElement | null;
+    expect(expandedToggle?.textContent).toBe("Show less");
+    expect(container.querySelector(".timeline-row-folded")).toBeNull();
+  });
+
+  it("calls the detail callback with the row timeline item id", async () => {
+    const onOpenDetail = vi.fn();
+    const groups: TimelineDisplayGroup[] = [
+      {
+        id: "group-ungrouped",
+        turnId: null,
+        rows: [
+          {
+            id: "row-detail",
+            turnId: null,
+            sequence: 1,
+            occurredAt: "2026-03-27T05:21:00Z",
+            label: "Tool activity",
+            content: "Ran a command",
+            density: "compact",
+            role: "event",
+            timelineItemId: "timeline_detail_001",
+            isLive: false,
+            showDetailButton: true,
+            detailActionLabel: "Inspect details",
+          },
+        ],
+      },
+    ];
+
+    await act(async () => {
+      root.render(
+        <ChatViewTimeline
+          expandedRowIds={new Set()}
+          formatTimestamp={formatTimestamp}
+          groups={groups}
+          hasLoadedThreadView
+          isLoadingThread={false}
+          onOpenDetail={onOpenDetail}
+          onToggleRowExpansion={() => {}}
+          selectedThreadId="thread_001"
+        />,
+      );
+    });
+
+    const detailButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Inspect details",
+    );
+
+    await act(async () => {
+      detailButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onOpenDetail).toHaveBeenCalledWith("timeline_detail_001");
+  });
+});

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ Each active task package `README.md` must include at least the following section
 
 ## Archived Task Packages
 
+- [issue-251-chat-view-components](./archive/issue-251-chat-view-components/README.md)
 - [issue-250-chat-page-hooks](./archive/issue-250-chat-page-hooks/README.md)
 - [issue-249-bff-route-boilerplate](./archive/issue-249-bff-route-boilerplate/README.md)
 - [issue-248-bff-mapping-boundaries](./archive/issue-248-bff-mapping-boundaries/README.md)

--- a/tasks/archive/issue-251-chat-view-components/README.md
+++ b/tasks/archive/issue-251-chat-view-components/README.md
@@ -1,0 +1,83 @@
+# issue-251-chat-view-components
+
+## Purpose
+
+Decompose `apps/frontend-bff/src/chat-view.tsx` into focused presentational components while preserving the current thread-first UI behavior.
+
+## Primary issue
+
+- GitHub Issue: #251
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Extract bounded presentational component modules from `chat-view.tsx`.
+- Keep accessibility labels, class names, copy, and behavior stable unless a local cleanup is explicitly required.
+- Validate with focused UI tests and build.
+
+## Exit criteria
+
+- Navigation, timeline, composer, or details surfaces are separated enough for this Issue's accepted slice.
+- Targeted UI tests and build show no visible behavior regression.
+- Pre-push validation passes before archive/PR follow-through.
+
+## Work plan
+
+1. Map high-cohesion regions in `chat-view.tsx`.
+2. Let the sprint planner choose one safe extraction slice.
+3. Implement the approved component extraction from this worktree.
+4. Run UI validation and evaluator review.
+5. Run dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Sprint 1 extracted `ChatViewComposer` into `apps/frontend-bff/src/chat-view-composer.tsx`.
+- Sprint 1 evaluator verdict: approved. Composer markup and callback behavior preserved.
+- Sprint 2 extracted `ChatViewTimeline` into `apps/frontend-bff/src/chat-view-timeline.tsx` and added `apps/frontend-bff/tests/chat-view-timeline.test.tsx`.
+- Sprint 2 evaluator verdict: approved. Timeline rendering, folding, and detail callbacks preserved.
+- Sprint 3 extracted `ChatViewDetails` into `apps/frontend-bff/src/chat-view-details.tsx` and added `apps/frontend-bff/tests/chat-view-details.test.tsx`.
+- Sprint 3 evaluator verdict: approved. Thread, request, and timeline item details remain user-selected and presentational.
+- Sprint 4 extracted `ChatViewNavigation` into `apps/frontend-bff/src/chat-view-navigation.tsx`.
+- Sprint 4 evaluator verdict: approved. Cumulative Issue scope is locally complete.
+- Validation evidence before pre-push:
+  - `cd apps/frontend-bff && npm run check`: pass.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: pass.
+  - `cd apps/frontend-bff && npm test`: pass, 105 tests.
+  - `cd apps/frontend-bff && npm run build`: pass.
+  - `cd apps/frontend-bff && npm run test:e2e -- e2e/issue-235-timeline-first-ia.spec.ts`: pass when rerun against current worktree on ports 3002/3003 with `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3003` after the default 3000/3001 ports were already occupied by existing dev servers.
+  - `git diff --check`: pass.
+- Dedicated pre-push validation evidence:
+  - `cd apps/frontend-bff && npm run check`: pass.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: pass.
+  - `cd apps/frontend-bff && npm test -- tests/chat-view.test.tsx tests/chat-view-timeline.test.tsx tests/chat-view-details.test.tsx tests/chat-page-client.test.tsx`: pass, 42 tests.
+  - `cd apps/frontend-bff && npm test`: pass, 105 tests across 13 files.
+  - `cd apps/frontend-bff && npm run build`: pass.
+  - Structural `rg` checks confirm navigation markup moved out of `chat-view.tsx` and the decomposed components export `ChatViewNavigation`, `ChatViewTimeline`, `ChatViewComposer`, and `ChatViewDetails`.
+  - `git diff --check`: pass.
+
+## Status / handoff notes
+
+- Status: locally complete; ready for archive and PR follow-through.
+- Active branch: `issue-251-chat-view-components`.
+- Active worktree: `.worktrees/issue-251-chat-view-components`.
+- Completion tracking, PR merge, worktree cleanup, Project `Done`, and Issue close remain pending.
+- Completion retrospective:
+  - Completion boundary: package archive before PR publication.
+  - Contract check: navigation, timeline, composer, and details surfaces are separate modules; targeted component tests, integrated chat tests, full BFF tests, build, and E2E evidence show no visible behavior regression.
+  - What worked: four small extraction slices kept a 1.9k-line component refactor reviewable and caught scope drift early.
+  - Workflow problems: E2E default ports conflicted with existing dev servers; rerunning against an explicit external stack on 3002/3003 resolved it without disturbing existing processes.
+  - Improvements to adopt: for E2E validation in active dev containers, prefer explicit alternate ports or `PLAYWRIGHT_BASE_URL` when default ports are already occupied.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: publish PR, merge to `main`, remove the worktree, clear Issue execution links, set Project status to `Done`, and close #251.
+
+## Archive conditions
+
+- Sprint evaluator returns `approved`.
+- Dedicated pre-push validation passes.
+- Package evidence and handoff notes are updated.
+- Package is moved to `tasks/archive/issue-251-chat-view-components/` before PR completion tracking.


### PR DESCRIPTION
## Summary

- Split `ChatView` into presentational surface modules for navigation, timeline, composer, and details.
- Added focused component tests for timeline and detail surfaces.
- Kept `ChatView` as the shell/coordinator for state, scrolling, selection, and callbacks.
- Archived the #251 task package.

Closes #251

## Validation

- `cd apps/frontend-bff && npm run check`
- `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `cd apps/frontend-bff && npm test -- tests/chat-view.test.tsx tests/chat-view-timeline.test.tsx tests/chat-view-details.test.tsx tests/chat-page-client.test.tsx`
- `cd apps/frontend-bff && npm test`
- `cd apps/frontend-bff && npm run build`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3003 npm run test:e2e -- e2e/issue-235-timeline-first-ia.spec.ts`
- `git diff --check`
