### PR TITLE
test: pilot runtime contract guard

### DIFF
--- a/apps/frontend-bff/src/handlers/threads.ts
+++ b/apps/frontend-bff/src/handlers/threads.ts
@@ -10,10 +10,12 @@ import type {
   ListResponse,
   RuntimeThreadInputAcceptedResponse,
   RuntimeThreadInterruptResponse,
+  RuntimeThreadListResponse,
   RuntimeThreadSummary,
   RuntimeThreadViewHelper,
   RuntimeTimelineItem,
 } from "../runtime-types";
+import { runtimeThreadListResponseSchema } from "../runtime-types";
 import {
   forwardSearch,
   jsonResponse,
@@ -24,7 +26,7 @@ import {
 
 export async function listThreads(request: Request, workspaceId: string) {
   try {
-    const result = await runtimeClient.requestJson<ListResponse<RuntimeThreadSummary>>(
+    const result = await runtimeClient.requestJson<RuntimeThreadListResponse>(
       `/api/v1/workspaces/${workspaceId}/threads${forwardSearch(request)}`,
     );
 
@@ -34,7 +36,10 @@ export async function listThreads(request: Request, workspaceId: string) {
       });
     }
 
-    return jsonResponse(result.status, mapThreadList(result.body));
+    return jsonResponse(
+      result.status,
+      mapThreadList(runtimeThreadListResponseSchema.parse(result.body)),
+    );
   } catch (error) {
     return toErrorResponse(error);
   }

--- a/apps/frontend-bff/src/runtime-types.ts
+++ b/apps/frontend-bff/src/runtime-types.ts
@@ -1,3 +1,29 @@
+import { z } from "zod";
+
+export const runtimeThreadSummarySchema = z.object({
+  thread_id: z.string(),
+  workspace_id: z.string(),
+  title: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  native_status: z.object({
+    thread_status: z.string(),
+    active_flags: z.array(z.string()),
+    latest_turn_status: z.string().nullable(),
+  }),
+  derived_hints: z.object({
+    accepting_user_input: z.boolean(),
+    has_pending_request: z.boolean(),
+    blocked_reason: z.string().nullable(),
+  }),
+});
+
+export const runtimeThreadListResponseSchema = z.object({
+  items: z.array(runtimeThreadSummarySchema),
+  next_cursor: z.string().nullable(),
+  has_more: z.boolean(),
+});
+
 export interface RuntimeWorkspaceSummary {
   workspace_id: string;
   workspace_name: string;
@@ -13,23 +39,8 @@ export interface RuntimeWorkspaceSummary {
   pending_approval_count: number;
 }
 
-export interface RuntimeThreadSummary {
-  thread_id: string;
-  workspace_id: string;
-  title: string;
-  created_at: string;
-  updated_at: string;
-  native_status: {
-    thread_status: string;
-    active_flags: string[];
-    latest_turn_status: string | null;
-  };
-  derived_hints: {
-    accepting_user_input: boolean;
-    has_pending_request: boolean;
-    blocked_reason: string | null;
-  };
-}
+export type RuntimeThreadSummary = z.infer<typeof runtimeThreadSummarySchema>;
+export type RuntimeThreadListResponse = z.infer<typeof runtimeThreadListResponseSchema>;
 
 export interface RuntimePendingRequestSummary {
   request_id: string;

--- a/apps/frontend-bff/tests/runtime-thread-contract.test.ts
+++ b/apps/frontend-bff/tests/runtime-thread-contract.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listThreads } from "../src/handlers";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+const validThreadListResponse = {
+  items: [
+    {
+      thread_id: "thread_001",
+      workspace_id: "ws_alpha",
+      title: "Investigate build",
+      created_at: "2026-03-27T05:12:34Z",
+      updated_at: "2026-03-27T05:22:00Z",
+      native_status: {
+        thread_status: "running",
+        active_flags: ["waiting_on_request"],
+        latest_turn_status: "running",
+      },
+      derived_hints: {
+        accepting_user_input: false,
+        has_pending_request: true,
+        blocked_reason: "pending_request",
+      },
+    },
+  ],
+  next_cursor: null,
+  has_more: false,
+};
+
+describe("runtime thread-list contract boundary", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts the runtime thread-list contract before mapping to the public shape", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(validThreadListResponse));
+
+    const response = await listThreads(
+      new Request("http://localhost/api/v1/workspaces/ws_alpha/threads?sort=-updated_at"),
+      "ws_alpha",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      items: [
+        {
+          thread_id: "thread_001",
+          workspace_id: "ws_alpha",
+          title: "Investigate build",
+          native_status: {
+            thread_status: "running",
+            active_flags: ["waiting_on_request"],
+            latest_turn_status: "running",
+          },
+          updated_at: "2026-03-27T05:22:00Z",
+          current_activity: {
+            kind: "waiting_on_approval",
+            label: "Approval required",
+          },
+          badge: {
+            kind: "approval_required",
+            label: "Approval required",
+          },
+          blocked_cue: {
+            kind: "approval_required",
+            label: "Needs your response",
+          },
+          resume_cue: {
+            reason_kind: "waiting_on_approval",
+            priority_band: "highest",
+            label: "Resume here first",
+          },
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+  });
+
+  it("rejects drifted runtime thread-list responses before mapping", async () => {
+    const driftedResponse = {
+      ...validThreadListResponse,
+      items: validThreadListResponse.items.map(({ derived_hints: _derivedHints, ...thread }) => ({
+        ...thread,
+        derived_status: {
+          accepting_user_input: false,
+          has_pending_request: true,
+          blocked_reason: "pending_request",
+        },
+      })),
+    };
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(driftedResponse));
+
+    const response = await listThreads(
+      new Request("http://localhost/api/v1/workspaces/ws_alpha/threads"),
+      "ws_alpha",
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "internal_server_error",
+        message: "unexpected frontend-bff failure",
+        details: {},
+      },
+    });
+  });
+});

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ Read this file first when you need to locate maintained knowledge across source-
 - [docs/specs/codex_webui_common_spec_v0_9.md](./specs/codex_webui_common_spec_v0_9.md): shared API and behavior rules
 - [docs/specs/codex_webui_internal_api_v0_9.md](./specs/codex_webui_internal_api_v0_9.md): maintained internal API contract
 - [docs/specs/codex_webui_public_api_v0_9.md](./specs/codex_webui_public_api_v0_9.md): maintained public API contract
