### PR TITLE
Move Codex running progress into active row

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -952,6 +952,47 @@ textarea {
   gap: 8px;
 }
 
+.timeline-row-live-status {
+  align-items: center;
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.timeline-row-live-placeholder .timeline-row-content {
+  min-height: 1.25em;
+}
+
+.timeline-row-live-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 rgba(15, 95, 93, 0.18);
+  animation: timeline-row-live-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes timeline-row-live-pulse {
+  0%,
+  100% {
+    opacity: 0.72;
+    transform: scale(0.92);
+    box-shadow: 0 0 0 0 rgba(15, 95, 93, 0.16);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+    box-shadow: 0 0 0 0.44rem rgba(15, 95, 93, 0.08);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline-row-live-dot {
+    animation: none;
+    box-shadow: none;
+  }
+}
+
 .timeline-request-inline-details {
   display: grid;
   gap: 6px;

--- a/apps/frontend-bff/src/chat-view-timeline.tsx
+++ b/apps/frontend-bff/src/chat-view-timeline.tsx
@@ -36,6 +36,19 @@ function timelineRowClass(row: TimelineDisplayRow) {
 
 const TIMELINE_PREVIEW_LINE_LIMIT = 8;
 const TIMELINE_PREVIEW_CHARACTER_LIMIT = 520;
+const LIVE_ASSISTANT_STATUS_LABEL = "Streaming";
+const LIVE_ASSISTANT_STATUS_A11Y_LABEL = "Codex is streaming progress in this assistant row.";
+
+function liveAssistantRowStatus(row: TimelineDisplayRow) {
+  if (row.isLive && row.role === "assistant") {
+    return {
+      label: LIVE_ASSISTANT_STATUS_LABEL,
+      a11yLabel: LIVE_ASSISTANT_STATUS_A11Y_LABEL,
+    };
+  }
+
+  return null;
+}
 
 function timelineContentPreview(content: string) {
   const lines = content.split(/\r?\n/);
@@ -115,20 +128,37 @@ export function ChatViewTimeline({
                     preview: row.content,
                   };
               const isExpanded = expandedRowIds.has(row.id);
+              const liveAssistantStatus = liveAssistantRowStatus(row);
               const displayedContent =
                 contentPreview.isFoldable && !isExpanded ? contentPreview.preview : row.content;
+              const isLiveAssistantPlaceholder =
+                row.isLive && row.role === "assistant" && displayedContent.length === 0;
 
               return (
                 <article
                   className={`${timelineRowClass(row)}${
                     contentPreview.isFoldable && !isExpanded ? " timeline-row-folded" : ""
-                  }`}
+                  }${isLiveAssistantPlaceholder ? " timeline-row-live-placeholder" : ""}`}
                   key={row.id}
                 >
                   <div className="workspace-meta-row timeline-row-meta">
                     <strong>{row.label}</strong>
-                    <span className="workspace-meta">
-                      {row.isLive ? "Live" : formatTimestamp(row.occurredAt)}
+                    <span
+                      className={
+                        liveAssistantStatus
+                          ? "workspace-meta timeline-row-live-status"
+                          : "workspace-meta"
+                      }
+                    >
+                      {liveAssistantStatus ? (
+                        <>
+                          <span aria-hidden="true" className="timeline-row-live-dot" />
+                          <span>{liveAssistantStatus.label}</span>
+                          <span className="sr-only">{liveAssistantStatus.a11yLabel}</span>
+                        </>
+                      ) : (
+                        formatTimestamp(row.occurredAt)
+                      )}
                     </span>
                   </div>
                   <p className="timeline-row-content">{displayedContent}</p>

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -466,6 +466,82 @@ function findMatchingRequestRow(
   return bestMatch?.row ?? null;
 }
 
+function hasLiveAssistantTimelineRow(groups: TimelineDisplayGroup[]) {
+  return groups.some((group) => group.rows.some((row) => row.role === "assistant" && row.isLive));
+}
+
+function latestTurnIdFromThreadView(threadView: PublicThreadView | null) {
+  if (!threadView) {
+    return null;
+  }
+
+  for (let index = threadView.timeline.items.length - 1; index >= 0; index -= 1) {
+    const turnId = threadView.timeline.items[index]?.turn_id;
+    if (turnId) {
+      return turnId;
+    }
+  }
+
+  return null;
+}
+
+function buildRunningAssistantPlaceholderRow({
+  latestSequence,
+  selectedThreadView,
+}: {
+  latestSequence: number;
+  selectedThreadView: PublicThreadView;
+}): TimelineDisplayRow | null {
+  if (selectedThreadView.current_activity.kind !== "running") {
+    return null;
+  }
+
+  return {
+    id: `timeline:running-placeholder:${selectedThreadView.thread.thread_id}`,
+    turnId: latestTurnIdFromThreadView(selectedThreadView),
+    itemId: null,
+    requestId: null,
+    requestState: null,
+    sequence: latestSequence + 1,
+    occurredAt: null,
+    label: "Codex is responding",
+    content: "",
+    density: "primary",
+    role: "assistant",
+    tone: "codex",
+    timelineItemId: null,
+    isLive: true,
+    defaultFoldEligible: false,
+    showDetailButton: false,
+    detailActionLabel: null,
+  };
+}
+
+function appendTimelineRowToGroups(groups: TimelineDisplayGroup[], row: TimelineDisplayRow | null) {
+  if (!row) {
+    return groups;
+  }
+
+  const nextGroups = groups.map((group) => ({
+    ...group,
+    rows: [...group.rows],
+  }));
+
+  const lastGroup = nextGroups.at(-1) ?? null;
+  if (lastGroup && lastGroup.turnId === row.turnId) {
+    lastGroup.rows.push(row);
+    return nextGroups;
+  }
+
+  nextGroups.push({
+    id: row.turnId ? `turn:${row.turnId}:${row.id}` : `item:${row.id}`,
+    turnId: lastGroup?.turnId === row.turnId ? row.turnId : null,
+    rows: [row],
+  });
+
+  return nextGroups;
+}
+
 export function ChatView({
   workspaceId,
   workspaces,
@@ -552,11 +628,20 @@ export function ChatView({
     streamEvents,
     draftAssistantMessages,
   });
+  const placeholderRunningRow =
+    selectedThreadView && !hasLiveAssistantTimelineRow(timelineModel.groups)
+      ? buildRunningAssistantPlaceholderRow({
+          latestSequence: timelineModel.groups.at(-1)?.rows.at(-1)?.sequence ?? 0,
+          selectedThreadView,
+        })
+      : null;
+  const timelineGroups = appendTimelineRowToGroups(timelineModel.groups, placeholderRunningRow);
+  const hasLiveAssistantRow = hasLiveAssistantTimelineRow(timelineGroups);
   const hasRequestDetailAffordance = selectedRequestDetail !== null;
-  const latestTimelineGroup = timelineModel.groups[timelineModel.groups.length - 1] ?? null;
+  const latestTimelineGroup = timelineGroups[timelineGroups.length - 1] ?? null;
   const latestTimelineRow = latestTimelineGroup?.rows[latestTimelineGroup.rows.length - 1] ?? null;
   const matchedPendingRequestRow = findMatchingRequestRow(
-    timelineModel.groups,
+    timelineGroups,
     selectedThreadView?.pending_request
       ? {
           state: "pending",
@@ -567,7 +652,7 @@ export function ChatView({
       : null,
   );
   const matchedResolvedRequestRow = findMatchingRequestRow(
-    timelineModel.groups,
+    timelineGroups,
     selectedThreadView?.latest_resolved_request
       ? {
           state: "resolved",
@@ -612,7 +697,12 @@ export function ChatView({
   const showInlineThreadFeedback =
     threadFeedback.isVisible &&
     !selectedThreadView?.pending_request &&
-    !selectedThreadView?.latest_resolved_request;
+    !selectedThreadView?.latest_resolved_request &&
+    !(
+      selectedThreadView?.current_activity.kind === "running" &&
+      connectionState === "live" &&
+      hasLiveAssistantRow
+    );
   const showThreadContextLabel = !selectedThreadView || isOpeningSelectedThread;
   const threadHeading = selectedThreadView?.thread.title
     ? selectedThreadView.thread.title
@@ -1101,7 +1191,7 @@ export function ChatView({
               <ChatViewTimeline
                 expandedRowIds={expandedTimelineRows}
                 formatTimestamp={formatTimestamp}
-                groups={timelineModel.groups}
+                groups={timelineGroups}
                 hasLoadedThreadView={selectedThreadView !== null}
                 isRespondingToRequest={isRespondingToRequest}
                 isLoadingThread={isLoadingThread}
@@ -1189,7 +1279,7 @@ export function ChatView({
             threadActivitySummary={threadActivitySummary}
             threadFeedback={threadFeedback}
             threadCount={threads.length}
-            timelineGroups={timelineModel.groups}
+            timelineGroups={timelineGroups}
             refreshHref={refreshHref}
             streamStateLabel={connectionStateLabel}
             workspaceId={workspaceId}

--- a/apps/frontend-bff/tests/chat-view-timeline.test.tsx
+++ b/apps/frontend-bff/tests/chat-view-timeline.test.tsx
@@ -113,9 +113,108 @@ describe("ChatViewTimeline", () => {
     expect(markup).toContain(
       'class="timeline-row timeline-row-prominent timeline-row-event timeline-row-tone-request"',
     );
-    expect(markup).toContain("Live");
+    expect(markup).toContain("Streaming");
+    expect(markup).toContain("Codex is streaming progress in this assistant row.");
     expect(markup).toContain("formatted:2026-03-27T05:21:00Z");
     expect(markup).toContain("Inspect approval context");
+  });
+
+  it("renders live assistant rows with inline streaming status and leaves completed assistant rows timestamped", async () => {
+    const groups: TimelineDisplayGroup[] = [
+      {
+        id: "group-turn-001",
+        turnId: "turn_001",
+        rows: [
+          {
+            id: "row-live-assistant",
+            turnId: "turn_001",
+            itemId: null,
+            requestId: null,
+            requestState: null,
+            sequence: 1,
+            occurredAt: "2026-03-27T05:20:00Z",
+            label: "Codex",
+            content: "Streaming answer",
+            density: "primary",
+            role: "assistant",
+            tone: "codex",
+            timelineItemId: null,
+            isLive: true,
+            defaultFoldEligible: false,
+            showDetailButton: false,
+            detailActionLabel: null,
+          },
+          {
+            id: "row-completed-assistant",
+            turnId: "turn_001",
+            itemId: null,
+            requestId: null,
+            requestState: null,
+            sequence: 2,
+            occurredAt: "2026-03-27T05:21:00Z",
+            label: "Codex",
+            content: "Final answer",
+            density: "primary",
+            role: "assistant",
+            tone: "codex",
+            timelineItemId: null,
+            isLive: false,
+            defaultFoldEligible: false,
+            showDetailButton: false,
+            detailActionLabel: null,
+          },
+        ],
+      },
+    ];
+
+    await act(async () => {
+      root.render(<ChatViewTimeline {...buildTimelineProps({ groups })} />);
+    });
+
+    const liveStatus = container.querySelector(".timeline-row-live-status");
+    expect(liveStatus?.textContent).toContain("Streaming");
+    expect(container.querySelector(".timeline-row-live-status .sr-only")?.textContent).toContain(
+      "Codex is streaming progress in this assistant row.",
+    );
+    expect(container.querySelectorAll(".timeline-row-live-status")).toHaveLength(1);
+    expect(container.textContent).toContain("formatted:2026-03-27T05:21:00Z");
+  });
+
+  it("renders an empty live assistant placeholder row with the same in-row streaming status", () => {
+    const groups: TimelineDisplayGroup[] = [
+      {
+        id: "group-turn-001",
+        turnId: "turn_001",
+        rows: [
+          {
+            id: "row-live-placeholder",
+            turnId: "turn_001",
+            itemId: null,
+            requestId: null,
+            requestState: null,
+            sequence: 1,
+            occurredAt: null,
+            label: "Codex is responding",
+            content: "",
+            density: "primary",
+            role: "assistant",
+            tone: "codex",
+            timelineItemId: null,
+            isLive: true,
+            defaultFoldEligible: false,
+            showDetailButton: false,
+            detailActionLabel: null,
+          },
+        ],
+      },
+    ];
+
+    const markup = renderToStaticMarkup(<ChatViewTimeline {...buildTimelineProps({ groups })} />);
+
+    expect(markup).toContain("timeline-row-live-placeholder");
+    expect(markup).toContain("Codex is responding");
+    expect(markup).toContain("Streaming");
+    expect(markup).toContain("Codex is streaming progress in this assistant row.");
   });
 
   it("renders muted system rows and error rows with their semantic tone classes", () => {

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -385,6 +385,347 @@ describe("ChatView", () => {
     expect(inlineFeedbackBadge?.className).not.toContain("success");
   });
 
+  it("keeps normal running progress inside the live assistant row instead of the thread feedback card", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={null}
+          connectionState="live"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_001"
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Running thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+            },
+            current_activity: {
+              kind: "running",
+              label: "Codex is running",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: false,
+              interrupt_available: true,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [
+                {
+                  timeline_item_id: "evt_live_001",
+                  thread_id: "thread_001",
+                  turn_id: "turn_001",
+                  item_id: "item_live_001",
+                  sequence: 1,
+                  occurred_at: "2026-03-27T05:20:00Z",
+                  kind: "message.assistant.delta",
+                  payload: {
+                    message_id: "message_001",
+                    delta: "Streaming answer",
+                  },
+                },
+              ],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[
+            {
+              thread_id: "thread_001",
+              title: "Running thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+              current_activity: {
+                kind: "running",
+                label: "Codex is running",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+          ]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[
+            {
+              workspace_id: "ws_alpha",
+              workspace_name: "alpha",
+              created_at: "2026-03-27T05:00:00Z",
+              updated_at: "2026-03-27T05:22:00Z",
+              active_session_summary: null,
+              pending_approval_count: 0,
+            },
+          ]}
+        />,
+      );
+    });
+
+    expect(container.querySelector(".thread-feedback-card-inline")).toBeNull();
+    expect(container.textContent).toContain("Streaming");
+    expect(container.textContent).not.toContain("Codex is running");
+    expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
+  });
+
+  it("keeps reconnecting feedback visible when a live assistant row is present", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={null}
+          connectionState="reconnecting"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_001"
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Running thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+            },
+            current_activity: {
+              kind: "running",
+              label: "Codex is running",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: false,
+              interrupt_available: true,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [
+                {
+                  timeline_item_id: "evt_live_001",
+                  thread_id: "thread_001",
+                  turn_id: "turn_001",
+                  item_id: "item_live_001",
+                  sequence: 1,
+                  occurred_at: "2026-03-27T05:20:00Z",
+                  kind: "message.assistant.delta",
+                  payload: {
+                    message_id: "message_001",
+                    delta: "Streaming answer",
+                  },
+                },
+              ],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[
+            {
+              thread_id: "thread_001",
+              title: "Running thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+              current_activity: {
+                kind: "running",
+                label: "Codex is running",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+          ]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[
+            {
+              workspace_id: "ws_alpha",
+              workspace_name: "alpha",
+              created_at: "2026-03-27T05:00:00Z",
+              updated_at: "2026-03-27T05:22:00Z",
+              active_session_summary: null,
+              pending_approval_count: 0,
+            },
+          ]}
+        />,
+      );
+    });
+
+    expect(container.querySelector(".thread-feedback-card-inline")).not.toBeNull();
+    expect(container.textContent).toContain("Reconnecting live updates");
+    expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
+    expect(container.textContent).toContain("Streaming");
+  });
+
+  it("shows the first running progress in the timeline before assistant content arrives", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          backgroundPriorityNotice={null}
+          connectionState="live"
+          draftAssistantMessages={{}}
+          errorMessage={null}
+          isCreatingThread={false}
+          isCreatingWorkspace={false}
+          isInterruptingThread={false}
+          isLoadingThread={false}
+          isLoadingThreads={false}
+          isLoadingWorkspaces={false}
+          isRespondingToRequest={false}
+          isSendingMessage={false}
+          composerDraft=""
+          onApproveRequest={() => {}}
+          onSubmitComposer={() => {}}
+          onCreateWorkspace={() => {}}
+          onDenyRequest={() => {}}
+          onInterruptThread={() => {}}
+          onOpenBackgroundPriorityThread={() => {}}
+          onAskCodex={() => {}}
+          onComposerDraftChange={() => {}}
+          onSelectThread={() => {}}
+          onSelectWorkspace={() => {}}
+          onWorkspaceNameChange={() => {}}
+          selectedRequestDetail={null}
+          selectedThreadId="thread_001"
+          selectedThreadView={{
+            thread: {
+              thread_id: "thread_001",
+              title: "Running thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+            },
+            current_activity: {
+              kind: "running",
+              label: "Codex is running",
+            },
+            pending_request: null,
+            latest_resolved_request: null,
+            composer: {
+              accepting_user_input: false,
+              interrupt_available: true,
+              blocked_by_request: false,
+              input_unavailable_reason: null,
+            },
+            timeline: {
+              items: [],
+              next_cursor: null,
+              has_more: false,
+            },
+          }}
+          statusMessage={null}
+          streamEvents={[]}
+          threads={[
+            {
+              thread_id: "thread_001",
+              title: "Running thread",
+              workspace_id: "ws_alpha",
+              native_status: {
+                thread_status: "running",
+                active_flags: [],
+                latest_turn_status: "running",
+              },
+              updated_at: "2026-03-27T05:22:00Z",
+              current_activity: {
+                kind: "running",
+                label: "Codex is running",
+              },
+              badge: null,
+              blocked_cue: null,
+              resume_cue: null,
+            },
+          ]}
+          workspaceId="ws_alpha"
+          workspaceName=""
+          workspaces={[
+            {
+              workspace_id: "ws_alpha",
+              workspace_name: "alpha",
+              created_at: "2026-03-27T05:00:00Z",
+              updated_at: "2026-03-27T05:22:00Z",
+              active_session_summary: null,
+              pending_approval_count: 0,
+            },
+          ]}
+        />,
+      );
+    });
+
+    expect(container.querySelector(".thread-feedback-card-inline")).toBeNull();
+    expect(container.querySelector(".timeline-row-live-placeholder")).not.toBeNull();
+    expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
+    expect(container.querySelector(".timeline-row-content")?.textContent ?? "").toBe("");
+    expect(container.textContent).toContain("Streaming");
+  });
+
   it("renders transient feedback above the chat panels", () => {
     const markup = renderToStaticMarkup(
       <ChatView

--- a/tasks/issue-289-active-codex-progress/README.md
+++ b/tasks/issue-289-active-codex-progress/README.md
@@ -1,0 +1,58 @@
+# Issue 289 Active Codex Progress
+
+## Purpose
+
+- Show normal Codex running/streaming progress in the active Codex Timeline row instead of as distant global chrome.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/289
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/notes/codex_webui_timeline_contextual_request_and_expansion_note_v0_1.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Render a compact in-row progress indicator for active live Codex/assistant rows.
+- Keep accessible working status text for screen readers.
+- Avoid showing normal running state as prominent global/header copy.
+- Preserve exceptional reconnect/error/global states.
+- Avoid layout shifts between running and completed assistant rows.
+
+## Exit criteria
+
+- Active Codex rows show an in-context progress indicator while streaming/running.
+- Completed Codex rows do not show the running indicator.
+- Reconnect/error states remain discoverable outside the normal progress indicator.
+- Focused frontend tests and pre-push validation pass.
+
+## Work plan
+
+- Inspect active assistant row rendering and live row model state.
+- Add compact progress indicator for live Codex rows.
+- Add focused tests for live versus completed row behavior.
+- Run targeted frontend validation.
+
+## Artifacts / evidence
+
+- Local frontend validation:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `npm test -- chat-view-timeline.test.tsx chat-view.test.tsx`
+- Sprint evaluator: approved.
+- Pre-push validation:
+  - `npm run check` passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - `npm test -- chat-view-timeline.test.tsx chat-view.test.tsx` passed with 26 tests.
+
+## Status / handoff notes
+
+- Status: `pre-push-validated`
+- Notes: Live Codex progress now renders inside active assistant timeline rows with accessible streaming status text, including an empty placeholder row before the first assistant delta arrives. Normal running feedback no longer appears as the inline thread feedback card when a live assistant row is present, while reconnecting and error states remain on the thread feedback surface. Sprint evaluator and pre-push validation passed in the worktree.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, pre-push validation has passed, and handoff notes are updated with validation evidence.


### PR DESCRIPTION
## Summary

- show live Codex progress inside active assistant Timeline rows
- add an empty live assistant placeholder before the first streamed delta
- keep reconnecting and exceptional thread feedback visible

## Validation

- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm test -- chat-view-timeline.test.tsx chat-view.test.tsx

Closes #289