### PR TITLE
Refactor E2E mock builders

### DIFF
--- a/apps/frontend-bff/e2e/background-priority.spec.ts
+++ b/apps/frontend-bff/e2e/background-priority.spec.ts
@@ -1,6 +1,16 @@
 import { expect, test } from "@playwright/test";
 
-import { stubEventSource } from "./helpers/browser-mocks";
+import {
+  fulfillJson,
+  mockApprovalRequestDetailFixture,
+  mockApprovalRequestFixture,
+  mockThreadListItemFixture,
+  mockThreadSummaryFixture,
+  mockThreadViewFixture,
+  mockTimelineItemFixture,
+  mockWorkspaceFixture,
+  stubEventSource,
+} from "./helpers/browser-mocks";
 
 async function emitNotificationEvent(
   page: Parameters<typeof test>[0]["page"],
@@ -25,9 +35,7 @@ async function emitNotificationEvent(
 async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page"]) {
   const baseTimestamp = "2026-04-24T03:10:00Z";
 
-  const workspace = {
-    workspace_id: "ws_alpha",
-    workspace_name: "alpha",
+  const workspace = mockWorkspaceFixture({
     created_at: "2026-04-24T03:00:00Z",
     updated_at: baseTimestamp,
     active_session_summary: {
@@ -36,9 +44,9 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
       last_message_at: baseTimestamp,
     },
     pending_approval_count: 1,
-  };
+  });
 
-  const primaryThread = {
+  const primaryThread = mockThreadListItemFixture({
     thread_id: "thread_001",
     workspace_id: "ws_alpha",
     native_status: {
@@ -55,12 +63,12 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
     blocked_cue: null,
     resume_cue: {
       reason_kind: "active_thread",
-      priority_band: "medium" as const,
+      priority_band: "medium",
       label: "Active now",
     },
-  };
+  });
 
-  const backgroundThread = {
+  const backgroundThread = mockThreadListItemFixture({
     thread_id: "thread_background",
     workspace_id: "ws_alpha",
     native_status: {
@@ -83,19 +91,19 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
     },
     resume_cue: {
       reason_kind: "waiting_on_approval",
-      priority_band: "highest" as const,
+      priority_band: "highest",
       label: "Resume here first",
     },
-  };
+  });
 
   const threadViewById = {
-    thread_001: {
-      thread: {
+    thread_001: mockThreadViewFixture({
+      thread: mockThreadSummaryFixture({
         thread_id: "thread_001",
         workspace_id: "ws_alpha",
         native_status: primaryThread.native_status,
         updated_at: primaryThread.updated_at,
-      },
+      }),
       current_activity: primaryThread.current_activity,
       pending_request: null,
       latest_resolved_request: null,
@@ -106,11 +114,9 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
       },
       timeline: {
         items: [
-          {
+          mockTimelineItemFixture({
             timeline_item_id: "evt_001",
             thread_id: "thread_001",
-            turn_id: null,
-            item_id: null,
             sequence: 1,
             occurred_at: baseTimestamp,
             kind: "message.assistant.completed",
@@ -118,31 +124,31 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
               summary: "assistant completed",
               content: "Primary thread is idle.",
             },
-          },
+          }),
         ],
         next_cursor: null,
         has_more: false,
       },
-    },
-    thread_background: {
-      thread: {
+    }),
+    thread_background: mockThreadViewFixture({
+      thread: mockThreadSummaryFixture({
         thread_id: "thread_background",
         workspace_id: "ws_alpha",
         native_status: backgroundThread.native_status,
         updated_at: backgroundThread.updated_at,
-      },
+      }),
       current_activity: backgroundThread.current_activity,
-      pending_request: {
+      pending_request: mockApprovalRequestFixture({
         request_id: "req_background",
         thread_id: "thread_background",
         turn_id: "turn_background",
         item_id: "item_background",
         request_kind: "approval",
-        status: "pending" as const,
-        risk_category: "external_side_effect" as const,
+        status: "pending",
+        risk_category: "external_side_effect",
         summary: "Deploy background fix",
         requested_at: backgroundThread.updated_at,
-      },
+      }),
       latest_resolved_request: null,
       composer: {
         accepting_user_input: false,
@@ -151,23 +157,21 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
       },
       timeline: {
         items: [
-          {
+          mockTimelineItemFixture({
             timeline_item_id: "evt_100",
             thread_id: "thread_background",
-            turn_id: null,
-            item_id: null,
             sequence: 1,
             occurred_at: backgroundThread.updated_at,
             kind: "approval.requested",
             payload: {
               summary: "Deploy background fix",
             },
-          },
+          }),
         ],
         next_cursor: null,
         has_more: false,
       },
-    },
+    }),
   };
 
   await page.route("**/api/v1/**", async (route) => {
@@ -176,26 +180,18 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
     const { pathname } = url;
 
     if (pathname === "/api/v1/workspaces" && request.method() === "GET") {
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          items: [workspace],
-          next_cursor: null,
-          has_more: false,
-        }),
+      return fulfillJson(route, {
+        items: [workspace],
+        next_cursor: null,
+        has_more: false,
       });
     }
 
     if (pathname === "/api/v1/workspaces/ws_alpha/threads" && request.method() === "GET") {
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          items: [primaryThread, backgroundThread],
-          next_cursor: null,
-          has_more: false,
-        }),
+      return fulfillJson(route, {
+        items: [primaryThread, backgroundThread],
+        next_cursor: null,
+        has_more: false,
       });
     }
 