+- [docs/specs/codex_webui_shared_contract_strategy_v0_1.md](./specs/codex_webui_shared_contract_strategy_v0_1.md): maintained near-term decision for reducing runtime/BFF contract drift without root workspace, shared package, generator, or lockfile churn
 - [docs/specs/codex_webui_ui_layout_spec_v0_9.md](./specs/codex_webui_ui_layout_spec_v0_9.md): maintained thread-first desktop/mobile UI layout and interaction structure
 - [docs/validation/app_server_behavior_validation_plan_checklist.md](./validation/app_server_behavior_validation_plan_checklist.md): app-server behavior validation plan
 - [docs/validation/codex_webui_ux_renewal_validation_gates_v0_1.md](./validation/codex_webui_ux_renewal_validation_gates_v0_1.md): maintained UX renewal browser, regression, desktop-inspection, and mobile-reachability validation gates

--- a/docs/log.md
+++ b/docs/log.md
@@ -29,6 +29,26 @@ After the heading, keep the body concise:
 
 ## Entries
 
+## [2026-04-26] ingest | shared contract strategy decision
+
+Source:
+
+- Issue `#259`
+- repo-wide refactor review on runtime/BFF contract drift
+- current two-package app layout without a root workspace or `packages/` directory
+
+Updated:
+
+- `docs/specs/codex_webui_shared_contract_strategy_v0_1.md`
+- `docs/index.md`
+- `docs/log.md`
+
+Notes:
+
+- recorded the near-term decision to defer a physical shared package or generator
+- chose maintained v0.9 API specs plus narrow BFF-local runtime-boundary schemas/tests as the current drift guard
+- documented `GET /api/v1/workspaces/{workspace_id}/threads` as the initial executable contract pilot
+
 ## [2026-04-27] ingest | Issue #253 legacy browser entry redirects
 
 Source:

