### PR TITLE
test: guard retired route boundaries

### DIFF
--- a/apps/frontend-bff/src/handlers.ts
+++ b/apps/frontend-bff/src/handlers.ts
@@ -12,15 +12,14 @@ export {
   startSession,
   stopSession,
 } from "./handlers/legacy";
+export { getApprovalStream, getSessionStream } from "./handlers/legacy-streams";
 export {
   getPendingRequest,
   getRequestDetail,
   postRequestResponse,
 } from "./handlers/requests";
 export {
-  getApprovalStream,
   getNotificationsStream,
-  getSessionStream,
   getThreadStream,
 } from "./handlers/streams";
 export {

--- a/apps/frontend-bff/src/handlers/legacy-streams.ts
+++ b/apps/frontend-bff/src/handlers/legacy-streams.ts
@@ -1,0 +1,30 @@
+import { toErrorResponse } from "../errors";
+import { mapApprovalStreamEvent, mapEvent } from "../mappings/legacy";
+import type {
+  RuntimeApprovalStreamEventProjection,
+  RuntimeSessionEventProjection,
+} from "../runtime-types";
+import { relaySse } from "./streams";
+
+export async function getSessionStream(request: Request, sessionId: string) {
+  try {
+    return await relaySse<RuntimeSessionEventProjection, ReturnType<typeof mapEvent>>(
+      request,
+      `/api/v1/sessions/${sessionId}/stream`,
+      mapEvent,
+    );
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
+export async function getApprovalStream(request: Request) {
+  try {
+    return await relaySse<
+      RuntimeApprovalStreamEventProjection,
+      ReturnType<typeof mapApprovalStreamEvent>
+    >(request, "/api/v1/approvals/stream", mapApprovalStreamEvent);
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}

--- a/apps/frontend-bff/src/handlers/streams.ts
+++ b/apps/frontend-bff/src/handlers/streams.ts
@@ -1,16 +1,7 @@
 import { logLiveChatDebug } from "../debug";
 import { toErrorResponse } from "../errors";
-import {
-  mapApprovalStreamEvent,
-  mapEvent,
-  mapNotificationEvent,
-  mapThreadStreamEvent,
-} from "../mappings";
-import type {
-  RuntimeApprovalStreamEventProjection,
-  RuntimeNotificationEvent,
-  RuntimeSessionEventProjection,
-} from "../runtime-types";
+import { mapNotificationEvent, mapThreadStreamEvent } from "../mappings";
+import type { RuntimeNotificationEvent, RuntimeSessionEventProjection } from "../runtime-types";
 import { type ActiveRuntimeErrorMapping, parseRuntimeErrorResponse, runtimeClient } from "./shared";
 
 function encodeSseData(data: unknown) {
@@ -164,7 +155,7 @@ function createSseRelayStream<TInput, TOutput>(
   });
 }
 
-async function relaySse<TInput, TOutput>(
+export async function relaySse<TInput, TOutput>(
   request: Request,
   path: string,
   mapper: (value: TInput) => TOutput,
@@ -198,29 +189,6 @@ async function relaySse<TInput, TOutput>(
       connection: "keep-alive",
     },
   });
-}
-
-export async function getSessionStream(request: Request, sessionId: string) {
-  try {
-    return await relaySse<RuntimeSessionEventProjection, ReturnType<typeof mapEvent>>(
-      request,
-      `/api/v1/sessions/${sessionId}/stream`,
-      mapEvent,
-    );
-  } catch (error) {
-    return toErrorResponse(error);
-  }
-}
-
-export async function getApprovalStream(request: Request) {
-  try {
-    return await relaySse<
-      RuntimeApprovalStreamEventProjection,
-      ReturnType<typeof mapApprovalStreamEvent>
-    >(request, "/api/v1/approvals/stream", mapApprovalStreamEvent);
-  } catch (error) {
-    return toErrorResponse(error);
-  }
 }
 
 export async function getThreadStream(request: Request, threadId: string) {

--- a/apps/frontend-bff/tests/architecture-boundaries.test.ts
+++ b/apps/frontend-bff/tests/architecture-boundaries.test.ts
@@ -1,0 +1,632 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(testDir, "..");
+const appDir = path.join(appRoot, "app");
+
+const sourceExtensions = [".ts", ".tsx"];
+const guardedRouteDirectories = [
+  "app/api/v1/home",
+  "app/api/v1/notifications",
+  "app/api/v1/requests",
+  "app/api/v1/threads",
+  "app/api/v1/workspaces",
+];
+
+const allowedFilePaths = new Set(
+  [
+    "app/api/v1/approvals/[approvalId]/approve/route.ts",
+    "app/api/v1/approvals/[approvalId]/deny/route.ts",
+    "app/api/v1/approvals/[approvalId]/route.ts",
+    "app/api/v1/approvals/route.ts",
+    "app/api/v1/approvals/stream/route.ts",
+    "app/api/v1/sessions/[sessionId]/events/route.ts",
+    "app/api/v1/sessions/[sessionId]/messages/route.ts",
+    "app/api/v1/sessions/[sessionId]/route.ts",
+    "app/api/v1/sessions/[sessionId]/start/route.ts",
+    "app/api/v1/sessions/[sessionId]/stop/route.ts",
+    "app/api/v1/sessions/[sessionId]/stream/route.ts",
+    "app/api/v1/workspaces/[workspaceId]/sessions/route.ts",
+    "src/chat-send-recovery.ts",
+    "src/handlers/legacy-streams.ts",
+    "src/handlers/legacy.ts",
+    "src/legacy-types.ts",
+    "src/mappings/legacy.ts",
+    "src/retired-routes.ts",
+    "src/session-status.ts",
+    "tests/chat-send-recovery.test.ts",
+    "tests/routes.test.ts",
+    "tests/session-status.test.ts",
+  ].map((filePath) => toAbsolutePath(filePath)),
+);
+
+const forbiddenModuleMatchers = [
+  /^app\/api\/v1\/sessions(?:\/|$)/,
+  /^app\/api\/v1\/approvals(?:\/|$)/,
+  /^app\/api\/v1\/workspaces\/\[workspaceId\]\/sessions\/route\.ts$/,
+  /^src\/legacy-types\.ts$/,
+  /^src\/handlers\/legacy-streams\.ts$/,
+  /^src\/handlers\/legacy\.ts$/,
+  /^src\/mappings\/legacy\.ts$/,
+];
+
+const forbiddenPathMatchers = [
+  /^\/api\/v1\/sessions(?:\/|$)/,
+  /^\/api\/v1\/approvals(?:\/|$)/,
+  /^\/api\/v1\/workspaces\/(?:\$\{[^}]+\}|[^/]+)\/sessions(?:\/|$|\$\{)/,
+];
+
+type Demand = "all" | Set<string>;
+
+interface ImportEdge {
+  modulePath: string;
+  demand: Demand;
+}
+
+interface ExportEdge {
+  exportName: string;
+  localName: string;
+  modulePath: string;
+  node: ts.ExportDeclaration;
+}
+
+interface ModuleInfo {
+  sourceFile: ts.SourceFile;
+  importEdges: ImportEdge[];
+  exportEdges: ExportEdge[];
+  exportedDeclarationNodes: Map<string, ts.Node>;
+}
+
+interface TraversalState {
+  demand: Demand;
+  scanWholeFile: boolean;
+}
+
+describe("frontend-bff architecture boundaries", () => {
+  it("keeps active v0.9 surfaces off retired routes and public path assumptions", () => {
+    const rootFiles = collectGuardRootFiles();
+    const traversalStates = collectTraversalStates(rootFiles);
+    const violations = [
+      ...collectModuleViolations(traversalStates),
+      ...collectPathViolations(traversalStates),
+    ];
+
+    expect(violations).toEqual([]);
+  });
+
+  it("checks shared barrels by requested export instead of allowing them wholesale", () => {
+    const activeHandlerStates = new Map<string, TraversalState>([
+      [toAbsolutePath("src/handlers.ts"), demandState(["getHome"])],
+    ]);
+    const legacyHandlerStates = new Map<string, TraversalState>([
+      [toAbsolutePath("src/handlers.ts"), demandState(["listSessions"])],
+    ]);
+    const activeMappingStates = new Map<string, TraversalState>([
+      [toAbsolutePath("src/mappings.ts"), demandState(["mapThread"])],
+    ]);
+    const legacyMappingStates = new Map<string, TraversalState>([
+      [toAbsolutePath("src/mappings.ts"), demandState(["mapSession"])],
+    ]);
+
+    expect(collectModuleViolations(activeHandlerStates)).toEqual([]);
+    expect(collectModuleViolations(activeMappingStates)).toEqual([]);
+    expect(collectModuleViolations(legacyHandlerStates)).toEqual([
+      "src/handlers.ts re-exports retired module src/handlers/legacy.ts",
+    ]);
+    expect(collectModuleViolations(legacyMappingStates)).toEqual([
+      "src/mappings.ts re-exports retired module src/mappings/legacy.ts",
+    ]);
+  });
+});
+
+function demandState(exportNames: string[]): TraversalState {
+  return {
+    demand: new Set(exportNames),
+    scanWholeFile: false,
+  };
+}
+
+function collectGuardRootFiles() {
+  const rootFiles = new Set<string>([
+    toAbsolutePath("app/page.tsx"),
+    toAbsolutePath("app/approvals/page.tsx"),
+  ]);
+
+  for (const filePath of walkDirectory(path.join(appDir, "chat"))) {
+    if (isSourceFile(filePath)) {
+      rootFiles.add(filePath);
+    }
+  }
+
+  for (const directory of guardedRouteDirectories) {
+    for (const filePath of walkDirectory(toAbsolutePath(directory))) {
+      if (!isSourceFile(filePath)) {
+        continue;
+      }
+
+      const repoRelativePath = toRepoRelativePath(filePath);
+      if (
+        repoRelativePath === "app/api/v1/workspaces/[workspaceId]/sessions/route.ts" ||
+        repoRelativePath.startsWith("app/api/v1/approvals/") ||
+        repoRelativePath.startsWith("app/api/v1/sessions/")
+      ) {
+        continue;
+      }
+
+      rootFiles.add(filePath);
+    }
+  }
+
+  return rootFiles;
+}
+
+function collectTraversalStates(rootFiles: Set<string>) {
+  const states = new Map<string, TraversalState>();
+  const queue = [...rootFiles];
+
+  for (const filePath of rootFiles) {
+    states.set(filePath, { demand: "all", scanWholeFile: true });
+  }
+
+  while (queue.length > 0) {
+    const filePath = queue.shift();
+    if (!filePath) {
+      continue;
+    }
+
+    const state = states.get(filePath);
+    if (!state) {
+      continue;
+    }
+
+    if (allowedFilePaths.has(filePath) || !fs.existsSync(filePath)) {
+      continue;
+    }
+
+    const moduleInfo = getModuleInfo(filePath);
+
+    for (const edge of moduleInfo.importEdges) {
+      if (allowedFilePaths.has(edge.modulePath)) {
+        continue;
+      }
+
+      if (mergeTraversalState(states, edge.modulePath, edge.demand, false)) {
+        queue.push(edge.modulePath);
+      }
+    }
+
+    for (const edge of moduleInfo.exportEdges) {
+      if (!isExportEdgeRelevant(edge, state.demand) || allowedFilePaths.has(edge.modulePath)) {
+        continue;
+      }
+
+      const nextDemand = edge.localName === "*" ? "all" : new Set([edge.localName]);
+      if (mergeTraversalState(states, edge.modulePath, nextDemand, false)) {
+        queue.push(edge.modulePath);
+      }
+    }
+  }
+
+  return states;
+}
+
+function collectModuleViolations(states: Map<string, TraversalState>) {
+  const violations: string[] = [];
+
+  for (const [filePath, state] of states) {
+    if (allowedFilePaths.has(filePath)) {
+      continue;
+    }
+
+    const moduleInfo = getModuleInfo(filePath);
+
+    for (const importEdge of moduleInfo.importEdges) {
+      const match = matchForbiddenModule(importEdge.modulePath);
+      if (!match) {
+        continue;
+      }
+
+      violations.push(
+        `${toRepoRelativePath(filePath)} imports retired module ${formatRepoPath(match)}`,
+      );
+    }
+
+    for (const exportEdge of moduleInfo.exportEdges) {
+      if (!isExportEdgeRelevant(exportEdge, state.demand)) {
+        continue;
+      }
+
+      const match = matchForbiddenModule(exportEdge.modulePath);
+      if (!match) {
+        continue;
+      }
+
+      violations.push(
+        `${toRepoRelativePath(filePath)} re-exports retired module ${formatRepoPath(match)}`,
+      );
+    }
+  }
+
+  return violations;
+}
+
+function collectPathViolations(states: Map<string, TraversalState>) {
+  const violations: string[] = [];
+
+  for (const [filePath, state] of states) {
+    if (allowedFilePaths.has(filePath)) {
+      continue;
+    }
+
+    const moduleInfo = getModuleInfo(filePath);
+    const ignoredRanges = state.scanWholeFile
+      ? []
+      : collectUnusedExportRanges(moduleInfo, state.demand);
+
+    walkNodes(moduleInfo.sourceFile, (node) => {
+      if (isIgnoredNode(node, ignoredRanges) || isModuleSpecifierNode(node)) {
+        return;
+      }
+
+      const candidate = extractLiteralCandidate(node);
+      if (!candidate) {
+        return;
+      }
+
+      const match = matchForbiddenPath(candidate);
+      if (!match) {
+        return;
+      }
+
+      violations.push(`${toRepoRelativePath(filePath)} uses retired path ${match}`);
+    });
+  }
+
+  return violations;
+}
+
+function getModuleInfo(filePath: string): ModuleInfo {
+  const sourceText = fs.readFileSync(filePath, "utf8");
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+  const importEdges: ImportEdge[] = [];
+  const exportEdges: ExportEdge[] = [];
+  const exportedDeclarationNodes = new Map<string, ts.Node>();
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isImportDeclaration(statement) && ts.isStringLiteral(statement.moduleSpecifier)) {
+      const modulePath = resolveLocalModule(filePath, statement.moduleSpecifier.text);
+      if (!modulePath) {
+        continue;
+      }
+
+      importEdges.push({
+        modulePath,
+        demand: getImportDemand(statement.importClause),
+      });
+      continue;
+    }
+
+    if (ts.isExportDeclaration(statement)) {
+      if (!statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) {
+        continue;
+      }
+
+      const modulePath = resolveLocalModule(filePath, statement.moduleSpecifier.text);
+      if (!modulePath) {
+        continue;
+      }
+
+      if (!statement.exportClause) {
+        exportEdges.push({
+          exportName: "*",
+          localName: "*",
+          modulePath,
+          node: statement,
+        });
+        continue;
+      }
+
+      if (!ts.isNamedExports(statement.exportClause)) {
+        continue;
+      }
+
+      for (const specifier of statement.exportClause.elements) {
+        exportEdges.push({
+          exportName: specifier.name.text,
+          localName: specifier.propertyName?.text ?? specifier.name.text,
+          modulePath,
+          node: statement,
+        });
+      }
+      continue;
+    }
+
+    if (!hasExportModifier(statement)) {
+      continue;
+    }
+
+    for (const [exportName, node] of getExportedDeclarationEntries(statement)) {
+      exportedDeclarationNodes.set(exportName, node);
+    }
+  }
+
+  return {
+    sourceFile,
+    importEdges,
+    exportEdges,
+    exportedDeclarationNodes,
+  };
+}
+
+function mergeTraversalState(
+  states: Map<string, TraversalState>,
+  filePath: string,
+  nextDemand: Demand,
+  scanWholeFile: boolean,
+) {
+  const previous = states.get(filePath);
+  if (!previous) {
+    states.set(filePath, {
+      demand: nextDemand === "all" ? "all" : new Set(nextDemand),
+      scanWholeFile,
+    });
+    return true;
+  }
+
+  const previousDemand = previous.demand;
+  const mergedDemand =
+    previousDemand === "all" || nextDemand === "all"
+      ? "all"
+      : new Set([...previousDemand, ...nextDemand]);
+  const demandChanged =
+    previousDemand !== "all" &&
+    (mergedDemand === "all" || mergedDemand.size !== previousDemand.size);
+  const scanChanged = scanWholeFile && !previous.scanWholeFile;
+
+  if (!demandChanged && !scanChanged) {
+    return false;
+  }
+
+  states.set(filePath, {
+    demand: mergedDemand,
+    scanWholeFile: previous.scanWholeFile || scanWholeFile,
+  });
+  return true;
+}
+
+function collectUnusedExportRanges(moduleInfo: ModuleInfo, demand: Demand) {
+  if (demand === "all") {
+    return [];
+  }
+
+  const activeNodes = new Set<ts.Node>();
+  for (const exportName of demand) {
+    const node = moduleInfo.exportedDeclarationNodes.get(exportName);
+    if (node) {
+      activeNodes.add(node);
+    }
+  }
+
+  const ranges: Array<[number, number]> = [];
+  const addedNodes = new Set<ts.Node>();
+
+  for (const node of moduleInfo.exportedDeclarationNodes.values()) {
+    if (activeNodes.has(node) || addedNodes.has(node)) {
+      continue;
+    }
+
+    addedNodes.add(node);
+    ranges.push([node.getStart(moduleInfo.sourceFile), node.getEnd()]);
+  }
+
+  return ranges;
+}
+
+function getImportDemand(importClause: ts.ImportClause | undefined): Demand {
+  if (!importClause) {
+    return "all";
+  }
+
+  const names = new Set<string>();
+
+  if (importClause.name) {
+    names.add("default");
+  }
+
+  const namedBindings = importClause.namedBindings;
+  if (namedBindings) {
+    if (ts.isNamespaceImport(namedBindings)) {
+      return "all";
+    }
+
+    for (const element of namedBindings.elements) {
+      names.add(element.propertyName?.text ?? element.name.text);
+    }
+  }
+
+  return names.size > 0 ? names : "all";
+}
+
+function getExportedDeclarationEntries(statement: ts.Statement): Array<[string, ts.Node]> {
+  if (ts.isFunctionDeclaration(statement) && statement.name) {
+    return [[statement.name.text, statement]];
+  }
+
+  if (ts.isClassDeclaration(statement) && statement.name) {
+    return [[statement.name.text, statement]];
+  }
+
+  if (ts.isEnumDeclaration(statement)) {
+    return [[statement.name.text, statement]];
+  }
+
+  if (ts.isTypeAliasDeclaration(statement) || ts.isInterfaceDeclaration(statement)) {
+    return [[statement.name.text, statement]];
+  }
+
+  if (ts.isVariableStatement(statement)) {
+    const entries: Array<[string, ts.Node]> = [];
+    for (const declaration of statement.declarationList.declarations) {
+      collectBindingNames(declaration.name, (name) => {
+        entries.push([name, statement]);
+      });
+    }
+    return entries;
+  }
+
+  return [];
+}
+
+function collectBindingNames(name: ts.BindingName, onName: (name: string) => void) {
+  if (ts.isIdentifier(name)) {
+    onName(name.text);
+    return;
+  }
+
+  for (const element of name.elements) {
+    if (ts.isOmittedExpression(element)) {
+      continue;
+    }
+
+    collectBindingNames(element.name, onName);
+  }
+}
+
+function hasExportModifier(node: ts.Node) {
+  return ts.canHaveModifiers(node)
+    ? ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ===
+        true
+    : false;
+}
+
+function isExportEdgeRelevant(edge: ExportEdge, demand: Demand) {
+  return demand === "all" || edge.exportName === "*" || demand.has(edge.exportName);
+}
+
+function resolveLocalModule(fromFilePath: string, specifier: string) {
+  if (specifier.startsWith("@/")) {
+    return resolveModulePath(path.join(appRoot, specifier.slice(2)));
+  }
+
+  if (specifier.startsWith(".")) {
+    return resolveModulePath(path.resolve(path.dirname(fromFilePath), specifier));
+  }
+
+  return null;
+}
+
+function resolveModulePath(candidatePath: string) {
+  const directMatch = sourceExtensions.find((extension) =>
+    candidatePath.endsWith(extension) ? fs.existsSync(candidatePath) : false,
+  );
+  if (directMatch) {
+    return candidatePath;
+  }
+
+  for (const extension of sourceExtensions) {
+    const filePath = `${candidatePath}${extension}`;
+    if (fs.existsSync(filePath)) {
+      return filePath;
+    }
+  }
+
+  for (const extension of sourceExtensions) {
+    const indexPath = path.join(candidatePath, `index${extension}`);
+    if (fs.existsSync(indexPath)) {
+      return indexPath;
+    }
+  }
+
+  return null;
+}
+
+function matchForbiddenModule(filePath: string) {
+  const repoRelativePath = toRepoRelativePath(filePath);
+  return forbiddenModuleMatchers.some((matcher) => matcher.test(repoRelativePath))
+    ? filePath
+    : null;
+}
+
+function matchForbiddenPath(candidate: string) {
+  for (const matcher of forbiddenPathMatchers) {
+    if (matcher.test(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function extractLiteralCandidate(node: ts.Node) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+
+  if (!ts.isTemplateExpression(node)) {
+    return null;
+  }
+
+  return `${node.head.text}${node.templateSpans
+    .map((span) => `\${${span.expression.getText()}}${span.literal.text}`)
+    .join("")}`;
+}
+
+function isIgnoredNode(node: ts.Node, ranges: Array<[number, number]>) {
+  return ranges.some(([start, end]) => node.getStart() >= start && node.getEnd() <= end);
+}
+
+function isModuleSpecifierNode(node: ts.Node) {
+  const parent = node.parent;
+  if (!parent) {
+    return false;
+  }
+
+  return (
+    (ts.isImportDeclaration(parent) || ts.isExportDeclaration(parent)) &&
+    parent.moduleSpecifier === node
+  );
+}
+
+function walkNodes(node: ts.Node, onNode: (node: ts.Node) => void) {
+  onNode(node);
+  ts.forEachChild(node, (child) => {
+    walkNodes(child, onNode);
+  });
+}
+
+function walkDirectory(directoryPath: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
+    const entryPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkDirectory(entryPath));
+      continue;
+    }
+
+    files.push(entryPath);
+  }
+
+  return files;
+}
+
+function isSourceFile(filePath: string) {
+  return sourceExtensions.some((extension) => filePath.endsWith(extension));
+}
+
+function toAbsolutePath(repoRelativePath: string) {
+  return path.join(appRoot, repoRelativePath);
+}
+
+function toRepoRelativePath(filePath: string) {
+  return path.relative(appRoot, filePath).replaceAll(path.sep, "/");
+}
+
+function formatRepoPath(filePath: string) {
+  return toRepoRelativePath(filePath);
+}

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-256-architecture-boundary-checks](./archive/issue-256-architecture-boundary-checks/README.md)
 - [issue-255-e2e-mock-builders](./archive/issue-255-e2e-mock-builders/README.md)
 - [issue-254-test-suite-split](./archive/issue-254-test-suite-split/README.md)
 - [issue-252-css-surface-modules](./archive/issue-252-css-surface-modules/README.md)

