### PR TITLE
fix(codex-runtime): recover missing native thread inputs

### DIFF
--- a/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
@@ -21,6 +21,44 @@ function firstRow<T>(rows: T[]) {
   return rows[0] ?? null;
 }
 
+function serializeErrorSignal(value: unknown) {
+  if (typeof value === "string") {
+    return value.toLowerCase();
+  }
+
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  try {
+    return JSON.stringify(value).toLowerCase();
+  } catch {
+    return String(value).toLowerCase();
+  }
+}
+
+function indicatesMissingNativeThread(error: RuntimeError) {
+  if (error.code !== "app_server_request_failed" || error.details?.rpc_method !== "turn/start") {
+    return false;
+  }
+
+  const messageSignal = error.message.toLowerCase();
+  const codeSignal = serializeErrorSignal(error.details?.rpc_error_code);
+  const dataSignal = serializeErrorSignal(error.details?.rpc_error_data);
+  const signals = [messageSignal, codeSignal, dataSignal];
+
+  return (
+    signals.some((signal) => signal.includes("thread_not_found")) ||
+    (signals.some((signal) => signal.includes("not_found")) &&
+      signals.some((signal) => signal.includes("thread") || signal.includes("session"))) ||
+    signals.some(
+      (signal) =>
+        (signal.includes("thread") || signal.includes("session")) &&
+        (signal.includes("not found") || signal.includes("missing")),
+    )
+  );
+}
+
 export class ThreadInputOrchestrator {
   constructor(
     private readonly database: RuntimeDatabase,
@@ -88,6 +126,19 @@ export class ThreadInputOrchestrator {
       });
     }
 
+    if (session.appSessionOverlayState === "recovery_pending") {
+      throw new RuntimeError(
+        409,
+        "thread_recovery_pending",
+        "thread requires recovery before accepting input",
+        {
+          thread_id: threadId,
+          status: session.status,
+          app_session_overlay_state: session.appSessionOverlayState,
+        },
+      );
+    }
+
     if (session.status !== "waiting_input") {
       throw new RuntimeError(
         409,
@@ -100,10 +151,37 @@ export class ThreadInputOrchestrator {
       );
     }
 
-    const nativeTurn = await this.nativeSessionGateway.sendUserMessage({
-      sessionId: threadId,
-      content: input.content,
-    });
+    let nativeTurn: { turnId: string };
+    try {
+      nativeTurn = await this.nativeSessionGateway.sendUserMessage({
+        sessionId: threadId,
+        content: input.content,
+      });
+    } catch (error) {
+      if (error instanceof RuntimeError && indicatesMissingNativeThread(error)) {
+        const recoveryMarkedAt = this.now().toISOString();
+        this.markThreadRecoveryPendingBeforeNativeTurnPersists(
+          threadId,
+          session.workspaceId,
+          recoveryMarkedAt,
+        );
+
+        throw new RuntimeError(
+          409,
+          "thread_recovery_pending",
+          "thread requires recovery before accepting input",
+          {
+            thread_id: threadId,
+            rpc_method: "turn/start",
+            rpc_error_code: error.details?.rpc_error_code ?? null,
+            rpc_error_data: error.details?.rpc_error_data ?? null,
+            native_error_message: error.message,
+          },
+        );
+      }
+
+      throw error;
+    }
     const userMessageId = generateMessageId();
     const userCreatedAt = this.now().toISOString();
 
@@ -193,6 +271,31 @@ export class ThreadInputOrchestrator {
       sessionId,
       turnId,
     });
