### PR TITLE
feat: add thread view settings dialog

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -496,6 +496,7 @@ textarea {
 
 .thread-context-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
@@ -527,6 +528,11 @@ textarea {
   min-width: 44px;
   min-height: 44px;
   padding: 8px;
+}
+
+.settings-button,
+.settings-close-button {
+  flex-shrink: 0;
 }
 
 .icon-button-glyph {
@@ -590,51 +596,85 @@ textarea {
   gap: 8px;
 }
 
-.theme-switch {
-  gap: 8px;
-  min-height: 40px;
-  padding-inline: 10px;
-  text-transform: capitalize;
+.settings-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: start center;
+  padding: 24px 16px;
+  background: rgba(6, 11, 14, 0.68);
 }
 
-.theme-switch-track {
-  display: inline-flex;
-  align-items: center;
-  width: 2.35rem;
-  padding: 2px;
-  border-radius: 999px;
-  background: var(--surface-muted-bg);
-  transition: background-color 160ms ease;
-}
-
-.theme-switch-thumb {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: 999px;
+.settings-dialog {
+  width: min(100%, 30rem);
+  max-height: min(calc(100dvh - 32px), 42rem);
+  overflow: auto;
+  border: 1px solid var(--panel-border);
+  border-radius: 20px;
   background: var(--panel-elevated-bg);
+  box-shadow: var(--surface-shadow-strong);
+  padding: 18px;
+}
+
+.settings-dialog-header,
+.settings-dialog-copy,
+.settings-dialog-sections,
+.settings-fieldset {
+  display: grid;
+}
+
+.settings-dialog-header {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 12px;
+}
+
+.settings-dialog-copy {
+  gap: 4px;
+}
+
+.settings-dialog-copy h3,
+.settings-legend {
+  margin: 0;
+}
+
+.settings-dialog-sections {
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.settings-fieldset {
+  gap: 10px;
+  min-width: 0;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--surface-input-border);
+  border-radius: 16px;
+  background: var(--surface-soft-bg);
+}
+
+.settings-legend {
+  padding: 0;
   color: var(--text-main);
-  font-size: 0.68rem;
-  font-weight: 800;
-  transform: translateX(0);
-  transition:
-    transform 160ms ease,
-    background-color 160ms ease;
-}
-
-.theme-switch[aria-checked="true"] .theme-switch-track {
-  background: var(--surface-accent-bg);
-}
-
-.theme-switch[aria-checked="true"] .theme-switch-thumb {
-  transform: translateX(0.9rem);
-}
-
-.theme-switch-label {
-  font-size: 0.84rem;
+  font-size: 0.92rem;
   font-weight: 700;
+}
+
+.settings-description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.settings-option-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-option {
+  min-width: 0;
 }
 
 .sidebar-mode-toggle {
@@ -859,9 +899,7 @@ textarea {
 
 .composer-toolbar {
   display: flex;
-  flex-wrap: wrap;
   align-items: flex-start;
-  justify-content: space-between;
   gap: 10px;
   min-width: 0;
 }
@@ -870,7 +908,6 @@ textarea {
   display: grid;
   gap: 3px;
   min-width: 0;
-  flex: 1 1 13rem;
 }
 
 .composer-toolbar-label,
@@ -1614,8 +1651,7 @@ textarea {
   }
 
   .thread-context-actions {
-    flex-direction: column;
-    align-items: stretch;
+    align-items: flex-start;
   }
 
   /* Request / Feedback */
@@ -1727,17 +1763,28 @@ textarea {
     padding: 0 0 calc(env(safe-area-inset-bottom)) 0;
   }
 
-  .composer-toolbar {
-    align-items: stretch;
+  .settings-dialog-overlay {
+    padding: 12px;
+    place-items: end stretch;
   }
 
-  .composer-mode-toggle {
+  .settings-dialog {
     width: 100%;
-    justify-content: stretch;
+    max-height: min(calc(100dvh - 24px), 38rem);
+    border-radius: 18px;
+    padding: 14px;
   }
 
-  .composer-mode-option {
-    flex: 1 1 0;
+  .settings-dialog-header {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .settings-fieldset {
+    padding: 12px;
+  }
+
+  .settings-option-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .composer-input-frame {

--- a/apps/frontend-bff/e2e/issue-305-composer-keybindings.spec.ts
+++ b/apps/frontend-bff/e2e/issue-305-composer-keybindings.spec.ts
@@ -192,6 +192,15 @@ async function mockComposerKeybindingSurface(
   });
 }
 
+function settingsButton(page: Page) {
+  return page.getByRole("button", { name: "Settings", exact: true });
+}
+
+async function openSettingsDialog(page: Page) {
+  await settingsButton(page).click();
+  await expect(page.getByRole("dialog", { name: "Settings", exact: true })).toBeVisible();
+}
+
 test("persists composer keybinding mode and respects chat/editor shortcuts without overflow", async ({
   page,
 }) => {
@@ -209,7 +218,6 @@ test("persists composer keybinding mode and respects chat/editor shortcuts witho
   const textarea = page.locator("#thread-composer-input");
 
   await expect(page.getByText("Enter sends. Shift+Enter adds a new line.")).toBeVisible();
-  await expect(page.getByRole("radio", { name: /Chat/i })).toBeChecked();
 
   await textarea.fill("First line");
   await textarea.press("Shift+Enter");
@@ -220,11 +228,15 @@ test("persists composer keybinding mode and respects chat/editor shortcuts witho
   await expect.poll(() => postedInputs.length).toBe(1);
   expect(postedInputs[0]).toContain("First line");
 
-  await page.locator(".composer-mode-option", { hasText: "Editor" }).click();
+  await openSettingsDialog(page);
+  await expect(page.locator('input[name="composer-keybinding-mode"][value="chat"]')).toBeChecked();
+  await page.locator(".settings-dialog .composer-mode-option", { hasText: "Editor" }).click();
   await expect(
     page.getByText("Enter adds a new line. Ctrl+Enter or Meta+Enter sends."),
   ).toBeVisible();
-  await expect(page.getByRole("radio", { name: /Editor/i })).toBeChecked();
+  await expect(
+    page.locator('input[name="composer-keybinding-mode"][value="editor"]'),
+  ).toBeChecked();
   await expect
     .poll(async () =>
       page.evaluate(() => window.localStorage.getItem("codex-webui.composer-keybinding-mode")),
@@ -232,7 +244,11 @@ test("persists composer keybinding mode and respects chat/editor shortcuts witho
     .toBe("editor");
 
   await page.reload();
-  await expect(page.getByRole("radio", { name: /Editor/i })).toBeChecked();
+  await openSettingsDialog(page);
+  await expect(
+    page.locator('input[name="composer-keybinding-mode"][value="editor"]'),
+  ).toBeChecked();
+  await page.getByRole("button", { name: "Close settings", exact: true }).click();
   await expect(
     page.getByText("Enter adds a new line. Ctrl+Enter or Meta+Enter sends."),
   ).toBeVisible();

--- a/apps/frontend-bff/e2e/issue-306-theme-switching.spec.ts
+++ b/apps/frontend-bff/e2e/issue-306-theme-switching.spec.ts
@@ -34,6 +34,20 @@ function primaryDenyButton(page: Page) {
   return page.locator(".danger-button").first();
 }
 
+function settingsButton(page: Page) {
+  return page.getByRole("button", { name: "Settings", exact: true });
+}
+
+async function openSettingsDialog(page: Page) {
+  await settingsButton(page).click();
+  await expect(page.getByRole("dialog", { name: "Settings", exact: true })).toBeVisible();
+}
+
+async function switchToLightTheme(page: Page) {
+  await openSettingsDialog(page);
+  await page.locator(".settings-dialog .composer-mode-option", { hasText: "Light" }).click();
+}
+
 async function mockThemeSurface(page: Page) {
   const workspace = {
     workspace_id: "ws_alpha",
@@ -453,8 +467,7 @@ test("persists theme across reload and preserves thread state while toggling", a
   await expect(page.getByRole("heading", { name: "Theme validation thread" })).toBeVisible();
   await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
 
-  const themeSwitch = page.getByRole("switch", { name: "Dark theme" });
-  await expect(themeSwitch).toHaveAttribute("aria-checked", "true");
+  await expect(settingsButton(page)).toHaveAttribute("aria-expanded", "false");
   await expect
     .poll(() =>
       page.evaluate(() => ({
@@ -474,9 +487,9 @@ test("persists theme across reload and preserves thread state while toggling", a
     return element.scrollTop;
   });
 
-  await themeSwitch.click();
+  await switchToLightTheme(page);
 
-  await expect(themeSwitch).toHaveAttribute("aria-checked", "false");
+  await expect(page.locator('input[name="thread-view-theme"][value="light"]')).toBeChecked();
   await expect(page).toHaveURL(/workspaceId=ws_alpha&threadId=thread_001/);
   await expect(page.getByRole("heading", { name: "Thread details", exact: true })).toBeVisible();
   await expect(composer).toHaveValue("Preserve this draft");
@@ -498,7 +511,8 @@ test("persists theme across reload and preserves thread state while toggling", a
 
   await page.reload();
   await expect(page.getByRole("heading", { name: "Theme validation thread" })).toBeVisible();
-  await expect(themeSwitch).toHaveAttribute("aria-checked", "false");
+  await openSettingsDialog(page);
+  await expect(page.locator('input[name="thread-view-theme"][value="light"]')).toBeChecked();
   await expect
     .poll(() =>
       page.evaluate(() => ({
@@ -523,9 +537,9 @@ test("captures dark and light theme evidence on desktop and mobile", async ({ pa
 
   await captureThemeScreenshot(page, `${viewportLabel}-dark.png`);
 
-  const themeSwitch = page.getByRole("switch", { name: "Dark theme" });
-  await themeSwitch.click();
-  await expect(themeSwitch).toHaveAttribute("aria-checked", "false");
+  await switchToLightTheme(page);
+  await expect(page.locator('input[name="thread-view-theme"][value="light"]')).toBeChecked();
+  await page.getByRole("button", { name: "Close settings", exact: true }).click();
   await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
 
   await captureThemeScreenshot(page, `${viewportLabel}-light.png`);
@@ -550,9 +564,9 @@ test("captures pending request controls and detail surface in dark and light the
   await captureThemeScreenshot(page, `${viewportLabel}-detail-dark.png`);
   await page.getByRole("button", { name: "Close", exact: true }).click();
 
-  const themeSwitch = page.getByRole("switch", { name: "Dark theme" });
-  await themeSwitch.click();
-  await expect(themeSwitch).toHaveAttribute("aria-checked", "false");
+  await switchToLightTheme(page);
+  await expect(page.locator('input[name="thread-view-theme"][value="light"]')).toBeChecked();
+  await page.getByRole("button", { name: "Close settings", exact: true }).click();
   await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
 
   await captureThemeScreenshot(page, `${viewportLabel}-pending-request-light.png`);
@@ -590,9 +604,9 @@ test("captures request feedback states across dark and light themes", async ({
   await errorPage.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
   await expect(primaryApproveButton(errorPage)).toBeVisible();
 
-  const themeSwitch = errorPage.getByRole("switch", { name: "Dark theme" });
-  await themeSwitch.click();
-  await expect(themeSwitch).toHaveAttribute("aria-checked", "false");
+  await switchToLightTheme(errorPage);
+  await expect(errorPage.locator('input[name="thread-view-theme"][value="light"]')).toBeChecked();
+  await errorPage.getByRole("button", { name: "Close settings", exact: true }).click();
 
   await primaryDenyButton(errorPage).click();
   await expect(errorPage.getByText("Failed to respond to the request.")).toBeVisible();

--- a/apps/frontend-bff/e2e/issue-313-settings-dialog.spec.ts
+++ b/apps/frontend-bff/e2e/issue-313-settings-dialog.spec.ts
@@ -1,0 +1,248 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { expectNoHorizontalScroll, fulfillJson, stubEventSource } from "./helpers/browser-mocks";
+
+async function mockSettingsDialogSurface(page: Page, postedInputs: string[]) {
+  const workspace = {
+    workspace_id: "ws_alpha",
+    workspace_name: "alpha",
+    created_at: "2026-04-05T02:20:00Z",
+    updated_at: "2026-04-05T02:33:00Z",
+    active_session_summary: {
+      session_id: "thread_001",
+      status: "waiting_on_user_input",
+      last_message_at: "2026-04-05T02:33:00Z",
+    },
+    pending_approval_count: 0,
+  };
+
+  const threadSummary = {
+    thread_id: "thread_001",
+    title: "Settings validation thread",
+    workspace_id: "ws_alpha",
+    native_status: {
+      thread_status: "idle",
+      active_flags: [],
+      latest_turn_status: "completed",
+    },
+    updated_at: "2026-04-05T02:33:00Z",
+  };
+
+  const threadView = {
+    thread: threadSummary,
+    current_activity: {
+      kind: "waiting_on_user_input",
+      label: "Waiting for your input",
+    },
+    pending_request: null,
+    latest_resolved_request: null,
+    composer: {
+      accepting_user_input: true,
+      interrupt_available: false,
+      blocked_by_request: false,
+      input_unavailable_reason: null,
+    },
+    timeline: {
+      items: Array.from({ length: 24 }, (_, index) => ({
+        timeline_item_id: `evt_${String(index + 1).padStart(3, "0")}`,
+        thread_id: "thread_001",
+        turn_id: `turn_${String(Math.floor(index / 2) + 1).padStart(3, "0")}`,
+        item_id: `item_${String(index + 1).padStart(3, "0")}`,
+        sequence: index + 1,
+        occurred_at: `2026-04-05T02:${String(index).padStart(2, "0")}:00Z`,
+        kind: index % 2 === 0 ? "message.user" : "message.assistant.completed",
+        payload:
+          index % 2 === 0
+            ? {
+                summary: "user input accepted",
+                content: `Settings check user message ${index + 1}`,
+              }
+            : {
+                summary: "assistant completed",
+                content: `Settings check assistant message ${index + 1}`,
+              },
+      })),
+      next_cursor: null,
+      has_more: false,
+    },
+  };
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const { pathname } = url;
+
+    if (pathname === "/api/v1/home" && request.method() === "GET") {
+      return fulfillJson(route, {
+        workspaces: [workspace],
+        resume_candidates: [],
+        pending_approval_count: 0,
+        updated_at: workspace.updated_at,
+      });
+    }
+
+    if (pathname === "/api/v1/workspaces" && request.method() === "GET") {
+      return fulfillJson(route, {
+        items: [workspace],
+        next_cursor: null,
+        has_more: false,
+      });
+    }
+
+    if (pathname === "/api/v1/workspaces/ws_alpha/threads" && request.method() === "GET") {
+      return fulfillJson(route, {
+        items: [
+          {
+            ...threadSummary,
+            current_activity: threadView.current_activity,
+            badge: null,
+            blocked_cue: null,
+            resume_cue: {
+              reason_kind: "active_thread",
+              priority_band: "medium",
+              label: "Resume here",
+            },
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      });
+    }
+
+    if (pathname === "/api/v1/threads/thread_001" && request.method() === "GET") {
+      return fulfillJson(route, threadSummary);
+    }
+
+    if (pathname === "/api/v1/threads/thread_001/view" && request.method() === "GET") {
+      return fulfillJson(route, threadView);
+    }
+
+    if (pathname === "/api/v1/threads/thread_001/timeline" && request.method() === "GET") {
+      return fulfillJson(route, threadView.timeline);
+    }
+
+    if (pathname === "/api/v1/threads/thread_001/inputs" && request.method() === "POST") {
+      const body = request.postDataJSON() as { content: string };
+      postedInputs.push(body.content);
+      return fulfillJson(
+        route,
+        {
+          accepted: {
+            thread_id: "thread_001",
+            turn_id: `turn_${String(postedInputs.length + 12).padStart(3, "0")}`,
+            input_item_id: `msg_${postedInputs.length}`,
+          },
+          thread: threadSummary,
+        },
+        202,
+      );
+    }
+
+    return route.abort();
+  });
+}
+
+function settingsButton(page: Page) {
+  return page.getByRole("button", { name: "Settings", exact: true });
+}
+
+function settingsDialog(page: Page) {
+  return page.getByRole("dialog", { name: "Settings", exact: true });
+}
+
+test("settings dialog preserves thread state, persists preferences, and avoids overflow", async ({
+  page,
+}) => {
+  const postedInputs: string[] = [];
+
+  await stubEventSource(page);
+  await mockSettingsDialogSurface(page, postedInputs);
+
+  await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
+  await expect(page.getByRole("heading", { name: "Settings validation thread" })).toBeVisible();
+  await expect(settingsButton(page)).toBeVisible();
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+  const composer = page.locator("#thread-composer-input");
+  await composer.fill("Preserve this draft");
+  await page.getByRole("button", { name: "Thread details", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Thread details", exact: true })).toBeVisible();
+
+  const scrollRegion = page.locator(".thread-view-scroll-region");
+  const scrollTopBefore = await scrollRegion.evaluate((element) => {
+    element.scrollTop = 360;
+    return element.scrollTop;
+  });
+
+  await settingsButton(page).click();
+  await expect(settingsDialog(page)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close settings", exact: true })).toBeFocused();
+
+  await page
+    .locator('.settings-dialog input[name="composer-keybinding-mode"][value="editor"]')
+    .focus();
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "Close settings", exact: true })).toBeFocused();
+
+  await page.keyboard.press("Shift+Tab");
+  await expect(
+    page.locator('.settings-dialog input[name="composer-keybinding-mode"][value="editor"]'),
+  ).toBeFocused();
+
+  await page.locator(".settings-dialog .composer-mode-option", { hasText: "Editor" }).click();
+  await page.locator(".settings-dialog .composer-mode-option", { hasText: "Light" }).click();
+  await expect(
+    page.getByText("Enter adds a new line. Ctrl+Enter or Meta+Enter sends."),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        composerMode: window.localStorage.getItem("codex-webui.composer-keybinding-mode"),
+        theme: window.localStorage.getItem("codex-webui.theme"),
+      })),
+    )
+    .toEqual({ composerMode: "editor", theme: "light" });
+
+  await page.getByRole("button", { name: "Close settings", exact: true }).click();
+  await expect(settingsDialog(page)).toHaveCount(0);
+  await expect(settingsButton(page)).toBeFocused();
+  await expect(page.getByRole("heading", { name: "Thread details", exact: true })).toBeVisible();
+  await expect(composer).toHaveValue("Preserve this draft");
+  const scrollTopAfterClose = await scrollRegion.evaluate((element) => element.scrollTop);
+  expect(Math.abs(scrollTopAfterClose - scrollTopBefore)).toBeLessThanOrEqual(2);
+
+  await settingsButton(page).click();
+  await expect(settingsDialog(page)).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(settingsDialog(page)).toHaveCount(0);
+  await expect(settingsButton(page)).toBeFocused();
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+  await composer.fill("Editor mode message");
+  await composer.press("Enter");
+  await expect(composer).toHaveValue("Editor mode message\n");
+  expect(postedInputs).toHaveLength(0);
+
+  await composer.press("Control+Enter");
+  await expect.poll(() => postedInputs.length).toBe(1);
+  expect(postedInputs[0]).toContain("Editor mode message");
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Settings validation thread" })).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        composerMode: window.localStorage.getItem("codex-webui.composer-keybinding-mode"),
+        documentTheme: document.documentElement.dataset.theme ?? null,
+        theme: window.localStorage.getItem("codex-webui.theme"),
+      })),
+    )
+    .toEqual({ composerMode: "editor", documentTheme: "light", theme: "light" });
+
+  await settingsButton(page).click();
+  await expect(page.locator('input[name="thread-view-theme"][value="light"]')).toBeChecked();
+  await expect(
+    page.locator('input[name="composer-keybinding-mode"][value="editor"]'),
+  ).toBeChecked();
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+});

--- a/apps/frontend-bff/src/chat-view-composer.tsx
+++ b/apps/frontend-bff/src/chat-view-composer.tsx
@@ -16,7 +16,6 @@ export interface ChatViewComposerProps {
   isComposerDisabled: boolean;
   isStartingThread: boolean;
   isTextareaDisabled: boolean;
-  onComposerKeybindingModeChange: (mode: ComposerKeybindingMode) => void;
   onComposerDraftChange: (value: string) => void;
   onSubmitComposer: () => void;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
@@ -33,7 +32,6 @@ export function ChatViewComposer({
   isComposerDisabled,
   isStartingThread,
   isTextareaDisabled,
-  onComposerKeybindingModeChange,
   onComposerDraftChange,
   onSubmitComposer,
   textareaRef,
@@ -85,41 +83,6 @@ export function ChatViewComposer({
             {composerShortcutSummary}
           </p>
         </div>
-        <fieldset className="composer-mode-toggle">
-          <legend className="sr-only">Composer keybinding mode</legend>
-          <label
-            className="composer-mode-option"
-            data-active={isChatMode ? "true" : "false"}
-            title="Chat mode: Enter sends and Shift+Enter adds a new line."
-          >
-            <input
-              checked={isChatMode}
-              className="composer-mode-input"
-              name="composer-keybinding-mode"
-              onChange={() => onComposerKeybindingModeChange("chat")}
-              type="radio"
-              value="chat"
-            />
-            <span className="composer-mode-option-label">Chat</span>
-            <span className="composer-mode-option-value">Enter sends</span>
-          </label>
-          <label
-            className="composer-mode-option"
-            data-active={!isChatMode ? "true" : "false"}
-            title="Editor mode: Enter adds a new line and Ctrl+Enter or Meta+Enter sends."
-          >
-            <input
-              checked={!isChatMode}
-              className="composer-mode-input"
-              name="composer-keybinding-mode"
-              onChange={() => onComposerKeybindingModeChange("editor")}
-              type="radio"
-              value="editor"
-            />
-            <span className="composer-mode-option-label">Editor</span>
-            <span className="composer-mode-option-value">Cmd/Ctrl+Enter sends</span>
-          </label>
-        </fieldset>
       </div>
       <label className="composer-input-frame" htmlFor="thread-composer-input">
         <span className="sr-only">{composerInputLabel}</span>

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -38,6 +38,8 @@ const SCROLL_FOLLOW_BOTTOM_THRESHOLD_PX = 48;
 const SCROLL_FOLLOW_SUSPEND_DELTA_PX = 24;
 export const THEME_STORAGE_KEY = "codex-webui.theme";
 const COMPOSER_KEYBINDING_MODE_STORAGE_KEY = "codex-webui.composer-keybinding-mode";
+const FOCUSABLE_SETTINGS_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 export type ComposerKeybindingMode = "chat" | "editor";
 export type ThemeName = "dark" | "light";
@@ -176,12 +178,47 @@ function SecondaryIcon({ children }: { children: ReactNode }) {
   );
 }
 
+function SettingsGlyph() {
+  return (
+    <svg fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <title>Settings</title>
+      <path
+        d="M12 8.75a3.25 3.25 0 1 0 0 6.5 3.25 3.25 0 0 0 0-6.5Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+      <path
+        d="m19.2 15.1 1.15 1.99-1.85 3.2-2.34-.46a7.94 7.94 0 0 1-1.73 1l-.61 2.3H10.2l-.61-2.3a7.93 7.93 0 0 1-1.73-1l-2.34.46-1.85-3.2 1.15-1.99a8.74 8.74 0 0 1 0-2.2L3.67 10.9l1.85-3.2 2.34.46c.53-.4 1.11-.74 1.73-1l.61-2.3h3.62l.61 2.3c.62.26 1.2.6 1.73 1l2.34-.46 1.85 3.2-1.15 1.99c.13.72.13 1.48 0 2.2Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
 function isComposerKeybindingMode(value: string | null): value is ComposerKeybindingMode {
   return value === "chat" || value === "editor";
 }
 
 function isThemeName(value: string | null): value is ThemeName {
   return value === "dark" || value === "light";
+}
+
+function getFocusableElements(container: HTMLElement | null) {
+  if (!container) {
+    return [];
+  }
+
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SETTINGS_SELECTOR)).filter(
+    (element) =>
+      !element.hasAttribute("disabled") &&
+      element.getAttribute("aria-hidden") !== "true" &&
+      element.tabIndex !== -1,
+  );
 }
 
 export function applyThemeToDocumentRoot(theme: ThemeName) {
@@ -687,14 +724,19 @@ export function ChatView({
   const [sidebarMode, setSidebarMode] = useState<SidebarMode>("full");
   const [composerKeybindingMode, setComposerKeybindingMode] =
     useState<ComposerKeybindingMode>("chat");
+  const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
   const [expandedTimelineRows, setExpandedTimelineRows] = useState<Set<string>>(() => new Set());
   const [isScrollFollowingLatest, setIsScrollFollowingLatest] = useState(true);
   const [hasNewerActivityBelow, setHasNewerActivityBelow] = useState(false);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
+  const settingsButtonRef = useRef<HTMLButtonElement | null>(null);
+  const settingsCloseButtonRef = useRef<HTMLButtonElement | null>(null);
+  const settingsDialogRef = useRef<HTMLDivElement | null>(null);
   const scrollRegionRef = useRef<HTMLDivElement | null>(null);
   const suppressScrollTrackingRef = useRef(false);
   const lastKnownScrollTopRef = useRef(0);
   const lastSeenTimelineActivityRef = useRef("empty");
+  const previousSettingsDialogOpenRef = useRef(false);
   const selectedWorkspace =
     workspaces.find((workspace) => workspace.workspace_id === workspaceId) ?? null;
   const hasSelectedThread = selectedThreadId !== null;
@@ -913,6 +955,88 @@ export function ChatView({
   }, []);
 
   useEffect(() => {
+    if (!isSettingsDialogOpen) {
+      return;
+    }
+
+    const focusableElements = getFocusableElements(settingsDialogRef.current);
+    focusableElements[0]?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setIsSettingsDialogOpen(false);
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const nextFocusableElements = getFocusableElements(settingsDialogRef.current);
+      const firstFocusableElement = nextFocusableElements[0] ?? null;
+      const lastFocusableElement = nextFocusableElements.at(-1) ?? null;
+
+      if (!firstFocusableElement || !lastFocusableElement) {
+        event.preventDefault();
+        return;
+      }
+
+      const activeElement = document.activeElement;
+      const isFocusInsideDialog =
+        activeElement instanceof HTMLElement &&
+        settingsDialogRef.current?.contains(activeElement) === true;
+
+      if (!isFocusInsideDialog) {
+        event.preventDefault();
+        (event.shiftKey ? lastFocusableElement : firstFocusableElement).focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === firstFocusableElement) {
+        event.preventDefault();
+        lastFocusableElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && activeElement === lastFocusableElement) {
+        event.preventDefault();
+        firstFocusableElement.focus();
+      }
+    }
+
+    function handleFocusIn(event: FocusEvent) {
+      const dialog = settingsDialogRef.current;
+      const focusTarget = event.target;
+
+      if (!(dialog && focusTarget instanceof HTMLElement) || dialog.contains(focusTarget)) {
+        return;
+      }
+
+      const nextFocusableElements = getFocusableElements(dialog);
+      nextFocusableElements[0]?.focus();
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("focusin", handleFocusIn);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, [isSettingsDialogOpen]);
+
+  useEffect(() => {
+    const wasOpen = previousSettingsDialogOpenRef.current;
+    previousSettingsDialogOpenRef.current = isSettingsDialogOpen;
+
+    if (!wasOpen || isSettingsDialogOpen) {
+      return;
+    }
+
+    settingsButtonRef.current?.focus();
+  }, [isSettingsDialogOpen]);
+
+  useEffect(() => {
     setIsNavigationOpen(false);
     setDetailSelection(null);
     setExpandedTimelineRows(new Set());
@@ -988,8 +1112,12 @@ export function ChatView({
     writeStoredComposerKeybindingMode(nextMode);
   }
 
-  function toggleTheme() {
-    setTheme((currentTheme) => (currentTheme === "dark" ? "light" : "dark"));
+  function openSettingsDialog() {
+    setIsSettingsDialogOpen(true);
+  }
+
+  function closeSettingsDialog() {
+    setIsSettingsDialogOpen(false);
   }
 
   function focusComposer() {
@@ -1187,18 +1315,18 @@ export function ChatView({
                 </div>
                 <div className="thread-context-actions">
                   <button
-                    aria-checked={theme === "dark"}
-                    aria-label="Dark theme"
-                    className="secondary-link compact-link action-button theme-switch"
-                    onClick={toggleTheme}
-                    role="switch"
-                    title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+                    aria-expanded={isSettingsDialogOpen}
+                    aria-haspopup="dialog"
+                    aria-label="Settings"
+                    className="secondary-link compact-link icon-button settings-button"
+                    onClick={openSettingsDialog}
+                    ref={settingsButtonRef}
+                    title="Settings"
                     type="button"
                   >
-                    <span aria-hidden="true" className="theme-switch-track">
-                      <span className="theme-switch-thumb">{theme === "dark" ? "D" : "L"}</span>
-                    </span>
-                    <span className="theme-switch-label">{theme}</span>
+                    <SecondaryIcon>
+                      <SettingsGlyph />
+                    </SecondaryIcon>
                   </button>
                   <button
                     aria-label="Thread details"
@@ -1240,6 +1368,134 @@ export function ChatView({
                 </div>
               </div>
             </header>
+            {isSettingsDialogOpen ? (
+              <div className="settings-dialog-overlay">
+                <div
+                  aria-labelledby="thread-view-settings-title"
+                  aria-modal="true"
+                  className="settings-dialog"
+                  ref={settingsDialogRef}
+                  role="dialog"
+                >
+                  <div className="settings-dialog-header">
+                    <div className="settings-dialog-copy">
+                      <p className="thread-context-label">Thread View preferences</p>
+                      <h3 id="thread-view-settings-title">Settings</h3>
+                    </div>
+                    <button
+                      aria-label="Close settings"
+                      className="secondary-link compact-link icon-button settings-close-button"
+                      onClick={closeSettingsDialog}
+                      ref={settingsCloseButtonRef}
+                      title="Close settings"
+                      type="button"
+                    >
+                      <SecondaryIcon>
+                        <svg fill="none" height="18" viewBox="0 0 24 24" width="18">
+                          <title>Close settings</title>
+                          <path
+                            d="m6 6 12 12"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth="1.8"
+                          />
+                          <path
+                            d="M18 6 6 18"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth="1.8"
+                          />
+                        </svg>
+                      </SecondaryIcon>
+                    </button>
+                  </div>
+                  <div className="settings-dialog-sections">
+                    <fieldset className="settings-fieldset">
+                      <legend className="settings-legend">Theme</legend>
+                      <p className="settings-description">
+                        Change the Thread View color theme immediately.
+                      </p>
+                      <div className="settings-option-grid">
+                        <label
+                          className="composer-mode-option settings-option"
+                          data-active={theme === "dark" ? "true" : "false"}
+                        >
+                          <input
+                            checked={theme === "dark"}
+                            className="composer-mode-input"
+                            name="thread-view-theme"
+                            onChange={() => setTheme("dark")}
+                            type="radio"
+                            value="dark"
+                          />
+                          <span className="composer-mode-option-label">Dark</span>
+                          <span className="composer-mode-option-value">Default fallback theme</span>
+                        </label>
+                        <label
+                          className="composer-mode-option settings-option"
+                          data-active={theme === "light" ? "true" : "false"}
+                        >
+                          <input
+                            checked={theme === "light"}
+                            className="composer-mode-input"
+                            name="thread-view-theme"
+                            onChange={() => setTheme("light")}
+                            type="radio"
+                            value="light"
+                          />
+                          <span className="composer-mode-option-label">Light</span>
+                          <span className="composer-mode-option-value">
+                            Brighter surface contrast
+                          </span>
+                        </label>
+                      </div>
+                    </fieldset>
+                    <fieldset className="settings-fieldset">
+                      <legend className="settings-legend">Enter to send</legend>
+                      <p className="settings-description">
+                        Choose how Enter behaves in the composer.
+                      </p>
+                      <div className="settings-option-grid">
+                        <label
+                          className="composer-mode-option settings-option"
+                          data-active={composerKeybindingMode === "chat" ? "true" : "false"}
+                          title="Chat mode: Enter sends and Shift+Enter adds a new line."
+                        >
+                          <input
+                            checked={composerKeybindingMode === "chat"}
+                            className="composer-mode-input"
+                            name="composer-keybinding-mode"
+                            onChange={() => updateComposerKeybindingMode("chat")}
+                            type="radio"
+                            value="chat"
+                          />
+                          <span className="composer-mode-option-label">Chat</span>
+                          <span className="composer-mode-option-value">Enter sends</span>
+                        </label>
+                        <label
+                          className="composer-mode-option settings-option"
+                          data-active={composerKeybindingMode === "editor" ? "true" : "false"}
+                          title="Editor mode: Enter adds a new line and Ctrl+Enter or Meta+Enter sends."
+                        >
+                          <input
+                            checked={composerKeybindingMode === "editor"}
+                            className="composer-mode-input"
+                            name="composer-keybinding-mode"
+                            onChange={() => updateComposerKeybindingMode("editor")}
+                            type="radio"
+                            value="editor"
+                          />
+                          <span className="composer-mode-option-label">Editor</span>
+                          <span className="composer-mode-option-value">Cmd/Ctrl+Enter sends</span>
+                        </label>
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            ) : null}
             <div className="thread-feedback-stack">
               {threadFeedback.isVisible ? (
                 <section
@@ -1454,7 +1710,6 @@ export function ChatView({
                 isComposerDisabled={isComposerDisabled}
                 isStartingThread={isStartingThread}
                 isTextareaDisabled={isComposerTextareaDisabled}
-                onComposerKeybindingModeChange={updateComposerKeybindingMode}
                 onComposerDraftChange={onComposerDraftChange}
                 onSubmitComposer={submitComposer}
                 textareaRef={composerRef}

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -142,10 +142,27 @@ describe("ChatView", () => {
     return textarea!;
   }
 
-  function themeSwitch(container: HTMLDivElement) {
-    const switchButton = container.querySelector<HTMLButtonElement>('button[role="switch"]');
-    expect(switchButton).not.toBeNull();
-    return switchButton!;
+  function settingsButton(container: HTMLDivElement) {
+    const button = container.querySelector<HTMLButtonElement>('button[aria-label="Settings"]');
+    expect(button).not.toBeNull();
+    return button!;
+  }
+
+  function settingsDialog(container: HTMLDivElement) {
+    const dialog = container.querySelector<HTMLDivElement>('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    return dialog!;
+  }
+
+  function dispatchTabKey(target: EventTarget, init: KeyboardEventInit = {}) {
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+      ...init,
+    });
+    target.dispatchEvent(event);
+    return event;
   }
 
   function dispatchComposerKeydown(
@@ -222,7 +239,7 @@ describe("ChatView", () => {
     };
   }
 
-  it("defaults to dark theme, applies it at the document root, and exposes the switch state", async () => {
+  it("defaults to dark theme, applies it at the document root, and exposes settings dialog controls", async () => {
     const storage = {
       getItem: vi.fn(() => null),
       setItem: vi.fn(),
@@ -236,15 +253,27 @@ describe("ChatView", () => {
       root.render(<ChatView {...buildChatViewBaseProps()} />);
     });
 
-    const switchButton = themeSwitch(container);
-    expect(switchButton.getAttribute("aria-checked")).toBe("true");
-    expect(switchButton.textContent).toContain("dark");
+    const button = settingsButton(container);
+    expect(button.getAttribute("aria-expanded")).toBe("false");
     expect(document.documentElement.dataset.theme).toBe("dark");
     expect(document.documentElement.style.colorScheme).toBe("dark");
     expect(storage.setItem).toHaveBeenCalledWith(THEME_STORAGE_KEY, "dark");
+
+    await act(async () => {
+      button.click();
+    });
+
+    const dialog = settingsDialog(container);
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.textContent).toContain("Settings");
+    const darkThemeOption = dialog.querySelector<HTMLInputElement>(
+      'input[name="thread-view-theme"][value="dark"]',
+    );
+    expect(darkThemeOption?.checked).toBe(true);
+    expect(document.activeElement?.getAttribute("aria-label")).toBe("Close settings");
   });
 
-  it("restores a persisted light theme and toggles without remounting the view", async () => {
+  it("restores a persisted light theme and updates it from the settings dialog without remounting the view", async () => {
     const storage = {
       getItem: vi.fn((key: string) => (key === THEME_STORAGE_KEY ? "light" : null)),
       setItem: vi.fn(),
@@ -258,13 +287,21 @@ describe("ChatView", () => {
       root.render(<ChatView {...buildChatViewBaseProps({ composerDraft: "draft persists" })} />);
     });
 
-    const switchButton = themeSwitch(container);
-    expect(switchButton.getAttribute("aria-checked")).toBe("false");
+    const button = settingsButton(container);
     expect(document.documentElement.dataset.theme).toBe("light");
     expect(composerTextarea(container).value).toBe("draft persists");
 
     await act(async () => {
-      switchButton.click();
+      button.click();
+    });
+
+    const darkThemeOption = settingsDialog(container).querySelector<HTMLInputElement>(
+      'input[name="thread-view-theme"][value="dark"]',
+    );
+    expect(darkThemeOption).not.toBeNull();
+
+    await act(async () => {
+      darkThemeOption?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(document.documentElement.dataset.theme).toBe("dark");
@@ -309,6 +346,96 @@ describe("ChatView", () => {
 
     expect(document.documentElement.dataset.theme).toBe("dark");
     expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+
+  it("closes settings on escape and returns focus to the settings button", async () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+      },
+    });
+
+    await act(async () => {
+      root.render(<ChatView {...buildChatViewBaseProps({ composerDraft: "Keep draft" })} />);
+    });
+
+    const button = settingsButton(container);
+
+    await act(async () => {
+      button.click();
+    });
+
+    expect(settingsDialog(container)).not.toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Escape",
+        }),
+      );
+    });
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(button);
+    expect(composerTextarea(container).value).toBe("Keep draft");
+  });
+
+  it("traps focus inside the settings dialog while it is open", async () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+      },
+    });
+
+    await act(async () => {
+      root.render(<ChatView {...buildChatViewBaseProps()} />);
+    });
+
+    const button = settingsButton(container);
+    const textarea = composerTextarea(container);
+
+    await act(async () => {
+      button.click();
+    });
+
+    const dialog = settingsDialog(container);
+    const closeButton = dialog.querySelector<HTMLButtonElement>(
+      'button[aria-label="Close settings"]',
+    );
+    const lastFocusable = dialog.querySelector<HTMLInputElement>(
+      'input[name="composer-keybinding-mode"][value="editor"]',
+    );
+
+    expect(closeButton).not.toBeNull();
+    expect(lastFocusable).not.toBeNull();
+    expect(document.activeElement).toBe(closeButton);
+
+    await act(async () => {
+      lastFocusable?.focus();
+      dispatchTabKey(window);
+    });
+
+    expect(document.activeElement).toBe(closeButton);
+
+    await act(async () => {
+      closeButton?.focus();
+      dispatchTabKey(window, { shiftKey: true });
+    });
+
+    expect(document.activeElement).toBe(lastFocusable);
+
+    await act(async () => {
+      textarea.focus();
+    });
+
+    expect(document.activeElement).not.toBe(textarea);
+    expect(dialog.contains(document.activeElement)).toBe(true);
   });
 
   it("renders thread context, pending request controls, and timeline state", () => {
@@ -2293,7 +2420,7 @@ describe("ChatView", () => {
     expect(container.textContent).not.toContain("Jump to latest activity");
   });
 
-  it("uses chat mode shortcuts by default and persists editor mode after mount", async () => {
+  it("uses dialog keybinding controls to persist mode changes and update keyboard behavior", async () => {
     const storage = {
       getItem: vi.fn((key: string) =>
         key === "codex-webui.composer-keybinding-mode" ? "editor" : null,
@@ -2343,8 +2470,13 @@ describe("ChatView", () => {
     });
 
     expect(onSubmitComposer).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('input[name="composer-keybinding-mode"]')).toBeNull();
 
-    const chatModeButton = container.querySelector<HTMLInputElement>(
+    await act(async () => {
+      settingsButton(container).click();
+    });
+
+    const chatModeButton = settingsDialog(container).querySelector<HTMLInputElement>(
       'input[name="composer-keybinding-mode"][value="chat"]',
     );
     expect(chatModeButton).not.toBeNull();

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-313-settings-dialog](./archive/issue-313-settings-dialog/README.md)
 - [issue-306-theme-switching](./archive/issue-306-theme-switching/README.md)
 - [issue-305-composer-keybindings](./archive/issue-305-composer-keybindings/README.md)
 - [issue-303-auto-scroll](./archive/issue-303-auto-scroll/README.md)

--- a/tasks/archive/issue-313-settings-dialog/README.md
+++ b/tasks/archive/issue-313-settings-dialog/README.md
@@ -1,0 +1,65 @@
+# Issue 313 Settings Dialog
+
+## Purpose
+
+- Consolidate lightweight UI preferences into a settings dialog opened from the Thread View header.
+
+## Primary issue
+
+- Issue: [#313 UI: move theme and Enter-send preferences into settings dialog](https://github.com/tsukushibito/codex-webui/issues/313)
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+- Related completed work: #305, #306
+
+## Scope for this package
+
+- Add a compact settings icon button in the Thread View top-right action area.
+- Add an accessible settings dialog.
+- Move theme switching into the dialog.
+- Move the Enter-to-send preference into the dialog.
+- Preserve persisted preference behavior and existing defaults unless implementation evidence requires a narrower adjustment.
+- Remove or demote the standalone header theme switch after the dialog owns the preference.
+
+## Exit criteria
+
+- The Thread View top-right area exposes a clear settings icon button.
+- Clicking the settings button opens a dialog containing theme and Enter-to-send controls.
+- Theme selection applies immediately and persists across reload.
+- Enter-to-send selection controls composer keyboard behavior and persists across reload.
+- Closing the dialog preserves composer draft, selected thread, selected detail, and scroll state.
+- Focused tests cover keyboard/screen-reader behavior and preference persistence.
+- Desktop and mobile layouts do not overflow or obscure primary Thread View actions.
+
+## Work plan
+
+- Inspect current theme and Enter-to-send state ownership in `chat-view.tsx` and `chat-view-composer.tsx`.
+- Add settings dialog state, markup, and accessible controls near the existing Thread View header actions.
+- Move theme and Enter-to-send UI into the dialog while preserving storage keys and behavior.
+- Update CSS for the icon button and dialog across desktop/mobile themes.
+- Add focused unit and E2E coverage for dialog behavior, persistence, and layout.
+- Run targeted validation before handing the slice to sprint evaluation.
+
+## Artifacts / evidence
+
+- Sprint evaluator: `approved` after focus containment was added to the modal settings dialog.
+- Dedicated pre-push validation: passed.
+- Validation:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `npm test` 15 files / 130 tests
+  - `npm run build`
+  - `npx playwright test e2e/issue-313-settings-dialog.spec.ts e2e/issue-305-composer-keybindings.spec.ts e2e/issue-306-theme-switching.spec.ts --project=desktop-chromium --project=mobile-chromium` 14 tests
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-313-settings-dialog`
+- Active worktree: `.worktrees/issue-313-settings-dialog`
+- Notes: Implemented a Thread View settings icon button and accessible modal dialog that owns theme and Enter-to-send preferences. Existing storage keys and defaults are preserved, the old standalone header theme switch and composer preference radios were removed, focus is contained while the dialog is open, and desktop/mobile overflow coverage is in place. Completion retrospective: package archive boundary is satisfied; Issue close still requires commit, push, PR, merge to `main`, parent checkout sync, worktree cleanup, and final Issue/Project completion tracking. Workflow note: E2E validation that updates screenshots can dirty tracked visual artifacts outside the target scope; verify and restore generated artifact churn before archive or commit.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, dedicated pre-push validation passes, completion retrospective is recorded, and handoff notes point to the final validation evidence.


### PR DESCRIPTION
Closes #313\n\n## Summary\n- add a top-right Thread View settings icon button and modal dialog\n- move theme and Enter-to-send preferences into settings\n- preserve persisted preferences and update focused unit/E2E coverage\n\n## Validation\n- npm run check\n- tsc --noEmit\n- npm test\n- npm run build\n- Playwright issue-313/305/306 desktop+mobile