### PR TITLE
fix: keep follow-up submit feedback composer-scoped

### DIFF
--- a/apps/frontend-bff/e2e/helpers/browser-mocks.ts
+++ b/apps/frontend-bff/e2e/helpers/browser-mocks.ts
@@ -316,6 +316,7 @@ export async function mockChatFlow(
   page: Page,
   options: {
     existingThread?: boolean;
+    followupResponseDelayMs?: number;
     longTimeline?: boolean;
   } = {},
 ) {
@@ -337,6 +338,7 @@ export async function mockChatFlow(
   let threadStatus: "idle" | "running" = "idle";
   let latestTurnStatus: "completed" | "running" | "interrupted" = "completed";
   const existingThread = options.existingThread ?? false;
+  const followupResponseDelayMs = options.followupResponseDelayMs ?? 0;
   const longTimeline = options.longTimeline ?? false;
   const timelineItems: Array<{
     timeline_item_id: string;
@@ -589,6 +591,12 @@ export async function mockChatFlow(
       const body = request.postDataJSON() as {
         content: string;
       };
+
+      if (followupResponseDelayMs > 0) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, followupResponseDelayMs);
+        });
+      }
 
       followupCount += 1;
       threadExists = true;

--- a/apps/frontend-bff/e2e/issue-312-submit-feedback.spec.ts
+++ b/apps/frontend-bff/e2e/issue-312-submit-feedback.spec.ts
@@ -1,0 +1,132 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { expectNoHorizontalScroll, mockChatFlow, stubEventSource } from "./helpers/browser-mocks";
+
+const FOLLOWUP_RESPONSE_DELAY_MS = 1_200;
+const GEOMETRY_TOLERANCE_PX = 1;
+
+type ThreadViewGeometry = {
+  readableColumn: {
+    left: number;
+    right: number;
+    top: number;
+    width: number;
+  } | null;
+  scrollRegion: {
+    height: number;
+    top: number;
+  } | null;
+  threadFeedbackCount: number;
+  timelineSection: {
+    left: number;
+    right: number;
+    top: number;
+    width: number;
+  } | null;
+};
+
+async function readThreadViewGeometry(page: Page): Promise<ThreadViewGeometry> {
+  return page.evaluate(() => {
+    const asBox = (element: HTMLElement | null) => {
+      if (!element) {
+        return null;
+      }
+
+      const rect = element.getBoundingClientRect();
+      return {
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        width: rect.width,
+      };
+    };
+
+    const scrollRegion = document.querySelector<HTMLElement>(".thread-view-scroll-region");
+    const scrollRegionRect = scrollRegion?.getBoundingClientRect() ?? null;
+
+    return {
+      readableColumn: asBox(
+        document.querySelector<HTMLElement>(
+          ".thread-view-scroll-region > .thread-view-readable-column",
+        ),
+      ),
+      scrollRegion: scrollRegionRect
+        ? {
+            height: scrollRegionRect.height,
+            top: scrollRegionRect.top,
+          }
+        : null,
+      threadFeedbackCount: document.querySelectorAll(".thread-feedback-card").length,
+      timelineSection: asBox(document.querySelector<HTMLElement>(".timeline-section")),
+    };
+  });
+}
+
+function expectStableGeometry(before: ThreadViewGeometry, pending: ThreadViewGeometry) {
+  expect(before.readableColumn).not.toBeNull();
+  expect(pending.readableColumn).not.toBeNull();
+  expect(before.scrollRegion).not.toBeNull();
+  expect(pending.scrollRegion).not.toBeNull();
+  expect(before.timelineSection).not.toBeNull();
+  expect(pending.timelineSection).not.toBeNull();
+
+  expect(Math.abs(before.readableColumn!.left - pending.readableColumn!.left)).toBeLessThanOrEqual(
+    GEOMETRY_TOLERANCE_PX,
+  );
+  expect(
+    Math.abs(before.readableColumn!.right - pending.readableColumn!.right),
+  ).toBeLessThanOrEqual(GEOMETRY_TOLERANCE_PX);
+  expect(Math.abs(before.readableColumn!.top - pending.readableColumn!.top)).toBeLessThanOrEqual(
+    GEOMETRY_TOLERANCE_PX,
+  );
+  expect(
+    Math.abs(before.timelineSection!.left - pending.timelineSection!.left),
+  ).toBeLessThanOrEqual(GEOMETRY_TOLERANCE_PX);
+  expect(
+    Math.abs(before.timelineSection!.right - pending.timelineSection!.right),
+  ).toBeLessThanOrEqual(GEOMETRY_TOLERANCE_PX);
+  expect(Math.abs(before.timelineSection!.top - pending.timelineSection!.top)).toBeLessThanOrEqual(
+    GEOMETRY_TOLERANCE_PX,
+  );
+  expect(Math.abs(before.scrollRegion!.top - pending.scrollRegion!.top)).toBeLessThanOrEqual(
+    GEOMETRY_TOLERANCE_PX,
+  );
+}
+
+test("existing-thread follow-up pending stays near the composer without inserting a submit feedback card", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-chromium", "desktop-only follow-up layout check");
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await stubEventSource(page);
+  await mockChatFlow(page, {
+    existingThread: true,
+    followupResponseDelayMs: FOLLOWUP_RESPONSE_DELAY_MS,
+    longTimeline: true,
+  });
+
+  await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
+  await expect(page.getByRole("region", { name: "Timeline", exact: true })).toBeVisible();
+  await expect(page.locator(".thread-feedback-card")).toHaveCount(0);
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+  const before = await readThreadViewGeometry(page);
+
+  await page.getByLabel("Continue thread").fill("Please continue from the pending draft.");
+  await page.getByRole("button", { name: "Send message", exact: true }).click();
+
+  const composerFeedback = page.locator(".composer-feedback-note");
+  await expect(composerFeedback).toContainText("Sending input to the current thread.");
+  await expect(composerFeedback).toHaveAttribute("role", "status");
+  await expect(composerFeedback).toHaveAttribute("aria-live", "polite");
+  await expect(page.locator(".thread-feedback-card")).toHaveCount(0);
+
+  const pending = await readThreadViewGeometry(page);
+  expect(pending.threadFeedbackCount).toBe(0);
+  expectStableGeometry(before, pending);
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+  await expect(composerFeedback).toContainText("Input accepted. Waiting for thread updates.");
+  await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+});

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -363,14 +363,12 @@ function buildThreadFeedbackDescriptor({
     };
   }
 