+  }
+
+  private markThreadRecoveryPendingBeforeNativeTurnPersists(
+    threadId: string,
+    workspaceId: string,
+    updatedAt: string,
+  ) {
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .update(sessions)
+        .set({
+          updatedAt,
+          appSessionOverlayState: "recovery_pending",
+        })
+        .where(eq(sessions.sessionId, threadId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          updatedAt,
+        })
+        .where(eq(workspaces.workspaceId, workspaceId))
+        .run();
+    })();
   }
 
   private markThreadRecoveryPending(

--- a/apps/codex-runtime/src/domain/threads/thread-service.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-service.ts
@@ -36,36 +36,37 @@ import type {
 } from "./types.js";
 
 function toThreadSummary(session: SessionRow): ThreadSummary {
+  const recoveryPending = session.appSessionOverlayState === "recovery_pending";
   const hasPendingRequest = session.status === "waiting_approval";
-  const acceptingUserInput = session.status === "waiting_input";
+  const acceptingUserInput = session.status === "waiting_input" && !recoveryPending;
 
   let threadStatus = "idle";
   let latestTurnStatus: string | null = "completed";
   let activeFlags: string[] = [];
-  let blockedReason: string | null = null;
+  let blockedReason: string | null = recoveryPending ? "thread_recovery_pending" : null;
 
   if (session.status === "created") {
     threadStatus = "created";
     latestTurnStatus = null;
-    blockedReason = "thread_not_started";
+    blockedReason ??= "thread_not_started";
   } else if (session.status === "running") {
     threadStatus = "running";
     latestTurnStatus = "running";
     activeFlags = ["turn_in_progress"];
-    blockedReason = "turn_in_progress";
+    blockedReason ??= "turn_in_progress";
   } else if (session.status === "waiting_approval") {
     threadStatus = "running";
     latestTurnStatus = "running";
     activeFlags = ["waiting_on_request"];
-    blockedReason = "waiting_on_request";
+    blockedReason ??= "waiting_on_request";
   } else if (session.status === "failed") {
     threadStatus = "error";
     latestTurnStatus = "failed";
-    blockedReason = "system_error";
+    blockedReason ??= "system_error";
   } else if (session.status === "stopped") {
     threadStatus = "interrupted";
     latestTurnStatus = "interrupted";
-    blockedReason = "thread_closed";
+    blockedReason ??= "thread_closed";
   }
 
   return {
@@ -191,6 +192,18 @@ function mapThreadInputError(error: unknown, threadId: string): never {
         status: runtimeError.details?.current_status ?? runtimeError.details?.status ?? null,
         workspace_id: runtimeError.details?.workspace_id ?? null,
         active_thread_id: runtimeError.details?.active_session_id ?? null,
+      },
+    );
+  }
+
+  if (runtimeError.code === "thread_recovery_pending") {
+    throw new RuntimeError(
+      409,
+      "thread_recovery_pending",
+      "thread requires recovery before accepting input",
+      {
+        ...runtimeError.details,
+        thread_id: threadId,
       },
     );
   }

--- a/apps/codex-runtime/tests/thread-routes.test.ts
+++ b/apps/codex-runtime/tests/thread-routes.test.ts
@@ -73,6 +73,23 @@ class FailingSendNativeSessionGateway extends StubNativeSessionGateway {
   }
 }
 
+class MissingThreadNativeSessionGateway extends StubNativeSessionGateway {
+  override async sendUserMessage(_input: {
+    sessionId: string;
+    content: string;
+  }): Promise<{ turnId: string }> {
+    this.sendUserMessages.push(_input);
+    throw new RuntimeError(502, "app_server_request_failed", "thread not found in app server", {
+      rpc_method: "turn/start",
+      rpc_error_code: "not_found",
+      rpc_error_data: {
+        threadId: _input.sessionId,
+        reason: "persisted thread missing after restart",
+      },
+    });
+  }
+}
+
 afterEach(async () => {
   await Promise.all(
     cleanupPaths.splice(0).map((entryPath) => fs.rm(entryPath, { recursive: true, force: true })),
@@ -1304,6 +1321,166 @@ describe("thread routes", () => {
         },
       },
     });
+
+    await app.close();
+  });
+
+  it("marks a persisted thread recovery_pending when native turn/start reports thread missing", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    const nativeSessionGateway = new MissingThreadNativeSessionGateway();
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    database.db
+      .insert(workspaces)
+      .values({
+        workspaceId: "ws_alpha",
+        workspaceName: "alpha",
+        directoryName: "alpha",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:00:00.000Z",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: "thread_001",
+        workspaceId: "ws_alpha",
+        title: "Recovered thread",
+        status: "waiting_input",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:01:00.000Z",
+        startedAt: "2026-04-09T00:00:00.000Z",
+        lastMessageAt: null,
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    const firstResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/threads/thread_001/inputs",
+      payload: {
+        client_request_id: "req_followup_missing_001",
+        content: "Continue after runtime restart",
+      },
+    });
+
+    expect(firstResponse.statusCode).toBe(409);
+    expect(firstResponse.json()).toMatchObject({
+      error: {
+        code: "thread_recovery_pending",
+        message: "thread requires recovery before accepting input",
+        details: {
+          thread_id: "thread_001",
+          rpc_method: "turn/start",
+          rpc_error_code: "not_found",
+          rpc_error_data: {
+            threadId: "thread_001",
+          },
+          native_error_message: "thread not found in app server",
+        },
+      },
+    });
+
+    expect(nativeSessionGateway.sendUserMessages).toEqual([
+      {
+        sessionId: "thread_001",
+        content: "Continue after runtime restart",
+      },
+    ]);
+
+    const persistedSession = database.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.sessionId, "thread_001"))
+      .get();
+    expect(persistedSession).toMatchObject({
+      sessionId: "thread_001",
+      status: "waiting_input",
+      currentTurnId: null,
+      pendingAssistantMessageId: null,
+      appSessionOverlayState: "recovery_pending",
+    });
+
+    const persistedMessages = database.db
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, "thread_001"))
+      .all();
+    expect(persistedMessages).toHaveLength(0);
+
+    const persistedEvents = database.db
+      .select()
+      .from(sessionEvents)
+      .where(eq(sessionEvents.sessionId, "thread_001"))
+      .all();
+    expect(persistedEvents).toHaveLength(0);
+
+    const threadResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001",
+    });
+    expect(threadResponse.statusCode).toBe(200);
+    expect(threadResponse.json()).toMatchObject({
+      thread_id: "thread_001",
+      derived_hints: {
+        accepting_user_input: false,
+        blocked_reason: "thread_recovery_pending",
+      },
+    });
+
+    const viewResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001/view",
+    });
+    expect(viewResponse.statusCode).toBe(200);
+    expect(viewResponse.json()).toMatchObject({
+      thread: {
+        thread_id: "thread_001",
+        derived_hints: {
+          accepting_user_input: false,
+          blocked_reason: "thread_recovery_pending",
+        },
+      },
+    });
+
+    const retryResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/threads/thread_001/inputs",
+      payload: {
+        client_request_id: "req_followup_missing_002",
+        content: "Retry after runtime restart",
+      },
+    });
+
+    expect(retryResponse.statusCode).toBe(409);
+    expect(retryResponse.json()).toMatchObject({
+      error: {
+        code: "thread_recovery_pending",
+        details: {
+          thread_id: "thread_001",
+        },
+      },
+    });
+    expect(nativeSessionGateway.sendUserMessages).toHaveLength(1);
 
     await app.close();
   });