--- a/docs/specs/codex_webui_shared_contract_strategy_v0_1.md
+++ b/docs/specs/codex_webui_shared_contract_strategy_v0_1.md
@@ -1,0 +1,77 @@
+# Codex WebUI shared contract strategy v0.1
+
+Last updated: 2026-04-26
+
+## 1. Purpose
+
+This document records the near-term shared-contract strategy for reducing drift between `codex-runtime`, `frontend-bff`, and tests during the v0.9 cutover.
+
+The strategy is intentionally narrow. It chooses how the repo should protect active contracts now without introducing package ownership, build, or lockfile changes before those boundaries are stable.
+
+## 2. Current constraints
+
+- `apps/codex-runtime` and `apps/frontend-bff` are separate Node.js/TypeScript packages.
+- The repo does not currently have a root workspace package, root `package.json`, or `packages/` directory.
+- Runtime domain projections and BFF runtime-client/public mapping types overlap, especially for thread, request, timeline, and workspace shapes.
+- The maintained semantic contracts live in the v0.9 internal and public API specifications.
+- Both app packages already use Zod, so executable boundary schemas can be added locally without new dependency or workspace churn.
+
+## 3. Alternatives considered
+
+### 3.1 Root shared package
+
+A root `packages/contracts` package would make shared imports explicit, but it requires workspace ownership, dependency wiring, package manager decisions, and lockfile changes. That is too much surface area for the current refactor slice.
+
+### 3.2 Generated contracts
+
+Generated TypeScript or schema artifacts could eventually reduce drift, but a generator needs a stable source format, generated-file policy, and validation ownership. Those decisions are not yet settled.
+
+### 3.3 Runtime schema export
+
+Exporting runtime schemas directly to the BFF would risk cross-app source imports and unclear dependency direction while runtime internals are still being refined.
+
+### 3.4 BFF-local runtime-boundary schemas
+
+BFF-local schemas duplicate a small part of the semantic contract, but they create executable drift detection at the boundary where runtime JSON enters the public facade. They fit the current two-package repo shape and can be promoted later.
+
+## 4. Decision
+
+For the v0.9 cutover, defer a physical shared package or generator.
+
+Use the maintained v0.9 API specs as the semantic source of truth, and add narrow BFF-local runtime-boundary schemas for high-risk runtime responses when contract drift would otherwise be easy to miss.
+
+Each schema pilot should:
+
+- cover one resource family at a time
+- validate runtime JSON before public mapping
+- keep public response mapping unchanged unless the public spec changes
+- avoid importing runtime source from the BFF or BFF source from the runtime
+- avoid root workspace, package, and lockfile churn
+- include focused tests that prove valid responses pass and drifted responses fail before mapping
+
+## 5. Initial pilot
+
+The initial pilot covers `GET /api/v1/workspaces/{workspace_id}/threads`.
+
+`frontend-bff` validates the runtime `ListResponse<RuntimeThreadSummary>` shape before mapping it to the public thread-list item response. This catches drift such as missing `derived_hints` before the public mapping code can silently consume an invalid runtime payload.
+
+## 6. Promotion criteria
+
+Revisit a shared package or generator when at least two of these become true:
+
+- three or more v0.9 resource families have BFF-local runtime-boundary schemas with repeated structure
+- runtime and BFF package ownership and workspace tooling are settled
+- generated contract artifacts have a clear source of truth and checked-in file policy
+- validation shows repeated drift that local boundary schemas cannot manage cleanly
+
+Until then, keep shared-contract work incremental and executable at the current app boundary.
+
+## 7. Non-goals
+
+- no root `package.json`
+- no `packages/` directory
+- no workspace configuration
+- no new lockfiles
+- no cross-app source imports
+- no broad runtime/public type migration
+- no replacement of the maintained v0.9 API specifications

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-259-shared-contract-strategy](./archive/issue-259-shared-contract-strategy/README.md)
 - [issue-256-architecture-boundary-checks](./archive/issue-256-architecture-boundary-checks/README.md)
 - [issue-255-e2e-mock-builders](./archive/issue-255-e2e-mock-builders/README.md)
 - [issue-254-test-suite-split](./archive/issue-254-test-suite-split/README.md)

