### PR TITLE
fix(frontend): remove thread start id toast

### DIFF
--- a/apps/frontend-bff/src/chat-page-client.tsx
+++ b/apps/frontend-bff/src/chat-page-client.tsx
@@ -543,7 +543,6 @@ export function ChatPageClient() {
         thread_id: result.thread.thread_id,
       });
       setComposerDraft("");
-      setStatusMessage(`Started thread ${result.thread.thread_id}.`);
       updateSelectedThreadId(result.thread.thread_id, "create_thread_success");
       await refreshThreads(result.thread.thread_id);
       void convergeStartedThreadSendability(result.thread.thread_id);

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -613,16 +613,7 @@ export function ChatView({
     threadFeedback.isVisible &&
     !selectedThreadView?.pending_request &&
     !selectedThreadView?.latest_resolved_request;
-  const headerStatusDescriptor = threadFeedback.isVisible
-    ? threadFeedback
-    : selectedThreadView &&
-        (selectedThreadView.current_activity.kind === "system_error" ||
-          selectedThreadView.current_activity.kind === "latest_turn_failed")
-      ? {
-          badgeTone: "warning" as const,
-          title: selectedThreadView.current_activity.label,
-        }
-      : null;
+  const showThreadContextLabel = !selectedThreadView || isOpeningSelectedThread;
   const threadHeading = selectedThreadView?.thread.title
     ? selectedThreadView.thread.title
     : isOpeningSelectedThread
@@ -922,23 +913,12 @@ export function ChatView({
             <header>
               <div className="thread-context-row">
                 <div className="thread-context-copy">
-                  <p className="thread-context-label">{threadContextLabel}</p>
+                  {showThreadContextLabel ? (
+                    <p className="thread-context-label">{threadContextLabel}</p>
+                  ) : null}
                   <h2 title={threadHeading}>{threadHeading}</h2>
                 </div>
                 <div className="thread-context-actions">
-                  {headerStatusDescriptor ? (
-                    <span
-                      className={
-                        headerStatusDescriptor.badgeTone === "warning"
-                          ? "status-badge warning"
-                          : headerStatusDescriptor.badgeTone === "success"
-                            ? "status-badge success"
-                            : "status-badge"
-                      }
-                    >
-                      {headerStatusDescriptor.title}
-                    </span>
-                  ) : null}
                   <button
                     aria-label="Thread details"
                     className="secondary-link compact-link icon-button"

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -963,7 +963,7 @@ describe("ChatPageClient", () => {
       });
       await flushUi();
 
-      expect(container.textContent).toContain("Started thread thread_new.");
+      expect(container.textContent).not.toContain("Started thread thread_new.");
       expect(container.textContent).not.toContain("Ready for your next input.");
 
       const followUpTextarea = container.querySelector("#thread-composer-input");
@@ -1622,7 +1622,7 @@ describe("ChatPageClient", () => {
       ),
     ).toBeUndefined();
     expect(container.textContent).toContain("Background work");
-    expect(container.textContent).toContain("Approval required");
+    expect(container.textContent).toContain("Input paused for approval.");
     expect(container.textContent).toContain("Approve request");
     expect(container.textContent).toContain("Deny request");
   });
@@ -1752,7 +1752,7 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
-    expect(container.textContent).toContain("Approval required");
+    expect(container.textContent).toContain("Input paused for approval.");
     expect(container.textContent).not.toContain("Background thread needs attention");
     expect(
       Array.from(container.querySelectorAll("button")).find(

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -230,7 +230,6 @@ describe("ChatView", () => {
     );
 
     expect(markup).toContain("Approval thread");
-    expect(markup).toContain("Approval required");
     expect(markup).toContain("Approve request");
     expect(markup).toContain("Pending request");
     expect(markup).toContain(">Threads<");
@@ -369,14 +368,11 @@ describe("ChatView", () => {
       );
     });
 
-    const headerBadge = container.querySelector(".thread-view-header-stack header .status-badge");
     const inlineFeedbackBadge = container.querySelector(
       ".thread-feedback-card-inline .status-badge",
     );
 
-    expect(headerBadge?.textContent).toContain("Approval required");
-    expect(headerBadge?.className).toContain("warning");
-    expect(headerBadge?.className).not.toContain("success");
+    expect(container.querySelector(".thread-view-header-stack header .status-badge")).toBeNull();
     expect(inlineFeedbackBadge?.textContent).toContain("Approval required");
     expect(inlineFeedbackBadge?.className).toContain("warning");
     expect(inlineFeedbackBadge?.className).not.toContain("success");
@@ -996,6 +992,8 @@ describe("ChatView", () => {
       'button[aria-label="Thread details"]',
     ) as HTMLButtonElement | null;
     expect(detailsButton).toBeDefined();
+    expect(container.querySelector(".thread-view-header-stack header .status-badge")).toBeNull();
+    expect(container.textContent).not.toContain("Started in");
 
     await act(async () => {
       detailsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/tasks/archive/issue-286-thread-header-toast/README.md
+++ b/tasks/archive/issue-286-thread-header-toast/README.md
@@ -1,0 +1,63 @@
+# Issue 286 Thread Header Toast
+
+## Purpose
+
+- Remove user-visible thread-start implementation noise and simplify the selected Thread View header so normal read-and-reply flow stays focused on the Timeline.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/286
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/notes/codex_webui_thread_view_information_architecture_note_v0_1.md`
+- `docs/notes/codex_webui_timeline_contextual_request_and_expansion_note_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Remove visible `Started thread <thread_id>.` success copy from the browser flow.
+- Keep thread identifiers available only through details/debug-oriented surfaces.
+- Remove or reduce the redundant desktop top header when Navigation and Thread View already expose the useful context.
+- Preserve discoverability for exceptional global states such as reconnecting or errors.
+
+## Exit criteria
+
+- Starting a new thread no longer shows a visible success message containing the thread ID.
+- The selected desktop Thread View does not show a redundant workspace/header row during the normal reading flow.
+- Exceptional connection/problem states remain visible in an appropriate global or composer-adjacent surface.
+- Focused tests and relevant validation pass for the changed frontend surface.
+
+## Work plan
+
+- Inspect the current thread-start status and selected-thread header rendering paths.
+- Update the frontend state/rendering so thread-start success IDs are not user-visible.
+- Simplify normal selected-thread header chrome without hiding exceptional states.
+- Add or update focused coverage for the affected rendering behavior.
+- Run the frontend validation commands appropriate for the change.
+
+## Artifacts / evidence
+
+- Sprint evaluator: approved Issue #286 implementation.
+- Pre-push validation:
+  - `npm run check`: passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `node ./node_modules/vitest/vitest.mjs run tests/chat-page-client.test.tsx tests/chat-view.test.tsx`: passed, 2 files / 33 tests.
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: Removed the visible thread-start ID status message, simplified the normal selected Thread View header chrome, kept Thread Details reachable, and preserved exceptional-state feedback through existing global/composer-adjacent surfaces.
+- Completion retrospective:
+  - Completion boundary: package archive, not final Issue close.
+  - Contract check: package exit criteria satisfied by implementation diff, focused tests, evaluator approval, and pre-push validation evidence.
+  - What worked: the issue was narrow enough for one sprint and the existing tests covered the relevant UI seams.
+  - Workflow problems: none requiring docs or skill updates.
+  - Improvements to adopt: keep future UI follow-ups similarly narrow when they come from screenshot review.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: publish via PR, merge to `main`, clean up the worktree, then close Issue #286 and mark Project `Done`.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, pre-push validation has passed, and handoff notes are updated with validation evidence.


### PR DESCRIPTION
## Summary
- remove the visible `Started thread <thread_id>.` status after first input creates a thread
- simplify the normal selected Thread View header by removing the redundant status badge/context label
- archive the Issue #286 task package with validation notes

## Validation
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `node ./node_modules/vitest/vitest.mjs run tests/chat-page-client.test.tsx tests/chat-view.test.tsx`

Closes #286