-  if (isSendingMessage) {
+  if (isSendingMessage && isStartingThread) {
     return {
       badgeTone: "success",
       isVisible: true,
-      title: isStartingThread ? "Submitting first input" : "Submitting follow-up input",
-      summary: isStartingThread
-        ? "Input is accepted locally while Thread View waits for the new thread to open."
-        : "Input is accepted locally while Thread View waits for the next thread update.",
+      title: "Submitting first input",
+      summary: "Input is accepted locally while Thread View waits for the new thread to open.",
       actions: [],
     };
   }

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -450,6 +450,98 @@ describe("ChatPageClient", () => {
     expect(container.querySelector(".chat-feedback-stack")).toBeNull();
   });
 
+  it("keeps follow-up pending feedback near the composer while sendThreadInput is unresolved", async () => {
+    const pendingSend = createDeferred<PublicThreadInputAcceptedResponse>();
+
+    chatDataMocks.listWorkspaceThreads.mockResolvedValue({
+      items: [
+        buildThreadListItem({
+          native_status: {
+            thread_status: "waiting_input",
+            active_flags: [],
+            latest_turn_status: null,
+          },
+          current_activity: {
+            kind: "waiting_on_user_input",
+            label: "Waiting for your input",
+          },
+        }),
+      ],
+      next_cursor: null,
+      has_more: false,
+    });
+    chatDataMocks.loadChatThreadBundle.mockResolvedValue({
+      view: buildThreadView({
+        thread: {
+          thread_id: "thread_001",
+          workspace_id: "ws_alpha",
+          title: "Investigate build",
+          native_status: {
+            thread_status: "waiting_input",
+            active_flags: [],
+            latest_turn_status: null,
+          },
+          updated_at: "2026-03-27T05:22:00Z",
+        },
+        current_activity: {
+          kind: "waiting_on_user_input",
+          label: "Waiting for your input",
+        },
+        composer: {
+          accepting_user_input: true,
+          interrupt_available: false,
+          blocked_by_request: false,
+          input_unavailable_reason: null,
+        },
+      }),
+      pendingRequestDetail: null,
+    });
+    chatDataMocks.sendThreadInput.mockReturnValue(pendingSend.promise);
+
+    await act(async () => {
+      root.render(<ChatPageClient />);
+    });
+    await flushUi();
+
+    const textarea = container.querySelector("#thread-composer-input");
+    expect(textarea).not.toBeNull();
+
+    await act(async () => {
+      const setTextareaValue = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+
+      setTextareaValue?.call(textarea as HTMLTextAreaElement, "Continue with the fix.");
+      textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await flushUi();
+
+    const sendButton = container.querySelector(
+      'button[aria-label="Send message"]',
+    ) as HTMLButtonElement | null;
+    expect(sendButton).not.toBeNull();
+
+    await act(async () => {
+      sendButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushUi();
+
+    expect(chatDataMocks.sendThreadInput).toHaveBeenCalledWith(
+      "thread_001",
+      "Continue with the fix.",
+      expect.stringMatching(/^input_followup_/),
+    );
+    const composerFeedback = container.querySelector(".composer-feedback-note");
+    expect(composerFeedback?.textContent).toContain("Sending input to the current thread.");
+    expect(composerFeedback?.getAttribute("role")).toBe("status");
+    expect(composerFeedback?.getAttribute("aria-live")).toBe("polite");
+    expect(container.querySelector(".thread-feedback-card")).toBeNull();
+
+    pendingSend.resolve(buildAcceptedInputResponse());
+    await flushUi();
+  });
+
   it("clears the selected thread from Navigation and starts a workspace-scoped thread", async () => {
     chatDataMocks.listWorkspaceThreads.mockResolvedValue({
       items: [buildThreadListItem()],

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -1012,6 +1012,57 @@ describe("ChatView", () => {
     expect(container.textContent).toContain("Streaming");
   });
 
+  it("keeps follow-up submit pending feedback out of the thread feedback card stack", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          {...buildChatViewBaseProps({
+            composerDraft: "Continue with the next step.",
+            isSendingMessage: true,
+            selectedThreadView: {
+              ...buildChatViewBaseProps().selectedThreadView!,
+              current_activity: {
+                kind: "waiting_on_user_input",
+                label: "Waiting for your input",
+              },
+              composer: {
+                accepting_user_input: true,
+                interrupt_available: false,
+                blocked_by_request: false,
+                input_unavailable_reason: null,
+              },
+            },
+          })}
+        />,
+      );
+    });
+
+    expect(container.querySelector(".thread-feedback-card")).toBeNull();
+    expect(container.textContent).not.toContain("Submitting follow-up input");
+  });
+
+  it("keeps the stronger thread feedback card for first-input submission", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          {...buildChatViewBaseProps({
+            composerDraft: "Start a new thread",
+            isCreatingThread: true,
+            selectedThreadId: null,
+            selectedThreadView: null,
+          })}
+        />,
+      );
+    });
+
+    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
+      "Submitting first input",
+    );
+    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
+      "new thread to open",
+    );
+  });
+
   it("shows the first running progress in the timeline before assistant content arrives", async () => {
     await act(async () => {
       root.render(

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-312-submit-feedback](./archive/issue-312-submit-feedback/README.md)
 - [issue-313-settings-dialog](./archive/issue-313-settings-dialog/README.md)
 - [issue-306-theme-switching](./archive/issue-306-theme-switching/README.md)
 - [issue-305-composer-keybindings](./archive/issue-305-composer-keybindings/README.md)

--- a/tasks/archive/issue-312-submit-feedback/README.md
+++ b/tasks/archive/issue-312-submit-feedback/README.md
@@ -1,0 +1,61 @@
+# Issue 312 Submit Feedback
+
+## Purpose
+
+- Prevent transient follow-up submit feedback from shifting the main Thread View layout.
+
+## Primary issue
+
+- Issue: [#312 UI: avoid layout shift from follow-up submit feedback](https://github.com/tsukushibito/codex-webui/issues/312)
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `apps/frontend-bff/README.md`
+- Related completed work: #302, #303, #304
+
+## Scope for this package
+
+- Replace the normal follow-up submit card with a lower-impact pending affordance that does not shift the main Thread View layout.
+- Keep accessible status semantics for screen readers.
+- Preserve stronger Thread View cards for action-critical or longer-lived states such as opening, reconnecting, recovery, request, error, or blocked-send states.
+- Keep first-input/new-thread submission feedback understandable without reintroducing a global banner.
+- Add focused regression coverage for follow-up send feedback placement and layout stability.
+
+## Exit criteria
+
+- Sending a follow-up input does not insert a full-width card above the timeline.
+- The user still receives a clear pending/accepted signal near the composer, send button, or latest timeline context.
+- The Thread View timeline position and readable column do not jump when the transient submit state appears or disappears.
+- `aria-live` or equivalent accessible status behavior is preserved.
+- Existing scoped feedback routing from #302 remains scoped to the relevant surface.
+
+## Work plan
+
+- Inspect current `threadFeedback` and composer feedback routing for submit states.
+- Move routine follow-up submission feedback out of the Thread View header-card stack.
+- Preserve stronger Thread View feedback for first-input/opening/recovery/action-critical states.
+- Add or update focused tests and E2E coverage for no header-card insertion and layout stability.
+- Run targeted validation before sprint evaluation.
+
+## Artifacts / evidence
+
+- Sprint evaluator: `approved`.
+- Dedicated pre-push validation: passed.
+- Validation:
+  - `npm run check`
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
+  - `npm test` 15 files / 133 tests
+  - `npm run build`
+  - `node ./node_modules/@playwright/test/cli.js test e2e/issue-312-submit-feedback.spec.ts --project=desktop-chromium` 1 test
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Active branch: `issue-312-submit-feedback`
+- Active worktree: `.worktrees/issue-312-submit-feedback`
+- Notes: Suppressed the routine selected-thread follow-up submit card while preserving first-input strong feedback and composer-local pending/accepted status semantics. Added unit, client, and desktop E2E coverage for no submit card insertion, composer feedback accessibility, layout stability, and no horizontal overflow. Completion retrospective: package archive boundary is satisfied; Issue close still requires commit, push, PR, merge to `main`, parent checkout sync, worktree cleanup, and final Issue/Project completion tracking. No durable workflow update is required from this slice.
+
+## Archive conditions
+
+- Archive this package after the exit criteria are met, dedicated pre-push validation passes, completion retrospective is recorded, and handoff notes point to the final validation evidence.


### PR DESCRIPTION
Closes #312\n\n## Summary\n- suppress the strong Thread View submit card for selected-thread follow-up sends\n- keep pending and accepted follow-up status near the composer\n- add unit, client, and focused Playwright layout-stability coverage\n\n## Validation\n- npm run check\n- tsc --noEmit\n- npm test\n- npm run build\n- Playwright issue-312 desktop