### PR TITLE
[codex] Resume persisted threads before input

### DIFF
--- a/apps/codex-runtime/src/domain/app-server/codex-app-server-gateway.ts
+++ b/apps/codex-runtime/src/domain/app-server/codex-app-server-gateway.ts
@@ -114,6 +114,7 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
   private itemPhases = new Map<string, string>();
   private turnStates = new Map<string, TurnState>();
   private pendingTurnStartConvergence = new Map<string, PendingTurnStartConvergence>();
+  private loadedSessionIds = new Set<string>();
   private eventSink: NativeSessionEventSink | null = null;
   private startPromise: Promise<AppServerSnapshot> | null = null;
   private eventChain = Promise.resolve();
@@ -186,26 +187,56 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
       personality: this.config.personality,
     });
 
+    this.loadedSessionIds.add(String(result.thread.id));
+
     return {
       sessionId: String(result.thread.id),
     };
   }
 
+  async resumeSession(input: { sessionId: string }) {
+    if (this.loadedSessionIds.has(input.sessionId)) {
+      return {
+        sessionId: input.sessionId,
+      };
+    }
+
+    const result = await this.sendRequest("thread/resume", {
+      threadId: input.sessionId,
+      personality: this.config.personality,
+    });
+
+    const sessionId = String(result.thread?.id ?? input.sessionId);
+    this.loadedSessionIds.add(sessionId);
+
+    return {
+      sessionId,
+    };
+  }
+
   async sendUserMessage(input: SendNativeSessionMessageInput) {
+    await this.resumeSession({ sessionId: input.sessionId });
+
     this.pendingTurnStartConvergence.set(input.sessionId, {
       turnId: null,
       queuedEvents: [],
     });
 
-    const result = await this.sendRequest("turn/start", {
-      threadId: input.sessionId,
-      input: [
-        {
-          type: "text",
-          text: input.content,
-        },
-      ],
-    });
+    let result: any;
+    try {
+      result = await this.sendRequest("turn/start", {
+        threadId: input.sessionId,
+        input: [
+          {
+            type: "text",
+            text: input.content,
+          },
+        ],
+      });
+    } catch (error) {
+      this.pendingTurnStartConvergence.delete(input.sessionId);
+      throw error;
+    }
 
     const turnId = String(result.turn.id);
     const pending = this.pendingTurnStartConvergence.get(input.sessionId);
@@ -308,6 +339,7 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
         pending.reject(new Error("codex app-server exited before the request completed"));
       }
       this.pendingRequests.clear();
