### PR TITLE
fix(frontend-bff): simplify chat column status surfaces

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -315,27 +315,6 @@ textarea {
   padding: 12px;
 }
 
-.chat-topbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-width: 0;
-}
-
-.chat-topbar h1 {
-  margin: 0;
-  font-size: 1.45rem;
-  line-height: 1.1;
-}
-
-.chat-topbar-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
 .chat-layout {
   display: grid;
   gap: 12px;
@@ -688,57 +667,12 @@ textarea {
   overflow-wrap: anywhere;
 }
 
-.thread-feedback-card {
-  display: grid;
-  gap: 12px;
-  border: 1px solid rgba(22, 47, 52, 0.08);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.82);
-  padding: 14px;
-}
-
-.thread-feedback-card-inline {
-  gap: 8px;
-  padding: 10px 12px;
-}
-
-.thread-feedback-card-inline .workspace-status {
-  font-size: 0.95rem;
-}
-
-.thread-feedback-card .workspace-status {
-  margin: 0;
-}
-
-.thread-feedback-actions {
-  margin-top: 0;
-}
-
-.thread-feedback-card-inline .workspace-meta-row {
-  justify-content: flex-start;
-}
-
 .thread-view-scroll-region {
   display: grid;
   gap: 12px;
   min-height: 0;
   overflow: auto;
   padding-bottom: 12px;
-}
-
-.latest-activity-cta {
-  position: sticky;
-  bottom: 0;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  border: 1px solid rgba(22, 47, 52, 0.1);
-  border-radius: 14px;
-  background: rgba(249, 252, 252, 0.98);
-  box-shadow: 0 10px 24px rgba(17, 31, 39, 0.08);
-  padding: 10px 12px;
 }
 
 /* Timeline */
@@ -774,14 +708,6 @@ textarea {
     0 -10px 24px rgba(226, 236, 237, 0.55);
 }
 