--- a/tasks/archive/issue-256-architecture-boundary-checks/README.md
+++ b/tasks/archive/issue-256-architecture-boundary-checks/README.md
@@ -1,0 +1,96 @@
+# issue-256-architecture-boundary-checks
+
+## Purpose
+
+Add lightweight validation that catches accidental active v0.9 dependencies on retired session/approval routes or legacy public path assumptions.
+
+## Primary issue
+
+- GitHub Issue: #256
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Add maintainable static checks or tests in the existing frontend BFF validation toolchain.
+- Guard active app/source/test surfaces from importing retired session/approval route modules.
+- Keep explicit compatibility/retired route tests allowed where they intentionally cover legacy paths.
+
+## Exit criteria
+
+- Existing validation fails if active v0.9 code unintentionally imports retired session/approval route modules.
+- The check is discoverable through normal BFF validation commands.
+- Evaluator review and dedicated pre-push validation pass before archive/PR follow-through.
+
+## Work plan
+
+1. Map retired route modules and active v0.9 source/test surfaces.
+2. Let the sprint planner choose a bounded static guard slice.
+3. Implement the approved check.
+4. Run targeted and full BFF validation.
+5. Run evaluator review and dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Implemented `apps/frontend-bff/tests/architecture-boundaries.test.ts`.
+- Added demand-aware coverage for shared `src/handlers.ts` and `src/mappings.ts` barrels so active exports pass while legacy export demand fails.
+- Split retired session/approval stream handlers into `apps/frontend-bff/src/handlers/legacy-streams.ts`; active stream handlers no longer import legacy mapping names.
+- Worker validation:
+  - `cd apps/frontend-bff && npm test -- tests/architecture-boundaries.test.ts` passed, 2 tests.
+  - `cd apps/frontend-bff && npm test` passed, 14 files / 102 tests.
+  - `cd apps/frontend-bff && npm run check` passed.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+- Evaluator verdict: `approved`.
+- Dedicated pre-push validation: passed `git diff --check`, targeted architecture test, full BFF test, BFF check, BFF tsc, and BFF build.
+
+## Status / handoff notes
+
+- Status: locally complete; ready for PR and merge follow-through.
+- Active branch: `issue-256-architecture-boundary-checks`.
+- Active worktree: `.worktrees/issue-256-architecture-boundary-checks`.
+- Completion tracking, PR merge, worktree cleanup, Project `Done`, and Issue close remain pending.
+
+## Completion retrospective
+
+### Completion boundary
+
+Package archive before PR follow-through for Issue #256.
+
+### Contract check
+
+- Satisfied: active v0.9 route/browser surfaces are guarded by `architecture-boundaries.test.ts` against retired session/approval modules and public path assumptions.
+- Satisfied: the guard runs through existing BFF `npm test` and was included in dedicated pre-push validation.
+- Satisfied: intentionally retired compatibility routes and legacy-specific tests remain quarantined through explicit allowlist entries.
+
+### What worked
+
+- The evaluator caught an important guard weakness where shared barrels were allowlisted wholesale.
+- A narrow regression test now proves requested-export traversal detects legacy barrel demand.
+
+### Workflow problems
+
+- The first implementation missed that retired and active stream handlers shared one module, which pulled legacy mappings into active traversal.
+
+### Improvements to adopt
+
+- For future boundary tests, treat shared barrels and mixed active/legacy modules as first-class risk areas during planning and evaluation.
+
+### Skill candidates or skill updates
+
+None.
+
+### Follow-up updates
+
+None.
+
+## Archive conditions
+
+- Sprint evaluator returns `approved`.
+- Dedicated pre-push validation passes.
+- Package evidence and handoff notes are updated.
+- Completion retrospective is recorded.
+- Package is moved to `tasks/archive/issue-256-architecture-boundary-checks/` before PR completion tracking.


### PR DESCRIPTION
## Summary
- add a frontend-bff architecture boundary test for active v0.9 surfaces versus retired session/approval modules and paths
- traverse shared handlers/mappings barrels by requested export demand instead of allowlisting them wholesale
- split retired session/approval stream handlers into a legacy stream module so active stream handlers avoid legacy mapping imports
- archive the Issue #256 task package with validation evidence and retrospective

## Validation
- cd apps/frontend-bff && npm test -- tests/architecture-boundaries.test.ts
- cd apps/frontend-bff && npm test
- cd apps/frontend-bff && npm run check
- cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- cd apps/frontend-bff && npm run build

Closes #256