+      this.loadedSessionIds.clear();
     });
 
     try {
@@ -434,6 +466,7 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
 
     if (method === "turn/started") {
       if (sessionId && turnId) {
+        this.loadedSessionIds.add(sessionId);
         this.turnStates.set(turnStateKey(sessionId, turnId), {
           hasFinalAssistantMessage: false,
           waitingForApproval: false,
@@ -448,6 +481,22 @@ export class CodexAppServerGateway implements NativeSessionGateway, AppServerCon
         await this.eventSink.convergeSessionWaitingForInput(sessionId, {
           native_event_name: "thread/status/changed",
         });
+      }
+      return;
+    }
+
+    if (method === "thread/started") {
+      const startedSessionId = String(params.thread?.id ?? params.threadId ?? "");
+      if (startedSessionId) {
+        this.loadedSessionIds.add(startedSessionId);
+      }
+      return;
+    }
+
+    if (method === "thread/closed") {
+      const closedSessionId = String(params.thread?.id ?? params.threadId ?? "");
+      if (closedSessionId) {
+        this.loadedSessionIds.delete(closedSessionId);
       }
       return;
     }

--- a/apps/codex-runtime/src/domain/sessions/native-session-gateway.ts
+++ b/apps/codex-runtime/src/domain/sessions/native-session-gateway.ts
@@ -13,6 +13,7 @@ export interface SendNativeSessionMessageInput {
 
 export interface NativeSessionGateway {
   createSession(input: CreateNativeSessionInput): Promise<{ sessionId: string }>;
+  resumeSession(input: { sessionId: string }): Promise<{ sessionId: string }>;
   sendUserMessage(input: SendNativeSessionMessageInput): Promise<{
     turnId: string;
   }>;
@@ -29,6 +30,12 @@ export class SyntheticNativeSessionGateway implements NativeSessionGateway {
   async createSession(_input: CreateNativeSessionInput) {
     return {
       sessionId: `thread_${crypto.randomUUID().replaceAll("-", "")}`,
+    };
+  }
+
+  async resumeSession(input: { sessionId: string }) {
+    return {
+      sessionId: input.sessionId,
     };
   }
 

--- a/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
@@ -38,7 +38,10 @@ function serializeErrorSignal(value: unknown) {
 }
 
 function indicatesMissingNativeThread(error: RuntimeError) {
-  if (error.code !== "app_server_request_failed" || error.details?.rpc_method !== "turn/start") {
+  if (
+    error.code !== "app_server_request_failed" ||
+    !["turn/start", "thread/resume"].includes(String(error.details?.rpc_method ?? ""))
+  ) {
     return false;
   }
 
@@ -172,7 +175,7 @@ export class ThreadInputOrchestrator {
           "thread requires recovery before accepting input",
           {
             thread_id: threadId,
-            rpc_method: "turn/start",
+            rpc_method: error.details?.rpc_method ?? "turn/start",
             rpc_error_code: error.details?.rpc_error_code ?? null,
             rpc_error_data: error.details?.rpc_error_data ?? null,
             native_error_message: error.message,

--- a/apps/codex-runtime/src/domain/threads/thread-service.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-service.ts
@@ -395,6 +395,8 @@ export class ThreadService {
     threadId: string,
     input: { client_request_id: string; content: string },
   ): Promise<{ thread: ThreadSummary; accepted_input: MessageProjection }> {
+    await this.resumeThreadForInput(threadId, { recoverPending: false });
+
     let acceptedInput: MessageProjection;
     try {
       acceptedInput = await this.threadInputOrchestrator.acceptThreadMessage(threadId, {
@@ -412,6 +414,7 @@ export class ThreadService {
   }
 
   async openThread(threadId: string) {
+    await this.resumeThreadForInput(threadId, { recoverPending: true });
     const thread = await this.getThread(threadId);
     return {
       thread_id: thread.thread_id,
@@ -846,5 +849,62 @@ export class ThreadService {
     })();
 
     return this.getThread(threadId);
+  }
+
+  private async resumeThreadForInput(threadId: string, options: { recoverPending: boolean }) {
+    const thread = firstRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, threadId))
+        .limit(1)
+        .all(),
+    );
+
+    if (!thread) {
+      throw new RuntimeError(404, "thread_not_found", "thread was not found", {
+        thread_id: threadId,
+      });
+    }
+
+    if (thread.appSessionOverlayState === "recovery_pending" && !options.recoverPending) {
+      return;
+    }
+
+    if (thread.status !== "waiting_input" && thread.appSessionOverlayState !== "recovery_pending") {
+      return;
+    }
+
+    try {
+      await this.nativeSessionGateway.resumeSession({
+        sessionId: threadId,
+      });
+    } catch (error) {
+      mapThreadInputError(error, threadId);
+    }
+
+    if (thread.appSessionOverlayState === "open") {
+      return;
+    }
+
+    const resumedAt = this.now().toISOString();
+    this.database.sqlite.transaction(() => {
+      this.database.db
+        .update(sessions)
+        .set({
+          updatedAt: resumedAt,
+          appSessionOverlayState: "open",
+        })
+        .where(eq(sessions.sessionId, threadId))
+        .run();
+
+      this.database.db
+        .update(workspaces)
+        .set({
+          updatedAt: resumedAt,
+        })
+        .where(eq(workspaces.workspaceId, thread.workspaceId))
+        .run();
+    })();
   }
 }

--- a/apps/codex-runtime/tests/fixtures/fake-codex-app-server.mjs
+++ b/apps/codex-runtime/tests/fixtures/fake-codex-app-server.mjs
@@ -6,6 +6,8 @@ let turnCounter = 1;
 let itemCounter = 1;
 const turnStartMode =
   process.argv.find((arg) => arg.startsWith("--turn-start-mode="))?.split("=")[1] ?? "normal";
+const requireResumeBeforeTurn = process.argv.includes("--require-resume-before-turn");
+const loadedThreadIds = new Set();
 
 function send(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
@@ -50,6 +52,22 @@ lineReader.on("line", (line) => {
 
   if (method === "thread/start") {
     const threadId = nextId("thread_live", threadCounter++);
+    loadedThreadIds.add(threadId);
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        thread: {
+          id: threadId,
+        },
+      },
+    });
+    return;
+  }
+
+  if (method === "thread/resume") {
+    const threadId = String(message.params?.threadId ?? "");
+    loadedThreadIds.add(threadId);
     send({
       jsonrpc: "2.0",
       id: message.id,
@@ -64,6 +82,18 @@ lineReader.on("line", (line) => {
 
   if (method === "turn/start") {
     const threadId = String(message.params?.threadId ?? "");
+    if (requireResumeBeforeTurn && !loadedThreadIds.has(threadId)) {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: "thread_not_found",
+          message: `thread ${threadId} is not loaded`,
+        },
+      });
+      return;
+    }
+
     const turnId = nextId("turn_live", turnCounter++);
     const itemId = nextId("item_live", itemCounter++);
     const prompt = String(message.params?.input?.[0]?.text ?? "");

--- a/apps/codex-runtime/tests/thread-routes.test.ts
+++ b/apps/codex-runtime/tests/thread-routes.test.ts
@@ -15,6 +15,7 @@ const cleanupPaths: string[] = [];
 
 class StubNativeSessionGateway implements NativeSessionGateway {
   readonly sendUserMessages: Array<{ sessionId: string; content: string }> = [];
+  readonly resumeSessions: Array<{ sessionId: string }> = [];
 
   constructor(
     private readonly sessionIds: string[] = [],
@@ -34,6 +35,11 @@ class StubNativeSessionGateway implements NativeSessionGateway {
     }
 
     return { sessionId };
+  }
+
+  async resumeSession(input: { sessionId: string }) {
+    this.resumeSessions.push(input);
+    return { sessionId: input.sessionId };
   }
 
   async sendUserMessage(_input: { sessionId: string; content: string }) {
@@ -2164,6 +2170,110 @@ describe("thread routes", () => {
         role: "user",
         content: "Continue the runtime cutover",
       },
+    });
+
+    await app.close();
+  });
+
+  it("resumes a persisted thread before accepting input after app-server restart", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+    await fs.mkdir(path.join(workspaceRoot, "alpha"), { recursive: true });
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: true,
+        appServerCommand: process.execPath,
+        appServerArgs: [
+          fileURLToPath(new URL("./fixtures/fake-codex-app-server.mjs", import.meta.url)),
+          "--require-resume-before-turn",
+        ],
+      },
+      database,
+    });
+
+    database.db
+      .insert(workspaces)
+      .values({
+        workspaceId: "ws_alpha",
+        workspaceName: "alpha",
+        directoryName: "alpha",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:00:00.000Z",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: "thread_persisted_001",
+        workspaceId: "ws_alpha",
+        title: "Persisted thread",
+        status: "waiting_input",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:01:00.000Z",
+        startedAt: "2026-04-09T00:00:00.000Z",
+        lastMessageAt: "2026-04-09T00:00:30.000Z",
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    const inputResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/threads/thread_persisted_001/inputs",
+      payload: {
+        client_request_id: "req_after_restart_001",
+        content: "Continue after restart",
+      },
+    });
+
+    expect(inputResponse.statusCode).toBe(202);
+    expect(inputResponse.json()).toMatchObject({
+      accepted_input: {
+        session_id: "thread_persisted_001",
+        role: "user",
+        content: "Continue after restart",
+      },
+    });
+
+    await waitForAssertion(async () => {
+      const persistedSession = database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, "thread_persisted_001"))
+        .limit(1)
+        .all()[0];
+
+      expect(persistedSession).toMatchObject({
+        status: "waiting_input",
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      });
+
+      const storedMessages = database.db
+        .select()
+        .from(messages)
+        .where(eq(messages.sessionId, "thread_persisted_001"))
+        .all();
+      expect(storedMessages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+            content: "Continue after restart",
+          }),
+          expect.objectContaining({
+            role: "assistant",
+            content: "Synthetic assistant response for: Continue after restart",
+          }),
+        ]),
+      );
     });
 
     await app.close();

--- a/docs/log.md
+++ b/docs/log.md
@@ -734,3 +734,21 @@ Notes:
 - added desktop viewport-use guidance so the shell does not appear as a centered card-like panel
 - specified that both normal Navigation and collapsed minibar stay flush to the physical left edge
 - clarified that readable content constraints should apply inside Timeline regions rather than as large outer margins around the whole desktop app
+
+## [2026-04-28] query | App Server thread resume contract
+
+Source:
+
+- user report that existing threads could not receive input after WebUI/app-server restart
+- OpenAI Codex App Server documentation for `thread/resume`
+
+Updated:
+
+- `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
+- `docs/log.md`
+
+Notes:
+
+- promoted `thread/resume` from an unproven open/load gap into an allowed v0.9 dependency
+- clarified that WebUI may call `thread/resume` with a recorded `thread.id` before later `turn/start`
+- preserved the warning that reopened thread history does not make approval/request helper objects fully recoverable without app-owned retention

--- a/docs/specs/codex_webui_app_server_contract_matrix_v0_9.md
+++ b/docs/specs/codex_webui_app_server_contract_matrix_v0_9.md
@@ -37,6 +37,7 @@ The matrix below is based primarily on:
 - `artifacts/app_server_observability/observations/p2-*`
 - `artifacts/app_server_observability/observations/p3-*`
 - `artifacts/app_server_observability/observations/p4-*`
+- OpenAI Codex App Server documentation for `thread/resume` and `thread/read`
 
 Where evidence is incomplete, this document marks the dependency as:
 
@@ -72,6 +73,7 @@ Where evidence is incomplete, this document marks the dependency as:
 | Event identity | stable native event ID | `reserved_do_not_depend` | No reliable cross-stream/history native event identity was observed. Use app-owned event IDs when needed. |
 | Thread ordering | native strict thread ordering key | `reserved_do_not_depend` | Native data did not expose a stable replay-safe ordering key. Runtime must assign thread-scoped `sequence`. |
 | Thread preview recency | native `preview` as latest-turn summary | `reserved_do_not_depend` | Observed to retain stale prompt text in some reload cases. |
+| Thread resume | `thread/resume` by recorded `thread.id` before later `turn/start` | `allowed` | Official App Server documentation defines `thread/resume` as reopening an existing thread so subsequent `turn/start` calls append to it. WebUI may use it to load a persisted thread after runtime or app-server restart. |
 
 ---
 
@@ -80,6 +82,7 @@ Where evidence is incomplete, this document marks the dependency as:
 ### 5.1 Current target rule
 
 The current evidence set does not establish a native history status that can be depended on as a directly observed `notLoaded` thread status in the same way as `idle` or `active`.
+However, the official App Server contract does establish explicit load behavior through `thread/resume`: clients may call it with a previously recorded `thread.id` to reopen a stored thread before starting the next turn.
 
 ### 5.2 Allowed v0.9 dependency
 
@@ -87,6 +90,7 @@ WebUI may still use the `notLoaded` concept in v0.9 only as:
 
 - a runtime-facing dependency slot tied to explicit open/load behavior
 - a facade/runtime operational state derived from persisted thread reachability and loadability
+- an implementation trigger to call `thread/resume` before sending new input to a persisted thread
 
 Public and internal APIs must not pretend that full thread history or request objects remain available merely because a thread can be reopened.
 


### PR DESCRIPTION
## Summary

- add `thread/resume` support to the native session gateway
- resume persisted waiting-input threads before existing-thread input reaches `turn/start`
- keep `recovery_pending` guarded on direct input, while allowing explicit `open` to retry resume
- update the app-server contract matrix now that `thread/resume` is documented

## Root Cause

After WebUI restart, the app-owned SQLite row still existed but the freshly started `codex app-server` process had not loaded that thread. WebUI sent `turn/start` directly with the persisted thread id, so native app-server could answer `thread not found` for an otherwise valid stored thread.

## Validation

- `codex --version` -> `codex-cli 0.125.0`
- OpenAI Codex App Server docs confirm `thread/resume` reopens an existing thread by recorded `thread.id` before later `turn/start`
- `npm run check`
- `npm test -- tests/thread-routes.test.ts`
- `npm test`
- `npm run build`