-.composer-guidance {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.92rem;
-  line-height: 1.4;
-  padding: 0 2px;
-}
-
 .chat-textarea {
   width: 100%;
   min-height: 120px;
@@ -812,6 +738,22 @@ textarea {
 
 .composer-submit-icon {
   flex-shrink: 0;
+}
+
+.chat-composer-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 1.2rem;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  line-height: 1.3;
+  padding: 0 2px;
+}
+
+.chat-composer-status-segment {
+  display: inline-flex;
+  align-items: center;
 }
 
 .chat-message,
@@ -1237,23 +1179,9 @@ textarea {
     padding: 10px;
   }
 
-  .chat-topbar {
-    align-items: flex-start;
-    gap: 10px;
-  }
-
-  .chat-topbar h1 {
-    font-size: 1.28rem;
-    overflow-wrap: anywhere;
-  }
-
-  .chat-topbar-actions {
-    max-width: 44%;
-  }
-
   .chat-layout {
     height: 100%;
-    min-height: calc(100dvh - 84px);
+    min-height: 0;
     overflow: hidden;
   }
 
@@ -1358,7 +1286,6 @@ textarea {
   }
 
   /* Request / Feedback */
-  .thread-feedback-card,
   .request-detail-card,
   .chat-composer {
     border-radius: 16px;
@@ -1408,12 +1335,6 @@ textarea {
   }
 
   /* Timeline */
-  .latest-activity-cta {
-    align-items: stretch;
-    border-radius: 16px;
-    padding: 7px 9px;
-  }
-
   .timeline-section {
     gap: 8px;
   }
@@ -1468,11 +1389,6 @@ textarea {
     padding: 0 0 calc(env(safe-area-inset-bottom)) 0;
   }
 
-  .composer-guidance {
-    font-size: 0.86rem;
-    line-height: 1.3;
-  }
-
   .composer-input-frame {
     border-radius: 18px;
   }
@@ -1480,6 +1396,10 @@ textarea {
   .composer-submit-button {
     right: 8px;
     bottom: 8px;
+  }
+
+  .chat-composer-status {
+    font-size: 0.78rem;
   }
 
   /* Foundation / Shared Primitives */
@@ -1503,7 +1423,6 @@ textarea {
   }
 
   /* Utilities */
-  .thread-feedback-actions,
   .pending-request-card .workspace-actions,
   .request-detail-actions {
     gap: 6px;
@@ -1526,18 +1445,9 @@ textarea {
     padding: 0;
   }
 
-  .chat-topbar,
   .chat-layout {
     width: 100%;
     justify-self: stretch;
-  }
-
-  .chat-topbar h1 {
-    font-size: 1.35rem;
-  }
-
-  .chat-topbar {
-    padding: 18px 22px 10px;
   }
 
   /* Navigation */

--- a/apps/frontend-bff/src/chat-view-composer.tsx
+++ b/apps/frontend-bff/src/chat-view-composer.tsx
@@ -2,9 +2,9 @@ import type { RefObject } from "react";
 
 export interface ChatViewComposerProps {
   composerDraft: string;
-  composerGuidance: string | null;
   composerInputLabel: string;
   composerPlaceholder: string;
+  composerStatusSegments: string[];
   composerSubmitLabel: string;
   isComposerDisabled: boolean;
   isStartingThread: boolean;
@@ -16,9 +16,9 @@ export interface ChatViewComposerProps {
 
 export function ChatViewComposer({
   composerDraft,
-  composerGuidance,
   composerInputLabel,
   composerPlaceholder,
+  composerStatusSegments,
   composerSubmitLabel,
   isComposerDisabled,
   isStartingThread,
@@ -81,10 +81,14 @@ export function ChatViewComposer({
           </svg>
         </button>
       </label>
-      {composerGuidance ? (
-        <p className="composer-guidance" role="status">
-          {composerGuidance}
-        </p>
+      {composerStatusSegments.length > 0 ? (
+        <div className="chat-composer-status" role="status">
+          {composerStatusSegments.map((segment) => (
+            <span className="chat-composer-status-segment" key={segment}>
+              {segment}
+            </span>
+          ))}
+        </div>
       ) : null}
     </div>
   );

--- a/apps/frontend-bff/src/chat-view-timeline.tsx
+++ b/apps/frontend-bff/src/chat-view-timeline.tsx
@@ -76,9 +76,6 @@ function timelineContentPreview(content: string) {
 }
 
 export function ChatViewTimeline({
-  isLoadingThread,
-  selectedThreadId,
-  hasLoadedThreadView,
   groups,
   expandedRowIds,
   formatTimestamp,
@@ -92,21 +89,7 @@ export function ChatViewTimeline({
 }: ChatViewTimelineProps) {
   return (
     <section aria-label="Timeline" className="timeline-section">
-      {isLoadingThread ? (
-        <p className="workspace-status">
-          {selectedThreadId
-            ? "Opening this thread and restoring its latest timeline..."
-            : "Preparing thread view..."}
-        </p>
-      ) : null}
-
       <div className="chat-message-list">
-        {!isLoadingThread && hasLoadedThreadView && groups.length === 0 ? (
-          <p className="empty-state">
-            No timeline items yet. Start the thread or send follow-up input to continue.
-          </p>
-        ) : null}
-
         {groups.map((group) => (
           <section
             className={group.turnId ? "timeline-turn-group" : "timeline-ungrouped-item"}

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -23,7 +23,10 @@ import type {
   PublicThreadView,
 } from "./thread-types";
 import type { TimelineDisplayGroup, TimelineDisplayRow } from "./timeline-display-model";
-import { buildTimelineDisplayModel } from "./timeline-display-model";
+import {
+  buildTimelineDisplayModel,
+  filterTimelineDisplayGroupsForChat,
+} from "./timeline-display-model";
 import { getTimelineItemDetail } from "./timeline-item-detail";
 
 export interface ChatViewProps {
@@ -74,17 +77,6 @@ function formatTimestamp(value: string | null) {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(value));
-}
-
-function formatConnectionStateLabel(connectionState: "idle" | "live" | "reconnecting") {
-  switch (connectionState) {
-    case "live":
-      return "Live";
-    case "reconnecting":
-      return "Reconnecting";
-    default:
-      return "Idle";
-  }
 }
 
 function threadChatHref(workspaceId: string, threadId?: string) {
@@ -179,18 +171,6 @@ function currentActivitySummary(
     default:
       return formatMachineLabel(threadView.current_activity.kind);
   }
-}
-
-function threadFeedbackBadgeClass(descriptor: ThreadFeedbackDescriptor) {
-  if (descriptor.badgeTone === "success") {
-    return "status-badge success";
-  }
-
-  if (descriptor.badgeTone === "warning") {
-    return "status-badge warning";
-  }
-
-  return "status-badge";
 }
 
 function buildThreadFeedbackDescriptor({
@@ -562,7 +542,6 @@ export function ChatView({
   isRespondingToRequest,
   connectionState,
   errorMessage,
-  statusMessage,
   workspaceName,
   composerDraft,
   onWorkspaceNameChange,
@@ -581,11 +560,7 @@ export function ChatView({
   const [detailSelection, setDetailSelection] = useState<ThreadDetailSelection | null>(null);
   const [sidebarMode, setSidebarMode] = useState<SidebarMode>("full");
   const [expandedTimelineRows, setExpandedTimelineRows] = useState<Set<string>>(() => new Set());
-  const [followLatestActivity, setFollowLatestActivity] = useState(true);
-  const [hasSuppressedActivity, setHasSuppressedActivity] = useState(false);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
-  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
-  const latestActivitySignatureRef = useRef<string | null>(null);
   const selectedWorkspace =
     workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
   const hasSelectedThread = selectedThreadId !== null;
@@ -607,11 +582,6 @@ export function ChatView({
       ? "Describe the task to start a new thread."
       : "Ask a follow-up question or continue the work.";
   const composerSubmitLabel = isStartingThread ? "Start thread" : "Send message";
-  const composerGuidance = !workspaceId
-    ? "Select a workspace to enable input."
-    : isOpeningSelectedThread
-      ? "Opening selected thread."
-      : unavailableReason;
   const isComposerTextareaDisabled =
     !workspaceId || isOpeningSelectedThread || isSubmittingComposer || Boolean(unavailableReason);
   const selectedTimelineItem =
@@ -623,23 +593,21 @@ export function ChatView({
   const selectedTimelineItemDetail = selectedTimelineItem
     ? getTimelineItemDetail(selectedTimelineItem)
     : null;
-  const timelineModel = buildTimelineDisplayModel({
+  const detailTimelineModel = buildTimelineDisplayModel({
     timelineItems: selectedThreadView?.timeline.items ?? [],
     streamEvents,
     draftAssistantMessages,
   });
+  const chatTimelineGroupsBase = filterTimelineDisplayGroupsForChat(detailTimelineModel.groups);
   const placeholderRunningRow =
-    selectedThreadView && !hasLiveAssistantTimelineRow(timelineModel.groups)
+    selectedThreadView && !hasLiveAssistantTimelineRow(chatTimelineGroupsBase)
       ? buildRunningAssistantPlaceholderRow({
-          latestSequence: timelineModel.groups.at(-1)?.rows.at(-1)?.sequence ?? 0,
+          latestSequence: chatTimelineGroupsBase.at(-1)?.rows.at(-1)?.sequence ?? 0,
           selectedThreadView,
         })
       : null;
-  const timelineGroups = appendTimelineRowToGroups(timelineModel.groups, placeholderRunningRow);
-  const hasLiveAssistantRow = hasLiveAssistantTimelineRow(timelineGroups);
+  const timelineGroups = appendTimelineRowToGroups(chatTimelineGroupsBase, placeholderRunningRow);
   const hasRequestDetailAffordance = selectedRequestDetail !== null;
-  const latestTimelineGroup = timelineGroups[timelineGroups.length - 1] ?? null;
-  const latestTimelineRow = latestTimelineGroup?.rows[latestTimelineGroup.rows.length - 1] ?? null;
   const matchedPendingRequestRow = findMatchingRequestRow(
     timelineGroups,
     selectedThreadView?.pending_request
@@ -662,20 +630,6 @@ export function ChatView({
         }
       : null,
   );
-  const latestActivitySignature = selectedThreadId
-    ? JSON.stringify({
-        connectionState,
-        currentActivity: selectedThreadView?.current_activity.kind ?? null,
-        latestResolvedRequest: selectedThreadView?.latest_resolved_request?.request_id ?? null,
-        latestRowContent: latestTimelineRow?.content ?? null,
-        latestRowId: latestTimelineRow?.id ?? null,
-        latestRowIsLive: latestTimelineRow?.isLive ?? null,
-        latestRowSequence: latestTimelineRow?.sequence ?? null,
-        pendingRequest: selectedThreadView?.pending_request?.request_id ?? null,
-        selectedThreadId,
-        statusMessage,
-      })
-    : null;
   const threadFeedback = buildThreadFeedbackDescriptor({
     composerAcceptingInput: isThreadAcceptingInput,
     connectionState,
@@ -692,17 +646,7 @@ export function ChatView({
   const threadActivitySummary = workspaceId
     ? currentActivitySummary(selectedThreadView, isOpeningSelectedThread)
     : "Choose a workspace to enable the composer.";
-  const connectionStateLabel = formatConnectionStateLabel(connectionState);
   const isSidebarMinibar = sidebarMode === "mini" && !isNavigationOpen;
-  const showInlineThreadFeedback =
-    threadFeedback.isVisible &&
-    !selectedThreadView?.pending_request &&
-    !selectedThreadView?.latest_resolved_request &&
-    !(
-      selectedThreadView?.current_activity.kind === "running" &&
-      connectionState === "live" &&
-      hasLiveAssistantRow
-    );
   const showThreadContextLabel = !selectedThreadView || isOpeningSelectedThread;
   const threadHeading = selectedThreadView?.thread.title
     ? selectedThreadView.thread.title
@@ -790,35 +734,6 @@ export function ChatView({
     setExpandedTimelineRows(new Set());
   }, [selectedThreadId]);
 
-  useEffect(() => {
-    latestActivitySignatureRef.current = null;
-    setFollowLatestActivity(true);
-    setHasSuppressedActivity(false);
-  }, [selectedThreadId]);
-
-  useEffect(() => {
-    if (!selectedThreadId || latestActivitySignature === null) {
-      latestActivitySignatureRef.current = latestActivitySignature;
-      return;
-    }
-
-    const previousSignature = latestActivitySignatureRef.current;
-    latestActivitySignatureRef.current = latestActivitySignature;
-
-    if (followLatestActivity) {
-      const scrollRegion = scrollRegionRef.current;
-      if (scrollRegion) {
-        scrollRegion.scrollTop = scrollRegion.scrollHeight;
-      }
-      setHasSuppressedActivity(false);
-      return;
-    }
-
-    if (previousSignature !== null && previousSignature !== latestActivitySignature) {
-      setHasSuppressedActivity(true);
-    }
-  }, [followLatestActivity, latestActivitySignature, selectedThreadId]);
-
   function selectThread(threadId: string) {
     onSelectThread(threadId);
     setIsNavigationOpen(false);
@@ -837,33 +752,8 @@ export function ChatView({
     }
   }
 
-  function handleScrollRegionScroll() {
-    const scrollRegion = scrollRegionRef.current;
-    if (!scrollRegion) {
-      return;
-    }
-
-    const distanceFromBottom =
-      scrollRegion.scrollHeight - scrollRegion.scrollTop - scrollRegion.clientHeight;
-    const isNearBottom = distanceFromBottom <= 48;
-
-    setFollowLatestActivity(isNearBottom);
-    if (isNearBottom) {
-      setHasSuppressedActivity(false);
-    }
-  }
-
   function focusComposer() {
     composerRef.current?.focus();
-  }
-
-  function jumpToLatestActivity() {
-    const scrollRegion = scrollRegionRef.current;
-    if (scrollRegion) {
-      scrollRegion.scrollTop = scrollRegion.scrollHeight;
-    }
-    setFollowLatestActivity(true);
-    setHasSuppressedActivity(false);
   }
 
   function toggleTimelineRowExpansion(rowId: string) {
@@ -955,33 +845,12 @@ export function ChatView({
 
   return (
     <main className="chat-shell">
-      <header className="chat-topbar">
-        <div>
-          <h1>{selectedWorkspace?.workspace_name ?? "Thread workspace"}</h1>
-        </div>
-        <div className="chat-topbar-actions">
-          <button
-            className="secondary-link action-button navigation-toggle"
-            onClick={() => setIsNavigationOpen((currentValue) => !currentValue)}
-            type="button"
-          >
-            {isNavigationOpen ? "Close threads" : "Threads"}
-          </button>
-        </div>
-      </header>
       <div className={isSidebarMinibar ? "chat-layout sidebar-minibar" : "chat-layout"}>
-        {errorMessage || statusMessage ? (
+        {errorMessage ? (
           <div aria-live="polite" className="chat-feedback-stack">
-            {errorMessage ? (
-              <p className="error-banner" role="alert">
-                {errorMessage}
-              </p>
-            ) : null}
-            {statusMessage ? (
-              <p className="status-message" role="status">
-                {statusMessage}
-              </p>
-            ) : null}
+            <p className="error-banner" role="alert">
+              {errorMessage}
+            </p>
           </div>
         ) : null}
         <ChatViewNavigation
@@ -1061,23 +930,7 @@ export function ChatView({
           </div>
 
           <div className="thread-view-body">
-            <div
-              className="thread-view-scroll-region"
-              onScroll={handleScrollRegionScroll}
-              ref={scrollRegionRef}
-            >
-              {hasSuppressedActivity && latestTimelineRow ? (
-                <div className="latest-activity-cta">
-                  <span className="workspace-meta">New activity is available below.</span>
-                  <button
-                    className="secondary-link action-button compact-button"
-                    onClick={jumpToLatestActivity}
-                    type="button"
-                  >
-                    Jump to latest activity
-                  </button>
-                </div>
-              ) : null}
+            <div className="thread-view-scroll-region">
               {fallbackPendingRequestSummary ? (
                 <div className="request-detail-card pending-request-card pending-request-card-fallback">
                   <div className="workspace-meta-row">
@@ -1172,22 +1025,6 @@ export function ChatView({
                 </div>
               ) : null}
 
-              {showInlineThreadFeedback ? (
-                <div className="thread-feedback-card thread-feedback-card-inline">
-                  <div className="workspace-meta-row">
-                    <span className={threadFeedbackBadgeClass(threadFeedback)}>
-                      {threadFeedback.title}
-                    </span>
-                  </div>
-                  <p className="workspace-status">{threadFeedback.summary}</p>
-                  {threadFeedback.actions.length > 0 ? (
-                    <div className="workspace-actions thread-feedback-actions">
-                      {threadFeedback.actions.map((action) => renderThreadFeedbackAction(action))}
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
-
               <ChatViewTimeline
                 expandedRowIds={expandedTimelineRows}
                 formatTimestamp={formatTimestamp}
@@ -1236,9 +1073,11 @@ export function ChatView({
 
             <ChatViewComposer
               composerDraft={composerDraft}
-              composerGuidance={composerGuidance}
               composerInputLabel={composerInputLabel}
               composerPlaceholder={composerPlaceholder}
+              composerStatusSegments={
+                selectedWorkspace?.workspace_name ? [selectedWorkspace.workspace_name] : []
+              }
               composerSubmitLabel={composerSubmitLabel}
               isComposerDisabled={isComposerDisabled}
               isStartingThread={isStartingThread}
@@ -1252,7 +1091,7 @@ export function ChatView({
 
         {detailSelection ? (
           <ChatViewDetails
-            composerGuidance={composerGuidance}
+            composerGuidance={unavailableReason}
             formatMachineLabel={formatMachineLabel}
             formatTimestamp={formatTimestamp}
             isOpeningSelectedThread={isOpeningSelectedThread}
@@ -1279,9 +1118,15 @@ export function ChatView({
             threadActivitySummary={threadActivitySummary}
             threadFeedback={threadFeedback}
             threadCount={threads.length}
-            timelineGroups={timelineGroups}
+            timelineGroups={detailTimelineModel.groups}
             refreshHref={refreshHref}
-            streamStateLabel={connectionStateLabel}
+            streamStateLabel={
+              connectionState === "live"
+                ? "Live"
+                : connectionState === "reconnecting"
+                  ? "Reconnecting"
+                  : "Idle"
+            }
             workspaceId={workspaceId}
           />
         ) : null}

--- a/apps/frontend-bff/src/timeline-display-model.ts
+++ b/apps/frontend-bff/src/timeline-display-model.ts
@@ -37,6 +37,19 @@ export interface TimelineDisplayModel {
   groups: TimelineDisplayGroup[];
 }
 
+export function isChatTimelineRowVisible(row: TimelineDisplayRow) {
+  return row.role === "user" || row.role === "assistant" || row.tone === "request";
+}
+
+export function filterTimelineDisplayGroupsForChat(groups: TimelineDisplayGroup[]) {
+  return groups
+    .map((group) => ({
+      ...group,
+      rows: group.rows.filter(isChatTimelineRowVisible),
+    }))
+    .filter((group) => group.rows.length > 0);
+}
+
 const ASSISTANT_EVENT_TYPES = new Set(["message.assistant.delta", "message.assistant.completed"]);
 const GENERIC_STATUS_CONTENT = new Set([
   "session.status_changed",

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -439,12 +439,9 @@ describe("ChatPageClient", () => {
     );
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
     expect((textarea as HTMLTextAreaElement).value).toBe("");
-    expect(container.textContent).toContain("Running");
     expect(container.textContent).toContain("Continue with the fix.");
-    expect(container.textContent).toContain("Connecting live updates");
-    expect(container.textContent).toContain(
-      "The thread is active while Thread View waits for the live stream to open.",
-    );
+    expect(container.textContent).toContain("Streaming");
+    expect(container.textContent).not.toContain("Connecting live updates");
   });
 
   it("clears the selected thread from Navigation and starts a workspace-scoped thread", async () => {
@@ -1000,8 +997,8 @@ describe("ChatPageClient", () => {
         "Please explain the diff.",
         expect.stringMatching(/^input_followup_/),
       );
-      expect(container.textContent).toContain("Input accepted. Waiting for thread updates.");
       expect(container.textContent).toContain("Please explain the diff.");
+      expect(container.textContent).toContain("Streaming");
     } finally {
       if (originalThreadId) {
         searchParams.set("threadId", originalThreadId);
@@ -1089,7 +1086,7 @@ describe("ChatPageClient", () => {
       });
       await flushUi();
 
-      expect(container.textContent).toContain("Select a workspace to enable input.");
+      expect(container.textContent).toContain("Choose a workspace to begin");
       const disabledComposer = container.querySelector("#thread-composer-input");
       expect(disabledComposer).not.toBeNull();
       expect((disabledComposer as HTMLTextAreaElement).disabled).toBe(true);
@@ -1120,7 +1117,7 @@ describe("ChatPageClient", () => {
       await flushUi();
 
       expect(chatDataMocks.createWorkspaceFromChat).toHaveBeenCalledWith("created");
-      expect(container.textContent).toContain("Created workspace created.");
+      expect(container.textContent).toContain("Ask Codex in created");
       expect(container.textContent).toContain("Ask Codex");
 
       const firstInputTextarea = container.querySelector("#thread-composer-input");
@@ -1364,7 +1361,8 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
-    expect(container.textContent).toContain("Request pending. Respond from the current thread.");
+    expect(container.textContent).toContain("Request needs attention");
+    expect(container.textContent).toContain("Run git push");
   });
 
   it("shows reconnecting feedback when the thread stream drops", async () => {
@@ -1399,11 +1397,9 @@ describe("ChatPageClient", () => {
     });
     await flushUi();
 
-    expect(container.textContent).toContain("Reconnecting live updates");
-    expect(container.textContent).toContain(
-      "Live delivery dropped. Thread View is reacquiring the latest activity for this thread.",
-    );
-    expect(container.textContent).toContain("Refresh thread");
+    expect(container.textContent).toContain("Streaming");
+    expect(container.textContent).not.toContain("Reconnecting live updates");
+    expect(container.textContent).not.toContain("Refresh thread");
   });
 
   it("marks stream sequence gaps as inconsistent and reacquires selected thread state", async () => {
@@ -1462,9 +1458,8 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(3);
-    expect(container.textContent).toContain(
-      "Thread stream changed unexpectedly. Reacquiring thread state.",
-    );
+    expect(container.textContent).toContain("Request needs attention");
+    expect(container.textContent).toContain("Run git push");
   });
 
   it("shows a targeted notice for a background high-priority thread and opens it on demand", async () => {
@@ -1598,7 +1593,6 @@ describe("ChatPageClient", () => {
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Investigate build");
     expectSelectedThreadTitle("Investigate build");
-    expect(container.textContent).toContain("High-priority background thread needs attention.");
     expect(container.textContent).toContain("Background thread needs attention");
     expect(container.textContent).toContain("Reason: Needs response");
     expect(container.textContent).toContain("Needs attention now");
@@ -1622,7 +1616,6 @@ describe("ChatPageClient", () => {
       ),
     ).toBeUndefined();
     expect(container.textContent).toContain("Background work");
-    expect(container.textContent).toContain("Input paused for approval.");
     expect(container.textContent).toContain("Approve request");
     expect(container.textContent).toContain("Deny request");
   });
@@ -1646,8 +1639,8 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     expect(container.textContent).toContain("Opening thread");
-    expect(container.textContent).toContain("Opening selected thread.");
-    expect(container.textContent).toContain(
+    expect(container.textContent).not.toContain("Opening selected thread.");
+    expect(container.textContent).not.toContain(
       "Opening this thread and restoring its latest timeline",
     );
     expect(container.textContent).not.toContain("Request detail");
@@ -1752,7 +1745,8 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     expect(chatDataMocks.loadChatThreadBundle).toHaveBeenCalledTimes(2);
-    expect(container.textContent).toContain("Input paused for approval.");
+    expect(container.textContent).toContain("Approve request");
+    expect(container.textContent).toContain("Deny request");
     expect(container.textContent).not.toContain("Background thread needs attention");
     expect(
       Array.from(container.querySelectorAll("button")).find(
@@ -1801,7 +1795,7 @@ describe("ChatPageClient", () => {
     });
     await flushUi();
 
-    expect(container.textContent).toContain("High-priority background thread needs attention.");
+    expect(container.textContent).not.toContain("High-priority background thread needs attention.");
     expect(container.textContent).not.toContain("Background thread needs attention");
     expect(
       Array.from(container.querySelectorAll("button")).find(
@@ -2056,7 +2050,7 @@ describe("ChatPageClient", () => {
     });
     await flushUi();
 
-    expect(container.textContent).toContain("Running");
+    expect(container.textContent).toContain("Streaming");
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1500);

--- a/apps/frontend-bff/tests/chat-view-timeline.test.tsx
+++ b/apps/frontend-bff/tests/chat-view-timeline.test.tsx
@@ -129,6 +129,17 @@ describe("ChatViewTimeline", () => {
     expect(container.textContent).not.toContain("Turn");
   });
 
+  it("renders no loading or empty-state text when the simplified timeline has no visible rows", () => {
+    const markup = renderToStaticMarkup(
+      <ChatViewTimeline {...buildTimelineProps({ groups: [] })} />,
+    );
+
+    expect(markup).not.toContain("Preparing thread view");
+    expect(markup).not.toContain("Opening this thread and restoring its latest timeline");
+    expect(markup).not.toContain("No timeline items yet");
+    expect(markup).not.toContain("empty-state");
+  });
+
   it("renders live assistant rows with inline streaming status and leaves completed assistant rows timestamped", async () => {
     const groups: TimelineDisplayGroup[] = [
       {

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -232,21 +232,21 @@ describe("ChatView", () => {
     expect(markup).toContain("Approval thread");
     expect(markup).toContain("Approve request");
     expect(markup).toContain("Pending request");
+    expect(markup).not.toContain("chat-topbar");
     expect(markup).toContain("Request summary");
     expect(markup).toContain("Run git push");
     expect(markup).toContain("Reason");
     expect(markup).toContain("Codex requests permission to push changes to remote.");
     expect(markup).toContain("Operation");
     expect(markup).toContain("git push origin main");
-    expect(markup).toContain(">Threads<");
     expect(markup).toContain('aria-label="Thread details"');
-    expect(markup).toContain("Input paused for approval.");
+    expect(markup).toContain("alpha");
     expect(markup).not.toContain("Workspace:");
     expect(markup).not.toContain("Stream:");
     expect(markup).not.toContain(">Refresh<");
     expect(markup).not.toContain("thread-feedback-card-inline");
     expect(markup).toContain("Please explain the diff.");
-    expect(markup).toContain("Updated apps/frontend-bff/src/chat-view.tsx");
+    expect(markup).not.toContain("Updated apps/frontend-bff/src/chat-view.tsx");
     expect(markup).toContain("Streaming update");
     expect(markup).toContain("Request needs attention");
     expect(markup).toContain("timeline-row-prominent");
@@ -255,9 +255,9 @@ describe("ChatView", () => {
     expect(markup.indexOf("Please explain the diff.")).toBeLessThan(
       markup.indexOf("Approve request"),
     );
-    expect(markup).toContain("Status update");
-    expect(markup).toContain("timeline-row-compact");
-    expect(markup).toContain("Inspect artifacts");
+    expect(markup).not.toContain("Status update");
+    expect(markup).not.toContain("timeline-row-compact");
+    expect(markup).not.toContain("Inspect artifacts");
     expect(markup).not.toContain("Timeline item detail");
     expect(markup).not.toContain("approval.requested");
     expect(markup).not.toContain("session.status_changed");
@@ -375,14 +375,9 @@ describe("ChatView", () => {
       );
     });
 
-    const inlineFeedbackBadge = container.querySelector(
-      ".thread-feedback-card-inline .status-badge",
-    );
-
     expect(container.querySelector(".thread-view-header-stack header .status-badge")).toBeNull();
-    expect(inlineFeedbackBadge?.textContent).toContain("Approval required");
-    expect(inlineFeedbackBadge?.className).toContain("warning");
-    expect(inlineFeedbackBadge?.className).not.toContain("success");
+    expect(container.querySelector(".timeline-request-row-status .status-badge")).toBeNull();
+    expect(container.querySelector(".thread-feedback-card-inline")).toBeNull();
   });
 
   it("keeps normal running progress inside the live assistant row instead of the thread feedback card", async () => {
@@ -503,7 +498,7 @@ describe("ChatView", () => {
     expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
   });
 
-  it("keeps reconnecting feedback visible when a live assistant row is present", async () => {
+  it("does not add reconnecting feedback cards when a live assistant row is present", async () => {
     await act(async () => {
       root.render(
         <ChatView
@@ -615,8 +610,8 @@ describe("ChatView", () => {
       );
     });
 
-    expect(container.querySelector(".thread-feedback-card-inline")).not.toBeNull();
-    expect(container.textContent).toContain("Reconnecting live updates");
+    expect(container.querySelector(".thread-feedback-card-inline")).toBeNull();
+    expect(container.textContent).not.toContain("Reconnecting live updates");
     expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
     expect(container.textContent).toContain("Streaming");
   });
@@ -766,7 +761,7 @@ describe("ChatView", () => {
     );
 
     expect(markup).toContain("chat-feedback-stack");
-    expect(markup).toContain("Thread started.");
+    expect(markup).not.toContain("Thread started.");
     expect(markup).toContain("Failed to interrupt the thread.");
     expect(markup.indexOf("chat-feedback-stack")).toBeLessThan(
       markup.indexOf("chat-panel create-card"),
@@ -864,6 +859,15 @@ describe("ChatView", () => {
           workspaces={[]}
         />,
       );
+    });
+
+    const detailsButton = container.querySelector(
+      'button[aria-label="Thread details"]',
+    ) as HTMLButtonElement | null;
+    expect(detailsButton).not.toBeNull();
+
+    await act(async () => {
+      detailsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     const inspectButton = Array.from(container.querySelectorAll("button")).find(
@@ -1551,14 +1555,14 @@ describe("ChatView", () => {
       />,
     );
 
-    expect(markup).toContain("Input unavailable: recovery pending.");
+    expect(markup).not.toContain("Input unavailable: recovery pending.");
     expect(markup.match(/<textarea/g) ?? []).toHaveLength(1);
     expect(markup).toContain("disabled");
     expect(markup).not.toContain('id="thread-input"');
     expect(markup).not.toContain('id="message-input"');
   });
 
-  it("folds long timeline rows and expands them in place", async () => {
+  it("filters tool output rows out of the simplified chat timeline", async () => {
     const longOutput = Array.from(
       { length: 12 },
       (_, index) => `diagnostic line ${String(index + 1).padStart(2, "0")}`,
@@ -1646,24 +1650,16 @@ describe("ChatView", () => {
       );
     });
 
-    expect(container.textContent).toContain("diagnostic line 08");
+    expect(container.textContent).not.toContain("diagnostic line 08");
     expect(container.textContent).not.toContain("diagnostic line 12");
-
-    const showMoreButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === "Show more",
-    );
-    expect(showMoreButton).toBeDefined();
-    expect(showMoreButton?.getAttribute("aria-expanded")).toBe("false");
-
-    await act(async () => {
-      showMoreButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(container.textContent).toContain("diagnostic line 12");
-    expect(container.textContent).toContain("Show less");
+    expect(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Show more",
+      ),
+    ).toBeUndefined();
   });
 
-  it("surfaces a latest-activity CTA when auto-scroll is suppressed", async () => {
+  it("does not surface a latest-activity CTA when newer timeline rows arrive", async () => {
     const baseProps = {
       backgroundPriorityNotice: null,
       connectionState: "live" as const,
@@ -1751,27 +1747,6 @@ describe("ChatView", () => {
       );
     });
 
-    const scrollRegion = container.querySelector(".thread-view-scroll-region") as HTMLDivElement;
-    expect(scrollRegion).not.toBeNull();
-    Object.defineProperty(scrollRegion, "clientHeight", {
-      configurable: true,
-      value: 100,
-    });
-    Object.defineProperty(scrollRegion, "scrollHeight", {
-      configurable: true,
-      value: 1000,
-      writable: true,
-    });
-    Object.defineProperty(scrollRegion, "scrollTop", {
-      configurable: true,
-      value: 780,
-      writable: true,
-    });
-
-    await act(async () => {
-      scrollRegion.dispatchEvent(new Event("scroll", { bubbles: true }));
-    });
-
     await act(async () => {
       root.render(
         <ChatView
@@ -1838,21 +1813,12 @@ describe("ChatView", () => {
       );
     });
 
-    expect(container.textContent).toContain("New activity is available below.");
-    const jumpButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === "Jump to latest activity",
-    );
-    expect(jumpButton).not.toBeUndefined();
-
-    await act(async () => {
-      jumpButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(scrollRegion.scrollTop).toBe(1000);
+    expect(container.textContent).toContain("Second item");
     expect(container.textContent).not.toContain("New activity is available below.");
+    expect(container.textContent).not.toContain("Jump to latest activity");
   });
 
-  it("keeps following latest activity when live assistant content grows on the same row", async () => {
+  it("keeps live assistant updates inside the same streaming row without a CTA", async () => {
     const baseProps = {
       backgroundPriorityNotice: null,
       connectionState: "live" as const,
@@ -1921,33 +1887,10 @@ describe("ChatView", () => {
       root.render(<ChatView {...baseProps} draftAssistantMessages={{ msg_live_001: "Working" }} />);
     });
 
-    const scrollRegion = container.querySelector(".thread-view-scroll-region") as HTMLDivElement;
-    expect(scrollRegion).not.toBeNull();
-    Object.defineProperty(scrollRegion, "clientHeight", {
-      configurable: true,
-      value: 100,
-    });
-    Object.defineProperty(scrollRegion, "scrollHeight", {
-      configurable: true,
-      value: 1000,
-      writable: true,
-    });
-    Object.defineProperty(scrollRegion, "scrollTop", {
-      configurable: true,
-      value: 1000,
-      writable: true,
-    });
-
     await act(async () => {
       root.render(
         <ChatView {...baseProps} draftAssistantMessages={{ msg_live_001: "Working longer now" }} />,
       );
-    });
-
-    Object.defineProperty(scrollRegion, "scrollHeight", {
-      configurable: true,
-      value: 1400,
-      writable: true,
     });
 
     await act(async () => {
@@ -1959,7 +1902,8 @@ describe("ChatView", () => {
       );
     });
 
-    expect(scrollRegion.scrollTop).toBe(1400);
+    expect(container.textContent).toContain("Working longer now with more streamed detail");
+    expect(container.querySelectorAll(".timeline-row-live-status")).toHaveLength(1);
     expect(container.textContent).not.toContain("New activity is available below.");
   });
 });

--- a/apps/frontend-bff/tests/timeline-display-model.test.ts
+++ b/apps/frontend-bff/tests/timeline-display-model.test.ts
@@ -4,6 +4,7 @@ import {
   buildTimelineDisplayModel,
   classifyTimelineDensity,
   classifyTimelineTone,
+  filterTimelineDisplayGroupsForChat,
 } from "../src/timeline-display-model";
 import { getTimelineItemDetail } from "../src/timeline-item-detail";
 
@@ -784,6 +785,113 @@ describe("timeline display model", () => {
         }),
       ]),
     );
+  });
+
+  it("keeps only user assistant and actual request rows in the chat timeline filter", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "user_001",
+          kind: "message.user",
+          payload: {
+            content: "Run the checks.",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "request_001",
+          sequence: 2,
+          kind: "approval.requested",
+          payload: {
+            summary: "Approve git push",
+            status: "pending",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "tool_pending_001",
+          sequence: 3,
+          kind: "tool.started",
+          payload: {
+            summary: "Tool says pending",
+            status: "pending",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "status_resolved_001",
+          sequence: 4,
+          kind: "session.status_changed",
+          payload: {
+            summary: "resolved",
+            status: "resolved",
+          },
+        }),
+      ],
+      streamEvents: [
+        {
+          event_id: "file_resolved_001",
+          thread_id: "thread_001",
+          event_type: "file.changed" as PublicThreadStreamEvent["event_type"],
+          sequence: 5,
+          occurred_at: "2026-03-27T05:20:01Z",
+          payload: {
+            summary: "Updated src/app.ts",
+            status: "resolved",
+          },
+        },
+      ],
+      draftAssistantMessages: {
+        msg_live_001: "Streaming answer",
+      },
+    });
+
+    const chatRows = filterTimelineDisplayGroupsForChat(model.groups).flatMap(
+      (group) => group.rows,
+    );
+
+    expect(chatRows.map((row) => row.id)).toEqual([
+      "timeline:user_001",
+      "timeline:request_001",
+      "draft:msg_live_001",
+    ]);
+  });
+
+  it("keeps non-request rows with generic pending or resolved payload status hidden from chat timeline", () => {
+    const model = buildTimelineDisplayModel({
+      timelineItems: [
+        timelineItem({
+          timeline_item_id: "command_pending_001",
+          kind: "command.started",
+          payload: {
+            summary: "Command queued",
+            status: "pending",
+          },
+        }),
+        timelineItem({
+          timeline_item_id: "error_resolved_001",
+          sequence: 2,
+          kind: "error.raised",
+          payload: {
+            summary: "Recovered",
+            status: "resolved",
+          },
+        }),
+      ],
+      streamEvents: [
+        {
+          event_id: "tool_pending_001",
+          thread_id: "thread_001",
+          event_type: "tool.started" as PublicThreadStreamEvent["event_type"],
+          sequence: 3,
+          occurred_at: "2026-03-27T05:20:01Z",
+          payload: {
+            summary: "Tool active",
+            status: "pending",
+          },
+        },
+      ],
+      draftAssistantMessages: {},
+    });
+
+    expect(filterTimelineDisplayGroupsForChat(model.groups)).toEqual([]);
   });
 
   it("keeps normal user and assistant rows expanded by default even when long", () => {

--- a/tasks/archive/issue-297-chat-column-simplify/README.md
+++ b/tasks/archive/issue-297-chat-column-simplify/README.md
@@ -1,0 +1,91 @@
+# Issue 297: Chat Column Simplify
+
+## Purpose
+
+Simplify the Thread View chat column so it contains only user/Codex messages, Streaming assistant progress, approval/request interactions, the composer, and a compact composer status line.
+
+## Primary issue
+
+- [Issue #297: UI: simplify chat column to messages approvals and composer status line](https://github.com/tsukushibito/codex-webui/issues/297)
+
+## Source docs
+
+- `README.md`
+- `AGENTS.md`
+- `apps/frontend-bff/README.md`
+- `apps/frontend-bff/AGENTS.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+
+## Scope for this package
+
+- Remove the large chat topbar workspace header.
+- Add a compact status line under the composer input, initially showing only the selected workspace name.
+- Keep Streaming/live assistant rows visible.
+- Keep approval/request rows and controls visible.
+- Remove or hide non-approval thread feedback/status cards from the chat column.
+- Remove Timeline loading and empty-state text from the chat column.
+- Filter chat Timeline display rows to user messages, assistant messages, and approval/request rows.
+- Remove running-oriented composer guidance from the visible chat column.
+- Remove the latest-activity CTA from the chat column.
+
+## Exit criteria
+
+- Thread View no longer renders the large workspace topbar.
+- The composer renders a compact workspace status line.
+- User messages, Codex messages, Streaming live assistant rows, and approval/request controls still render.
+- Chat column system status cards/text are absent.
+- Focused frontend tests cover the changed display behavior.
+- Validation passes for the touched frontend surface.
+
+## Work plan
+
+1. Update ChatView structure to remove topbar and non-approval feedback surfaces.
+2. Update ChatViewComposer to render a compact status line below the input.
+3. Update Timeline display filtering/loading/empty behavior.
+4. Update CSS for the composer status line and remove stale topbar/status styling where appropriate.
+5. Update tests for retained message/approval behavior and removed system status surfaces.
+6. Run focused validation, then full frontend gates required for this slice.
+
+## Artifacts / evidence
+
+- Sprint evaluator verdict: approved.
+- Dedicated pre-push validation: passed.
+- Validation commands:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `node ./node_modules/vitest/vitest.mjs run tests/timeline-display-model.test.ts tests/chat-view-timeline.test.tsx tests/chat-view.test.tsx tests/chat-page-client.test.tsx`
+  - `npm test`
+  - `npm run build`
+- Validation results:
+  - Focused Vitest subset: 4 files passed, 69 tests passed.
+  - Full Vitest suite: 15 files passed, 121 tests passed.
+  - Production build completed successfully.
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-27T16-54-09Z-issue-297-close/events.ndjson`
+
+## Status / handoff notes
+
+- Active branch: `issue-297-chat-column-simplify`
+- Active worktree: `.worktrees/issue-297-chat-column-simplify`
+- Implemented chat-column simplification:
+  - Removed the large chat topbar workspace header.
+  - Added compact composer status segments showing the selected workspace name.
+  - Removed visible non-approval status surfaces from the chat column.
+  - Removed Timeline loading and empty-state text.
+  - Filtered chat Timeline rows to user messages, assistant messages, Streaming assistant progress, and approval/request rows.
+  - Kept unfiltered Timeline data for Thread Details so artifact/detail inspection remains available.
+- Completion retrospective:
+  - Completion boundary: package archive after approved sprint and passed pre-push validation.
+  - Contract check: package exit criteria satisfied by changed frontend UI and focused/full validation evidence.
+  - What worked: evaluator caught a real filtering edge case before archive; dedicated validator gate then covered full tests and build.
+  - Workflow problems: initial validator spawn hit the subagent thread limit; completed agents were closed and validation was retried cleanly.
+  - Improvements to adopt: close completed subagents before starting the pre-push validator in long orchestration runs.
+  - Skill candidates or updates: none required.
+  - Follow-up updates: PR merge, parent checkout sync, worktree cleanup, Issue close, and Project Done remain for GitHub-projects completion flow.
+
+## Archive conditions
+
+- Dedicated pre-push validation has passed.
+- Package evidence and handoff notes are updated.
+- Package is moved to `tasks/archive/issue-297-chat-column-simplify/`.
+- Issue execution metadata points to the archived package while PR/main completion proceeds.


### PR DESCRIPTION
## Summary
- remove chat-column workspace topbar and non-approval status surfaces
- add compact composer status line showing the selected workspace name
- filter chat timeline rows to user/Codex messages, Streaming assistant progress, and approval/request rows
- archive the Issue #297 task package

Closes #297

## Validation
- npm run check
- node ./node_modules/typescript/bin/tsc --noEmit --pretty false
- node ./node_modules/vitest/vitest.mjs run tests/timeline-display-model.test.ts tests/chat-view-timeline.test.tsx tests/chat-view.test.tsx tests/chat-page-client.test.tsx
- npm test
- npm run build