--- a/tasks/archive/issue-299-restart-thread-recovery/README.md
+++ b/tasks/archive/issue-299-restart-thread-recovery/README.md
@@ -1,0 +1,66 @@
+# Runtime restart thread recovery
+
+## Purpose
+
+- Fix Issue #299 by making persisted runtime threads behave correctly after `codex-runtime` restarts with a fresh `codex app-server` child.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/299
+
+## Source docs
+
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/specs/codex_webui_public_api_v0_9.md`
+- `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Implement the runtime open/load/recovery boundary for persisted-but-not-loaded threads.
+- Make thread view and follow-up input paths handle restart-time native reachability consistently.
+- Add regression coverage for the restart or native `thread not found` path.
+- Keep the change scoped to `apps/codex-runtime` unless tests reveal a required BFF error-mapping adjustment.
+
+## Exit criteria
+
+- `POST /api/v1/threads/{thread_id}/open`, `GET /api/v1/threads/{thread_id}/view`, and `POST /api/v1/threads/{thread_id}/inputs` have consistent behavior for persisted threads that are not loaded by the native app-server.
+- Follow-up input after runtime restart either succeeds through a supported open/load path or fails with an explicit recovery-aware WebUI error instead of an unclassified native failure.
+- Runtime tests cover the selected restart/not-loaded behavior and raw native `thread not found` mapping.
+- `apps/codex-runtime` validation for the touched slice passes.
+
+## Work plan
+
+- Inspect the native app-server gateway capabilities and current error mapping around `turn/start`.
+- Define the smallest supported open/load behavior that is consistent with the v0.9 docs and current native evidence.
+- Update runtime thread service/orchestrator logic for view and input admission.
+- Extend fake app-server or targeted tests to reproduce the restart/not-loaded path.
+- Run targeted runtime tests and app-local checks.
+
+## Artifacts / evidence
+
+- Sprint evaluator verdict: approved.
+- Dedicated pre-push validation: passed.
+- Validation evidence from `apps/codex-runtime`:
+  - `npm run check`
+  - `npm test -- tests/thread-routes.test.ts`
+  - `npm test`
+  - `npm run build`
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: Implemented recovery-aware input blocking for persisted threads whose native `turn/start` reports a missing thread. The slice marks the runtime session `recovery_pending`, prevents misleading follow-up sends, and adds runtime regression coverage. Remaining workflow before Issue close: commit/push, open PR, merge to `main`, sync parent checkout, remove active worktree, and final GitHub Project/Issue completion tracking.
+- Completion retrospective:
+  - Completion boundary: package archive after local implementation, evaluator approval, and dedicated pre-push validation.
+  - Contract check: package exit criteria satisfied by runtime changes and tests; Issue close is not applicable until the work reaches `main`.
+  - What worked: the planner kept the first sprint narrow enough to safely address the user-visible restart failure without inventing unsupported native reopen/load behavior.
+  - Workflow problems: none requiring a repo skill or docs update.
+  - Improvements to adopt: keep distinguishing full native reopen/load support from recovery-aware failure handling when app-server evidence is incomplete.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: publish the branch through PR workflow and keep #299 open/In Progress until merged and cleaned up.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, dedicated pre-push validation has passed, completion retrospective has been performed, and handoff notes are updated.


### PR DESCRIPTION
## Summary

- mark persisted runtime threads as `recovery_pending` when native `turn/start` reports a missing thread after restart
- block repeated input before another native call once recovery is pending
- expose recovery-pending thread hints and add runtime regression coverage
- archive the Issue #299 local task package after local validation

## Root cause

The runtime persisted thread rows in SQLite but sent their IDs directly to a fresh `codex app-server` after restart. If native state did not have the thread loaded, `turn/start` surfaced as a raw app-server missing-thread failure.

## Validation

- `npm run check`
- `npm test -- tests/thread-routes.test.ts`
- `npm test`
- `npm run build`

Fixes #299