--- a/tasks/archive/issue-259-shared-contract-strategy/README.md
+++ b/tasks/archive/issue-259-shared-contract-strategy/README.md
@@ -1,0 +1,105 @@
+# issue-259-shared-contract-strategy
+
+## Purpose
+
+Reduce drift between runtime response shapes, BFF runtime-client types, public mappings, and tests through a deliberate shared-contract strategy.
+
+## Primary issue
+
+- GitHub Issue: #259
+
+## Source docs
+
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `apps/codex-runtime/README.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Evaluate the minimal shared package, schema export, or generated contract approach for current runtime/BFF boundaries.
+- Document the chosen shared-contract decision in the maintained docs.
+- If implementation proceeds, pilot the approach on one narrow v0.9 resource family only.
+- Avoid broad contract migration or lockfile/workspace churn unless the planner proves it is necessary for the pilot.
+
+## Exit criteria
+
+- The repo has a documented shared-contract decision.
+- Any implemented pilot is narrow, validated, and does not destabilize runtime or BFF tests.
+- Evaluator review and dedicated pre-push validation pass before archive/PR follow-through.
+
+## Work plan
+
+1. Inspect existing runtime and BFF contract/type duplication.
+2. Let the sprint planner choose the smallest viable decision/pilot slice.
+3. Implement the approved slice.
+4. Run targeted and app-level validation for touched areas.
+5. Run evaluator review and dedicated pre-push validation before archive/PR follow-through.
+
+## Artifacts / evidence
+
+- Sprint planner selected a maintained decision doc plus a narrow BFF-local runtime-boundary schema pilot for `GET /api/v1/workspaces/{workspace_id}/threads`.
+- Added `docs/specs/codex_webui_shared_contract_strategy_v0_1.md`.
+- Added `runtimeThreadSummarySchema` and `runtimeThreadListResponseSchema` in `apps/frontend-bff/src/runtime-types.ts`.
+- Updated `listThreads` to validate runtime thread-list JSON before public mapping.
+- Added `apps/frontend-bff/tests/runtime-thread-contract.test.ts` for valid thread-list mapping and drift rejection before mapping.
+- Worker validation:
+  - `git diff --check` passed.
+  - `cd apps/frontend-bff && npm run check` passed.
+  - `cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - `cd apps/frontend-bff && node ./node_modules/vitest/vitest.mjs run tests/architecture-boundaries.test.ts tests/routes-workspace-home.test.ts tests/routes.test.ts tests/runtime-thread-contract.test.ts` passed, 4 files / 26 tests.
+  - `cd apps/frontend-bff && npm test` passed, 15 files / 104 tests.
+  - `cd apps/codex-runtime && npm run check` passed.
+  - `cd apps/codex-runtime && npm test` passed, 6 files / 42 tests.
+- Evaluator verdict: `approved`.
+- Dedicated pre-push validation: passed `git diff --check`, BFF check, BFF tsc, targeted BFF tests, full BFF test, BFF build, runtime check, and runtime test.
+
+## Status / handoff notes
+
+- Status: locally complete; ready for PR and merge follow-through.
+- Active branch: `issue-259-shared-contract-strategy`.
+- Active worktree: `.worktrees/issue-259-shared-contract-strategy`.
+- Completion tracking, PR merge, worktree cleanup, Project `Done`, and Issue close remain pending.
+
+## Completion retrospective
+
+### Completion boundary
+
+Package archive before PR follow-through for Issue #259.
+
+### Contract check
+
+- Satisfied: the shared-contract decision is documented at `docs/specs/codex_webui_shared_contract_strategy_v0_1.md`.
+- Satisfied: root workspace/shared package/generator work is explicitly deferred with promotion criteria instead of left ambiguous.
+- Satisfied: the executable pilot is limited to `GET /api/v1/workspaces/{workspace_id}/threads` and validates runtime JSON before public mapping.
+- Satisfied: runtime and BFF validation passed without package/workspace churn.
+
+### What worked
+
+- Planning narrowed a broad architecture issue into a decision plus one executable contract pilot.
+- Keeping the pilot inside the BFF runtime boundary avoided cross-app imports and package manager changes.
+
+### Workflow problems
+
+- The worktree-local `node_modules` symlink was initially created one directory too shallow and had to be corrected before validation.
+
+### Improvements to adopt
+
+- For future worktree setup, use `../../../../apps/<app>/node_modules` from app directories inside `.worktrees/<branch>/`.
+
+### Skill candidates or skill updates
+
+None.
+
+### Follow-up updates
+
+None.
+
+## Archive conditions
+
+- Sprint evaluator returns `approved`.
+- Dedicated pre-push validation passes.
+- Package evidence and handoff notes are updated.
+- Completion retrospective is recorded.
+- Package is moved to `tasks/archive/issue-259-shared-contract-strategy/` before PR completion tracking.


### PR DESCRIPTION
## Summary
- document the near-term shared-contract strategy for the v0.9 runtime/BFF boundary
- add a narrow BFF-local Zod contract guard for workspace thread-list runtime responses
- add focused tests proving valid thread-list mapping and drift rejection before mapping
- archive the Issue #259 task package with validation evidence and retrospective

## Validation
- git diff --check
- cd apps/frontend-bff && npm run check
- cd apps/frontend-bff && node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- cd apps/frontend-bff && node ./node_modules/vitest/vitest.mjs run tests/architecture-boundaries.test.ts tests/routes-workspace-home.test.ts tests/routes.test.ts tests/runtime-thread-contract.test.ts
- cd apps/frontend-bff && npm test
- cd apps/frontend-bff && npm run build
- cd apps/codex-runtime && npm run check
- cd apps/codex-runtime && npm test

Closes #259