### PR TITLE
fix(frontend-bff): hide live assistant timeline drafts

### DIFF
--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -466,82 +466,6 @@ function findMatchingRequestRow(
   return bestMatch?.row ?? null;
 }
 
-function hasLiveAssistantTimelineRow(groups: TimelineDisplayGroup[]) {
-  return groups.some((group) => group.rows.some((row) => row.role === "assistant" && row.isLive));
-}
-
-function latestTurnIdFromThreadView(threadView: PublicThreadView | null) {
-  if (!threadView) {
-    return null;
-  }
-
-  for (let index = threadView.timeline.items.length - 1; index >= 0; index -= 1) {
-    const turnId = threadView.timeline.items[index]?.turn_id;
-    if (turnId) {
-      return turnId;
-    }
-  }
-
-  return null;
-}
-
-function buildRunningAssistantPlaceholderRow({
-  latestSequence,
-  selectedThreadView,
-}: {
-  latestSequence: number;
-  selectedThreadView: PublicThreadView;
-}): TimelineDisplayRow | null {
-  if (selectedThreadView.current_activity.kind !== "running") {
-    return null;
-  }
-
-  return {
-    id: `timeline:running-placeholder:${selectedThreadView.thread.thread_id}`,
-    turnId: latestTurnIdFromThreadView(selectedThreadView),
-    itemId: null,
-    requestId: null,
-    requestState: null,
-    sequence: latestSequence + 1,
-    occurredAt: null,
-    label: "Codex is responding",
-    content: "",
-    density: "primary",
-    role: "assistant",
-    tone: "codex",
-    timelineItemId: null,
-    isLive: true,
-    defaultFoldEligible: false,
-    showDetailButton: false,
-    detailActionLabel: null,
-  };
-}
-
-function appendTimelineRowToGroups(groups: TimelineDisplayGroup[], row: TimelineDisplayRow | null) {
-  if (!row) {
-    return groups;
-  }
-
-  const nextGroups = groups.map((group) => ({
-    ...group,
-    rows: [...group.rows],
-  }));
-
-  const lastGroup = nextGroups.at(-1) ?? null;
-  if (lastGroup && lastGroup.turnId === row.turnId) {
-    lastGroup.rows.push(row);
-    return nextGroups;
-  }
-
-  nextGroups.push({
-    id: row.turnId ? `turn:${row.turnId}:${row.id}` : `item:${row.id}`,
-    turnId: lastGroup?.turnId === row.turnId ? row.turnId : null,
-    rows: [row],
-  });
-
-  return nextGroups;
-}
-
 export function ChatView({
   workspaceId,
   workspaces,
@@ -628,15 +552,7 @@ export function ChatView({
     streamEvents,
     draftAssistantMessages,
   });
-  const placeholderRunningRow =
-    selectedThreadView && !hasLiveAssistantTimelineRow(timelineModel.groups)
-      ? buildRunningAssistantPlaceholderRow({
-          latestSequence: timelineModel.groups.at(-1)?.rows.at(-1)?.sequence ?? 0,
-          selectedThreadView,
-        })
-      : null;
-  const timelineGroups = appendTimelineRowToGroups(timelineModel.groups, placeholderRunningRow);
-  const hasLiveAssistantRow = hasLiveAssistantTimelineRow(timelineGroups);
+  const timelineGroups = timelineModel.groups;
   const hasRequestDetailAffordance = selectedRequestDetail !== null;
   const latestTimelineGroup = timelineGroups[timelineGroups.length - 1] ?? null;
   const latestTimelineRow = latestTimelineGroup?.rows[latestTimelineGroup.rows.length - 1] ?? null;
@@ -697,12 +613,7 @@ export function ChatView({
   const showInlineThreadFeedback =
     threadFeedback.isVisible &&
     !selectedThreadView?.pending_request &&
-    !selectedThreadView?.latest_resolved_request &&
-    !(
-      selectedThreadView?.current_activity.kind === "running" &&
-      connectionState === "live" &&
-      hasLiveAssistantRow
-    );
+    !selectedThreadView?.latest_resolved_request;
   const showThreadContextLabel = !selectedThreadView || isOpeningSelectedThread;
   const threadHeading = selectedThreadView?.thread.title
     ? selectedThreadView.thread.title

--- a/apps/frontend-bff/src/timeline-display-model.ts
+++ b/apps/frontend-bff/src/timeline-display-model.ts
@@ -431,11 +431,12 @@ export function buildTimelineDisplayModel({
   streamEvents: PublicThreadStreamEvent[];
   draftAssistantMessages: Record<string, string>;
 }): TimelineDisplayModel {
+  void draftAssistantMessages;
+
   const sortedTimelineItems = timelineItems.toSorted(
     (left, right) => left.sequence - right.sequence,
   );
   const rows: TimelineDisplayRow[] = [];
-  const restAssistantKeys = new Set<string>();
   const restCompletedAssistantKeys = new Set<string>();
   const restAssistantContents = new Set<string>();
   const restDedupKeys = new Set<string>();
@@ -477,9 +478,6 @@ export function buildTimelineDisplayModel({
 
     const content = timelineItemContent(item);
     if (isAssistantTimelineItem(item)) {
-      for (const key of timelineAssistantKeys(item)) {
-        restAssistantKeys.add(key);
-      }
       const explicitKey = assistantTimelineKey(item);
       const key: string =
         explicitKey ??
@@ -649,6 +647,10 @@ export function buildTimelineDisplayModel({
     }
 
     const isCompleted = group.completedContent !== null;
+    if (!isCompleted) {
+      continue;
+    }
+
     rows.push({
       id: `assistant:${group.key}`,
       turnId: group.turnId,
@@ -677,6 +679,10 @@ export function buildTimelineDisplayModel({
     }
 
     const isCompleted = group.completedContent !== null;
+    if (!isCompleted) {
+      continue;
+    }
+
     rows.push({
       id: `timeline-assistant:${group.key}`,
       turnId: group.turnId,
@@ -692,32 +698,6 @@ export function buildTimelineDisplayModel({
       tone: "codex",
       timelineItemId: group.timelineItemId,
       isLive: !isCompleted,
-      defaultFoldEligible: false,
-      showDetailButton: false,
-      detailActionLabel: null,
-    });
-  }
-
-  for (const [messageId, content] of Object.entries(draftAssistantMessages)) {
-    if (assistantDeltaGroups.has(messageId) || restAssistantKeys.has(messageId) || !content) {
-      continue;
-    }
-
-    rows.push({
-      id: `draft:${messageId}`,
-      turnId: null,
-      itemId: null,
-      requestId: null,
-      requestState: null,
-      sequence: Number.MAX_SAFE_INTEGER,
-      occurredAt: null,
-      label: timelineDisplayLabel("message.assistant.delta", true),
-      content: `${content}...`,
-      density: "primary",
-      role: "assistant",
-      tone: "codex",
-      timelineItemId: null,
-      isLive: true,
       defaultFoldEligible: false,
       showDetailButton: false,
       detailActionLabel: null,

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -247,7 +247,7 @@ describe("ChatView", () => {
     expect(markup).not.toContain("thread-feedback-card-inline");
     expect(markup).toContain("Please explain the diff.");
     expect(markup).toContain("Updated apps/frontend-bff/src/chat-view.tsx");
-    expect(markup).toContain("Streaming update");
+    expect(markup).not.toContain("Streaming update");
     expect(markup).toContain("Request needs attention");
     expect(markup).toContain("timeline-row-prominent");
     expect(markup).not.toContain("pending-request-card-fallback");
@@ -385,7 +385,7 @@ describe("ChatView", () => {
     expect(inlineFeedbackBadge?.className).not.toContain("success");
   });
 
-  it("keeps normal running progress inside the live assistant row instead of the thread feedback card", async () => {
+  it("keeps normal running progress out of the timeline while assistant content is streaming", async () => {
     await act(async () => {
       root.render(
         <ChatView
@@ -497,13 +497,14 @@ describe("ChatView", () => {
       );
     });
 
-    expect(container.querySelector(".thread-feedback-card-inline")).toBeNull();
-    expect(container.textContent).toContain("Streaming");
-    expect(container.textContent).not.toContain("Codex is running");
-    expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
+    expect(container.querySelector(".thread-feedback-card-inline")).not.toBeNull();
+    expect(container.textContent).toContain("Codex is running");
+    expect(container.textContent).not.toContain("Streaming answer");
+    expect(container.textContent).not.toContain("Streaming");
+    expect(container.querySelector(".timeline-row-live-status")).toBeNull();
   });
 
-  it("keeps reconnecting feedback visible when a live assistant row is present", async () => {
+  it("keeps reconnecting feedback visible without rendering live assistant deltas", async () => {
     await act(async () => {
       root.render(
         <ChatView
@@ -617,11 +618,11 @@ describe("ChatView", () => {
 
     expect(container.querySelector(".thread-feedback-card-inline")).not.toBeNull();
     expect(container.textContent).toContain("Reconnecting live updates");
-    expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
-    expect(container.textContent).toContain("Streaming");
+    expect(container.querySelector(".timeline-row-live-status")).toBeNull();
+    expect(container.textContent).not.toContain("Streaming answer");
   });
 
-  it("shows the first running progress in the timeline before assistant content arrives", async () => {
+  it("does not add a timeline placeholder before assistant content arrives", async () => {
     await act(async () => {
       root.render(
         <ChatView
@@ -719,11 +720,11 @@ describe("ChatView", () => {
       );
     });
 
-    expect(container.querySelector(".thread-feedback-card-inline")).toBeNull();
-    expect(container.querySelector(".timeline-row-live-placeholder")).not.toBeNull();
-    expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
-    expect(container.querySelector(".timeline-row-content")?.textContent ?? "").toBe("");
-    expect(container.textContent).toContain("Streaming");
+    expect(container.querySelector(".thread-feedback-card-inline")).not.toBeNull();
+    expect(container.querySelector(".timeline-row-live-placeholder")).toBeNull();
+    expect(container.querySelector(".timeline-row-live-status")).toBeNull();
+    expect(container.textContent).toContain("Codex is running");
+    expect(container.textContent).not.toContain("Streaming");
   });
 
   it("renders transient feedback above the chat panels", () => {
@@ -1852,7 +1853,7 @@ describe("ChatView", () => {
     expect(container.textContent).not.toContain("New activity is available below.");
   });
 
-  it("keeps following latest activity when live assistant content grows on the same row", async () => {
+  it("does not scroll the timeline for hidden draft assistant content growth", async () => {
     const baseProps = {
       backgroundPriorityNotice: null,
       connectionState: "live" as const,
@@ -1959,7 +1960,7 @@ describe("ChatView", () => {
       );
     });
 
-    expect(scrollRegion.scrollTop).toBe(1400);
+    expect(scrollRegion.scrollTop).toBe(1000);
     expect(container.textContent).not.toContain("New activity is available below.");
   });
 });

--- a/apps/frontend-bff/tests/timeline-display-model.test.ts
+++ b/apps/frontend-bff/tests/timeline-display-model.test.ts
@@ -43,7 +43,7 @@ function rows(model: ReturnType<typeof buildTimelineDisplayModel>) {
 }
 
 describe("timeline display model", () => {
-  it("merges assistant deltas for the same assistant key into one live item in sequence order", () => {
+  it("suppresses assistant deltas until completion", () => {
     const model = buildTimelineDisplayModel({
       timelineItems: [],
       streamEvents: [
@@ -67,15 +67,7 @@ describe("timeline display model", () => {
       draftAssistantMessages: {},
     });
 
-    const modelRows = rows(model);
-    expect(modelRows).toHaveLength(1);
-    expect(modelRows[0]).toMatchObject({
-      label: "Codex is responding",
-      content: "Hi there...",
-      density: "primary",
-      role: "assistant",
-      isLive: true,
-    });
+    expect(rows(model)).toEqual([]);
   });
 
   it("replaces a live assistant draft on completion and dedupes after REST convergence", () => {
@@ -178,7 +170,7 @@ describe("timeline display model", () => {
     ]);
   });
 
-  it("suppresses matching live stream deltas when REST assistant deltas already exist", () => {
+  it("suppresses stored and streamed assistant deltas until completion", () => {
     const model = buildTimelineDisplayModel({
       timelineItems: [
         timelineItem({
@@ -207,14 +199,7 @@ describe("timeline display model", () => {
       draftAssistantMessages: {},
     });
 
-    expect(rows(model)).toEqual([
-      expect.objectContaining({
-        id: "timeline-assistant:message_001",
-        content: "Partial...",
-        isLive: true,
-        showDetailButton: false,
-      }),
-    ]);
+    expect(rows(model)).toEqual([]);
   });
 
   it("collapses stored assistant deltas and completion into one logical assistant row", () => {


### PR DESCRIPTION
## Summary
- suppress incomplete assistant deltas and draft assistant messages from Timeline rows
- remove the running assistant placeholder row that showed `Codex is responding` / `Streaming` before content arrived
- keep running/reconnecting feedback outside Timeline while Codex is still streaming

## Validation
- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- npm test -- timeline-display-model.test.ts chat-view.test.tsx

Note: the dedicated pre-push validator agent was not spawned because this session disallows sub-agent use without an explicit user request; the same read-only validation commands were run directly.