@@ -205,18 +201,13 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
       request.method() === "GET"
     ) {
       const threadId = pathname.includes("thread_background") ? "thread_background" : "thread_001";
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(threadViewById[threadId]),
-      });
+      return fulfillJson(route, threadViewById[threadId]);
     }
 
     if (pathname === "/api/v1/requests/req_background" && request.method() === "GET") {
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
+      return fulfillJson(
+        route,
+        mockApprovalRequestDetailFixture({
           request_id: "req_background",
           thread_id: "thread_background",
           turn_id: "turn_background",
@@ -238,7 +229,7 @@ async function mockBackgroundPriorityFlow(page: Parameters<typeof test>[0]["page
             environment: "staging",
           },
         }),
-      });
+      );
     }
 
     return route.abort();

--- a/apps/frontend-bff/e2e/helpers/browser-mocks.ts
+++ b/apps/frontend-bff/e2e/helpers/browser-mocks.ts
@@ -1,11 +1,249 @@
 import type { Page, Route } from "@playwright/test";
 
-function json(route: Route, body: unknown, status = 200) {
+export function fulfillJson(route: Route, body: unknown, status = 200) {
   return route.fulfill({
     status,
     contentType: "application/json",
     body: JSON.stringify(body),
   });
+}
+
+const json = fulfillJson;
+
+export function mockWorkspaceFixture(
+  overrides: Partial<{
+    workspace_id: string;
+    workspace_name: string;
+    created_at: string;
+    updated_at: string;
+    active_session_summary: {
+      session_id: string;
+      status: string;
+      last_message_at: string | null;
+    } | null;
+    pending_approval_count: number;
+  }> = {},
+) {
+  return {
+    workspace_id: "ws_alpha",
+    workspace_name: "alpha",
+    created_at: "2026-04-05T02:20:00Z",
+    updated_at: "2026-04-05T02:21:00Z",
+    active_session_summary: null,
+    pending_approval_count: 0,
+    ...overrides,
+  };
+}
+
+export function mockThreadSummaryFixture(
+  overrides: Partial<{
+    thread_id: string;
+    workspace_id: string;
+    native_status: {
+      thread_status: string;
+      active_flags: string[];
+      latest_turn_status: string | null;
+    };
+    updated_at: string;
+  }> = {},
+) {
+  return {
+    thread_id: "thread_001",
+    workspace_id: "ws_alpha",
+    native_status: {
+      thread_status: "idle",
+      active_flags: [],
+      latest_turn_status: "completed",
+    },
+    updated_at: "2026-04-05T02:21:00Z",
+    ...overrides,
+  };
+}
+
+export function mockThreadListItemFixture(
+  overrides: Partial<{
+    thread_id: string;
+    workspace_id: string;
+    native_status: {
+      thread_status: string;
+      active_flags: string[];
+      latest_turn_status: string | null;
+    };
+    updated_at: string;
+    current_activity: {
+      kind: string;
+      label: string;
+    };
+    badge: {
+      kind: string;
+      label: string;
+    } | null;
+    blocked_cue: {
+      kind: string;
+      label: string;
+    } | null;
+    resume_cue: {
+      reason_kind: string;
+      priority_band: "low" | "medium" | "high" | "highest";
+      label: string;
+    } | null;
+  }> = {},
+) {
+  return {
+    ...mockThreadSummaryFixture(),
+    current_activity: {
+      kind: "waiting_on_user_input",
+      label: "Waiting for your input",
+    },
+    badge: null,
+    blocked_cue: null,
+    resume_cue: {
+      reason_kind: "active_thread",
+      priority_band: "medium" as const,
+      label: "Active now",
+    },
+    ...overrides,
+  };
+}
+
+export function mockTimelineItemFixture(
+  overrides: Partial<{
+    timeline_item_id: string;
+    thread_id: string;
+    turn_id: string | null;
+    item_id: string | null;
+    sequence: number;
+    occurred_at: string;
+    kind: string;
+    payload: Record<string, unknown>;
+  }> = {},
+) {
+  return {
+    timeline_item_id: "evt_001",
+    thread_id: "thread_001",
+    turn_id: null,
+    item_id: null,
+    sequence: 1,
+    occurred_at: "2026-04-05T02:21:00Z",
+    kind: "message.assistant.completed",
+    payload: {
+      summary: "assistant completed",
+      content: "Fixture message",
+    },
+    ...overrides,
+  };
+}
+
+export function mockApprovalRequestFixture(
+  overrides: Partial<{
+    request_id: string;
+    thread_id: string;
+    turn_id: string;
+    item_id: string;
+    request_kind: string;
+    status: "pending" | "resolved";
+    risk_category: string;
+    summary: string;
+    requested_at: string;
+    responded_at?: string | null;
+    decision?: "approved" | "denied" | "pending" | null;
+  }> = {},
+) {
+  return {
+    request_id: "req_001",
+    thread_id: "thread_001",
+    turn_id: "turn_001",
+    item_id: "item_001",
+    request_kind: "approval",
+    status: "pending" as const,
+    risk_category: "external_side_effect",
+    summary: "Run deployment",
+    requested_at: "2026-04-05T02:40:00Z",
+    ...overrides,
+  };
+}
+
+export function mockThreadViewFixture(
+  overrides: Partial<{
+    thread: ReturnType<typeof mockThreadSummaryFixture>;
+    current_activity: {
+      kind: string;
+      label: string;
+    };
+    pending_request: ReturnType<typeof mockApprovalRequestFixture> | null;
+    latest_resolved_request: Record<string, unknown> | null;
+    composer: {
+      accepting_user_input: boolean;
+      interrupt_available: boolean;
+      blocked_by_request: boolean;
+    };
+    timeline: {
+      items: ReturnType<typeof mockTimelineItemFixture>[];
+      next_cursor: string | null;
+      has_more: boolean;
+    };
+  }> = {},
+) {
+  return {
+    thread: mockThreadSummaryFixture(),
+    current_activity: {
+      kind: "waiting_on_user_input",
+      label: "Waiting for your input",
+    },
+    pending_request: null,
+    latest_resolved_request: null,
+    composer: {
+      accepting_user_input: true,
+      interrupt_available: false,
+      blocked_by_request: false,
+    },
+    timeline: {
+      items: [mockTimelineItemFixture()],
+      next_cursor: null,
+      has_more: false,
+    },
+    ...overrides,
+  };
+}
+
+export function mockApprovalRequestDetailFixture(
+  overrides: Partial<{
+    request_id: string;
+    thread_id: string;
+    turn_id: string;
+    item_id: string;
+    request_kind: string;
+    status: "pending" | "resolved";
+    risk_category: string;
+    summary: string;
+    reason: string;
+    operation_summary: string;
+    requested_at: string;
+    responded_at: string | null;
+    decision: "approved" | "denied" | "pending" | null;
+    decision_options: {
+      policy_scope_supported: boolean;
+      default_policy_scope: string;
+    };
+    context: Record<string, unknown>;
+  }> = {},
+) {
+  return {
+    ...mockApprovalRequestFixture(),
+    reason: "Apply the prepared deployment plan.",
+    operation_summary: "Deploy the latest checked-in build to staging.",
+    responded_at: null,
+    decision: null,
+    decision_options: {
+      policy_scope_supported: false,
+      default_policy_scope: "once",
+    },
+    context: {
+      environment: "staging",
+      change_ticket: "CHG-93",
+    },
+    ...overrides,
+  };
 }
 
 type MockEventSourceInstance = {

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-255-e2e-mock-builders](./archive/issue-255-e2e-mock-builders/README.md)
 - [issue-254-test-suite-split](./archive/issue-254-test-suite-split/README.md)
 - [issue-252-css-surface-modules](./archive/issue-252-css-surface-modules/README.md)
 - [issue-253-retire-home-approvals](./archive/issue-253-retire-home-approvals/README.md)

--- a/tasks/archive/issue-255-e2e-mock-builders/README.md
+++ b/tasks/archive/issue-255-e2e-mock-builders/README.md
@@ -1,0 +1,110 @@
+# issue-255-e2e-mock-builders
+
+## Purpose
+
+Consolidate Playwright browser mock fixtures and common thread/request interaction setup so E2E scenarios can reuse builders instead of copying large JSON structures.
+
+## Primary issue
+
+- GitHub Issue: #255
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/frontend-bff/README.md`
+- `tasks/README.md`
+
+## Scope for this package
+
+- Identify a bounded E2E fixture/helper consolidation slice.
+- Introduce focused builders for common workspace, thread, timeline, pending request, or notification mock shapes where they remove real duplication.
+- Keep scenario specs readable and avoid production behavior changes.
+- Preserve existing E2E behavior and validation commands.
+
+## Exit criteria
+
+- At least one duplicated E2E fixture area uses reusable builders rather than copied large JSON structures.
+- Existing affected E2E specs pass or any environment-only blocker is documented with equivalent targeted evidence.
+- Evaluator review and dedicated pre-push validation pass before archive/PR follow-through.
+
+## Work plan
+
+1. Map the current `e2e/helpers/browser-mocks.ts` and specs that duplicate thread/request/notification shapes.
+2. Let the sprint planner choose one bounded helper consolidation slice.
+3. Implement the approved helper/builder extraction and update affected specs.
+4. Run targeted E2E or focused validation plus full BFF checks.
+5. Run evaluator review and dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Sprint planner chose a bounded helper consolidation slice: add shared E2E fixture builders in `apps/frontend-bff/e2e/helpers/browser-mocks.ts` and refactor only `apps/frontend-bff/e2e/background-priority.spec.ts`.
+- Implementation exported `fulfillJson` and added shallow builders:
+  - `mockWorkspaceFixture`
+  - `mockThreadSummaryFixture`
+  - `mockThreadListItemFixture`
+  - `mockThreadViewFixture`
+  - `mockTimelineItemFixture`
+  - `mockApprovalRequestFixture`
+  - `mockApprovalRequestDetailFixture`
+- `background-priority.spec.ts` now uses the builders for workspace, primary/background thread list items, thread views, timeline items, pending request, and request detail while preserving `thread_001`, `thread_background`, `req_background`, timestamps, labels, statuses, `reason`, `operation_summary`, `decision_options`, and `context.environment`.
+- Worker validation passed:
+  - `cd apps/frontend-bff && npm run check`
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+- Default Playwright startup was blocked by an existing process on `127.0.0.1:3001`. The main orchestrator ran the targeted E2E on an isolated manual stack with runtime `127.0.0.1:3101` and BFF `127.0.0.1:3100`, then stopped both servers:
+  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 npm run test:e2e -- background-priority.spec.ts --reporter=line` passed 2 tests.
+  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 npm run test:e2e -- approval-flow.spec.ts chat-flow.spec.ts --reporter=line` passed 6 tests.
+- Sprint evaluator verdict: approved. No findings.
+- Dedicated pre-push validation passed:
+  - `git diff --check`
+  - changed-file and helper marker checks
+  - `cd apps/frontend-bff && npm run check`
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `cd apps/frontend-bff && npm test`
+  - `cd apps/frontend-bff && npm run build`
+
+## Status / handoff notes
+
+- Status: locally complete; archived after evaluator approval and dedicated pre-push validation.
+- Active branch: `issue-255-e2e-mock-builders`.
+- Active worktree: `.worktrees/issue-255-e2e-mock-builders`.
+- PR merge, worktree cleanup, Project `Done`, and Issue close remain pending.
+
+## Completion retrospective
+
+### Completion boundary
+
+Package archive boundary for #255. Issue close remains gated on PR merge to `main`, synced clean parent checkout, worktree cleanup, and GitHub Project update.
+
+### Contract check
+
+- Satisfied: a duplicated E2E fixture area now uses reusable builders rather than copied large JSON structures.
+- Satisfied: existing E2E behavior for the affected scenario and helper compatibility specs passed on an isolated alternate-port stack.
+- Satisfied: production behavior was not changed; the implementation diff is limited to E2E helper/spec files plus package tracking.
+
+### What worked
+
+Keeping the builder extraction focused on one local mock flow avoided a broad E2E harness rewrite while still creating reusable public-shape factories.
+
+### Workflow problems
+
+Default Playwright ports remained occupied, so E2E validation had to use a manual alternate-port runtime/BFF stack.
+
+### Improvements to adopt
+
+When default Playwright startup is blocked by occupied ports, record both the blocked default command and the alternate stack URLs used for validation.
+
+### Skill candidates or skill updates
+
+None.
+
+### Follow-up updates
+
+Future E2E additions should prefer the new `browser-mocks.ts` builders for workspace, thread, timeline, and approval request shapes instead of copying full response JSON.
+
+## Archive conditions
+
+- Sprint evaluator returns `approved`.
+- Dedicated pre-push validation passes.
+- Package evidence and handoff notes are updated.
+- Completion retrospective is recorded.
+- Package is moved to `tasks/archive/issue-255-e2e-mock-builders/` before PR completion tracking.


### PR DESCRIPTION
## Summary
- Export `fulfillJson` and add reusable E2E fixture builders for workspace, thread, timeline, and approval request shapes.
- Refactor the background-priority E2E mock to use the builders while preserving scenario IDs and visible behavior.
- Archive the #255 task package.

## Validation
- `git diff --check`
- `cd apps/frontend-bff && npm run check`
- `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `cd apps/frontend-bff && npm test`
- `cd apps/frontend-bff && npm run build`
- Isolated-stack E2E because default `3001` was occupied:
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 npm run test:e2e -- background-priority.spec.ts --reporter=line`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 npm run test:e2e -- approval-flow.spec.ts chat-flow.spec.ts --reporter=line`

Closes #255