### PR TITLE
feat(frontend): show approval details inline

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -912,6 +912,36 @@ textarea {
   white-space: pre-wrap;
 }
 
+.timeline-request-inline-details {
+  display: grid;
+  gap: 6px;
+  border: 1px solid rgba(185, 98, 31, 0.14);
+  border-radius: 12px;
+  background: rgba(255, 249, 242, 0.74);
+  padding: 10px 12px;
+}
+
+.timeline-request-inline-summary,
+.timeline-request-inline-note {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+}
+
+.timeline-request-inline-summary strong,
+.timeline-request-inline-note strong {
+  color: var(--text-main);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.timeline-request-inline-summary p,
+.timeline-request-inline-note span {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 .timeline-row-folded .timeline-row-content {
   color: var(--text-muted);
 }
@@ -1348,6 +1378,11 @@ textarea {
 
   .timeline-row-compact {
     padding: 6px 8px;
+  }
+
+  .timeline-request-inline-details {
+    gap: 4px;
+    padding: 8px 9px;
   }
 
   .timeline-row-primary p,

--- a/apps/frontend-bff/src/chat-view-timeline.tsx
+++ b/apps/frontend-bff/src/chat-view-timeline.tsx
@@ -4,6 +4,9 @@ export interface TimelineRequestRowContext {
   state: "pending" | "resolved";
   badgeClassName: string;
   badgeLabel: string;
+  requestSummary: string;
+  requestReason: string | null;
+  requestOperationSummary: string | null;
   showRequestDetailButton: boolean;
   showResponseActions: boolean;
 }
@@ -131,6 +134,28 @@ export function ChatViewTimeline({
                       <span className={requestContext.badgeClassName}>
                         {requestContext.badgeLabel}
                       </span>
+                    </div>
+                  ) : null}
+                  {requestContext?.state === "pending" ? (
+                    <div className="timeline-request-inline-details">
+                      <div className="timeline-request-inline-summary">
+                        <strong>Request summary</strong>
+                        <p>{requestContext.requestSummary}</p>
+                      </div>
+                      {requestContext.requestReason ? (
+                        <p className="timeline-request-inline-note">
+                          <strong>Reason</strong>
+                          <span>{requestContext.requestReason}</span>
+                        </p>
+                      ) : null}
+                      {requestContext.requestOperationSummary ? (
+                        <p className="timeline-request-inline-note">
+                          <strong>Operation</strong>
+                          <code className="artifact-inline">
+                            {requestContext.requestOperationSummary}
+                          </code>
+                        </p>
+                      ) : null}
                     </div>
                   ) : null}
                   {contentPreview.isFoldable ||

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -637,6 +637,9 @@ export function ChatView({
       state: "pending" | "resolved";
       badgeClassName: string;
       badgeLabel: string;
+      requestSummary: string;
+      requestReason: string | null;
+      requestOperationSummary: string | null;
       showRequestDetailButton: boolean;
       showResponseActions: boolean;
     }
@@ -647,6 +650,9 @@ export function ChatView({
       state: "pending",
       badgeClassName: requestSummaryBadgeClass("pending"),
       badgeLabel: "Pending request",
+      requestSummary: selectedThreadView.pending_request.summary,
+      requestReason: selectedRequestDetail?.reason ?? null,
+      requestOperationSummary: selectedRequestDetail?.operation_summary ?? null,
       showRequestDetailButton: selectedRequestDetail !== null,
       showResponseActions: true,
     };
@@ -662,6 +668,9 @@ export function ChatView({
       badgeLabel: `Resolved: ${formatMachineLabel(
         selectedThreadView.latest_resolved_request.decision,
       )}`,
+      requestSummary: selectedRequestDetail?.summary ?? "",
+      requestReason: selectedRequestDetail?.reason ?? null,
+      requestOperationSummary: selectedRequestDetail?.operation_summary ?? null,
       showRequestDetailButton: selectedRequestDetail !== null,
       showResponseActions: false,
     };

--- a/apps/frontend-bff/tests/chat-view-timeline.test.tsx
+++ b/apps/frontend-bff/tests/chat-view-timeline.test.tsx
@@ -306,6 +306,9 @@ describe("ChatViewTimeline", () => {
                 state: "pending",
                 badgeClassName: "status-badge warning",
                 badgeLabel: "Pending request",
+                requestSummary: "Run git push",
+                requestReason: "Codex requests permission to push changes to remote.",
+                requestOperationSummary: "git push origin main",
                 showRequestDetailButton: true,
                 showResponseActions: true,
               },
@@ -316,6 +319,12 @@ describe("ChatViewTimeline", () => {
     });
 
     expect(container.textContent).toContain("Pending request");
+    expect(container.textContent).toContain("Request summary");
+    expect(container.textContent).toContain("Run git push");
+    expect(container.textContent).toContain("Reason");
+    expect(container.textContent).toContain("Codex requests permission to push changes to remote.");
+    expect(container.textContent).toContain("Operation");
+    expect(container.textContent).toContain("git push origin main");
 
     const approveButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Approve request",
@@ -336,5 +345,62 @@ describe("ChatViewTimeline", () => {
     expect(onApproveRequest).toHaveBeenCalledTimes(1);
     expect(onDenyRequest).toHaveBeenCalledTimes(1);
     expect(onOpenRequestDetail).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps resolved request rows compact and action-free", async () => {
+    const groups: TimelineDisplayGroup[] = [
+      {
+        id: "group-turn-resolved",
+        turnId: "turn_resolved",
+        rows: [
+          {
+            id: "row-request",
+            turnId: "turn_resolved",
+            itemId: "item_approval_001",
+            requestId: "req_001",
+            requestState: "resolved",
+            sequence: 4,
+            occurredAt: "2026-03-27T05:24:00Z",
+            label: "Request resolved",
+            content: "Push request was approved",
+            density: "compact",
+            role: "event",
+            timelineItemId: "timeline_request_001",
+            isLive: false,
+            defaultFoldEligible: false,
+            showDetailButton: true,
+            detailActionLabel: "Inspect request",
+          },
+        ],
+      },
+    ];
+
+    await act(async () => {
+      root.render(
+        <ChatViewTimeline
+          {...buildTimelineProps({
+            groups,
+            requestRowContexts: {
+              "row-request": {
+                state: "resolved",
+                badgeClassName: "status-badge success",
+                badgeLabel: "Resolved: approved",
+                requestSummary: "Run git push",
+                requestReason: null,
+                requestOperationSummary: null,
+                showRequestDetailButton: true,
+                showResponseActions: false,
+              },
+            },
+          })}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Resolved: approved");
+    expect(container.textContent).toContain("Inspect request");
+    expect(container.querySelector(".timeline-request-inline-details")).toBeNull();
+    expect(container.textContent).not.toContain("Approve request");
+    expect(container.textContent).not.toContain("Deny request");
   });
 });

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -232,6 +232,12 @@ describe("ChatView", () => {
     expect(markup).toContain("Approval thread");
     expect(markup).toContain("Approve request");
     expect(markup).toContain("Pending request");
+    expect(markup).toContain("Request summary");
+    expect(markup).toContain("Run git push");
+    expect(markup).toContain("Reason");
+    expect(markup).toContain("Codex requests permission to push changes to remote.");
+    expect(markup).toContain("Operation");
+    expect(markup).toContain("git push origin main");
     expect(markup).toContain(">Threads<");
     expect(markup).toContain('aria-label="Thread details"');
     expect(markup).toContain("Input paused for approval.");
@@ -245,6 +251,7 @@ describe("ChatView", () => {
     expect(markup).toContain("Request needs attention");
     expect(markup).toContain("timeline-row-prominent");
     expect(markup).not.toContain("pending-request-card-fallback");
+    expect(markup).toContain("Request detail");
     expect(markup.indexOf("Please explain the diff.")).toBeLessThan(
       markup.indexOf("Approve request"),
     );

--- a/tasks/archive/issue-287-approval-inline-details/README.md
+++ b/tasks/archive/issue-287-approval-inline-details/README.md
@@ -1,0 +1,66 @@
+# Issue 287 Approval Inline Details
+
+## Purpose
+
+- Make pending approval/request Timeline rows actionable by showing the request summary, reason, and operation in context without requiring Thread Details for the common decision path.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/287
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/notes/codex_webui_timeline_contextual_request_and_expansion_note_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Render request summary/message inline on the matching Timeline approval row.
+- Render `Reason` inline when request detail data is available.
+- Render `Operation` inline when `operation_summary` is available.
+- Keep approve/deny actions visible and text-labeled for pending approval rows.
+- Keep Details as the secondary surface for audit/debug metadata and longer structured fields.
+- Preserve compact fallback behavior when no contextual Timeline row can be matched.
+
+## Exit criteria
+
+- Pending approval rows provide enough visible information for the common approve/deny decision path.
+- Inline rows show summary, reason, and operation when the public request detail payload provides them.
+- `Request detail` is no longer required for ordinary approval decisions.
+- Long operation text wraps or truncates without overlapping row actions.
+- Resolved approval rows remain compact and do not show approve/deny actions.
+- Focused frontend tests and pre-push validation pass.
+
+## Work plan
+
+- Inspect request row context rendering and selected request detail plumbing.
+- Extend the matched pending request row rendering to include detail summary, reason, and operation.
+- Preserve resolved-row compactness and fallback request behavior.
+- Add or update focused tests for inline request details and resolved-row action behavior.
+- Run targeted frontend validation.
+
+## Artifacts / evidence
+
+- Sprint evaluator: approved Issue #287 implementation.
+- Pre-push validation:
+  - `npm run check`: passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`: passed.
+  - `node ./node_modules/vitest/vitest.mjs run tests/chat-view.test.tsx tests/chat-view-timeline.test.tsx`: passed, 2 files / 20 tests.
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: Matched pending approval rows now render request summary, reason, and operation inline in the timeline row while keeping approve/deny actions and the secondary `Request detail` affordance visible. Resolved rows remain compact and action-free.
+- Completion retrospective:
+  - Completion boundary: package archive, not final Issue close.
+  - Contract check: package exit criteria satisfied by implementation diff, focused tests, evaluator approval, and pre-push validation evidence.
+  - What worked: existing request row context made the slice small and avoided runtime/API changes.
+  - Workflow problems: none requiring docs or skill updates.
+  - Improvements to adopt: continue threading UI-only follow-ups through display context objects when contracts already expose the needed data.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: publish via PR, merge to `main`, clean up the worktree, then close Issue #287 and mark Project `Done`.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, pre-push validation has passed, and handoff notes are updated with validation evidence.


### PR DESCRIPTION
## Summary
- show pending approval request summary, reason, and operation inline on the matched Timeline row
- keep approve/deny actions visible and keep Request detail as secondary metadata
- preserve compact resolved request rows and fallback request-card behavior

## Validation
- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `node ./node_modules/vitest/vitest.mjs run tests/chat-view.test.tsx tests/chat-view-timeline.test.tsx`

Closes #287