### PR TITLE
fix: keep thread status inline

### DIFF
--- a/apps/frontend-bff/app/globals.css
+++ b/apps/frontend-bff/app/globals.css
@@ -424,8 +424,7 @@ textarea {
   margin: 0;
 }
 
-.navigation-notice-stack,
-.thread-feedback-stack {
+.navigation-notice-stack {
   display: grid;
   gap: 10px;
 }
@@ -508,6 +507,11 @@ textarea {
   flex: 1;
   grid-template-rows: minmax(0, 1fr) auto;
   min-height: 0;
+}
+
+.thread-view-boundary-stack {
+  display: grid;
+  gap: 10px;
 }
 
 .thread-view-scroll-stack {
@@ -897,36 +901,6 @@ textarea {
   min-width: 0;
 }
 
-.composer-toolbar {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  min-width: 0;
-}
-
-.composer-toolbar-copy {
-  display: grid;
-  gap: 3px;
-  min-width: 0;
-}
-
-.composer-toolbar-label,
-.composer-toolbar-hint {
-  margin: 0;
-}
-
-.composer-toolbar-label {
-  color: var(--text-main);
-  font-size: 0.82rem;
-  font-weight: 700;
-}
-
-.composer-toolbar-hint {
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  line-height: 1.35;
-}
-
 .composer-mode-toggle {
   display: inline-flex;
   flex-wrap: wrap;
@@ -1061,17 +1035,7 @@ textarea {
 }
 
 .chat-composer-status-rail {
-  display: grid;
-  gap: 6px;
-}
-
-.chat-composer-status-empty,
-.chat-composer-feedback-slot {
-  min-height: 1.2rem;
-}
-
-.chat-composer-feedback-slot {
-  display: grid;
+  display: block;
 }
 
 .chat-message,
@@ -1509,6 +1473,74 @@ textarea {
 .thread-feedback-card {
   display: grid;
   gap: 10px;
+}
+
+.thread-inline-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 10px 12px;
+  min-width: 0;
+  padding: 0 2px;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.thread-inline-status.info,
+.thread-inline-status.success {
+  color: var(--text-muted);
+}
+
+.thread-inline-status.warning,
+.thread-inline-status.error {
+  padding: 10px 12px;
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  background: var(--surface-muted-bg);
+  color: var(--text-main);
+}
+
+.thread-inline-status.warning {
+  border-color: rgba(185, 98, 31, 0.22);
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
+.thread-inline-status.error {
+  border-color: rgba(178, 65, 60, 0.22);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.thread-inline-status-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 16rem;
+}
+
+.thread-inline-status-title,
+.thread-inline-status-message {
+  margin: 0;
+}
+
+.thread-inline-status-title {
+  font-size: 0.84rem;
+}
+
+.thread-inline-status-message-standalone {
+  color: inherit;
+}
+
+.thread-inline-status-actions {
+  flex: 0 1 auto;
+  justify-content: flex-start;
+}
+
+.thread-inline-status-actions .action-button {
+  max-width: 100%;
 }
 
 .thread-feedback-copy {

--- a/apps/frontend-bff/e2e/issue-316-inline-status.spec.ts
+++ b/apps/frontend-bff/e2e/issue-316-inline-status.spec.ts
@@ -1,0 +1,121 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { expectNoHorizontalScroll, mockChatFlow, stubEventSource } from "./helpers/browser-mocks";
+
+const FOLLOWUP_RESPONSE_DELAY_MS = 1_200;
+
+type BoundaryBoxes = {
+  composer: { bottom: number; top: number } | null;
+  inlineStatus: { bottom: number; top: number } | null;
+  latestTimelineRow: { bottom: number; top: number } | null;
+};
+
+async function readBoundaryBoxes(page: Page): Promise<BoundaryBoxes> {
+  return page.evaluate(() => {
+    const toBox = (element: Element | null) => {
+      if (!(element instanceof HTMLElement)) {
+        return null;
+      }
+
+      const rect = element.getBoundingClientRect();
+      return { top: rect.top, bottom: rect.bottom };
+    };
+
+    const timelineRows = Array.from(document.querySelectorAll(".timeline-row"));
+    const latestTimelineRow = timelineRows.at(-1) ?? null;
+
+    return {
+      composer: toBox(document.querySelector(".chat-composer")),
+      inlineStatus: toBox(document.querySelector(".thread-inline-status")),
+      latestTimelineRow: toBox(latestTimelineRow),
+    };
+  });
+}
+
+function expectBoundaryOrder(boxes: BoundaryBoxes) {
+  expect(boxes.latestTimelineRow).not.toBeNull();
+  expect(boxes.inlineStatus).not.toBeNull();
+  expect(boxes.composer).not.toBeNull();
+  expect(boxes.latestTimelineRow!.top).toBeLessThan(boxes.inlineStatus!.top);
+  expect(boxes.inlineStatus!.top).toBeLessThan(boxes.composer!.top);
+}
+
+test.describe("Issue 316 inline status boundary", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await page.setViewportSize(
+      testInfo.project.name === "mobile-chromium"
+        ? { width: 360, height: 800 }
+        : { width: 1440, height: 900 },
+    );
+    await stubEventSource(page);
+    await mockChatFlow(page, {
+      existingThread: true,
+      followupResponseDelayMs: FOLLOWUP_RESPONSE_DELAY_MS,
+      longTimeline: true,
+    });
+  });
+
+  test("keeps follow-up submit feedback inline at the timeline/composer boundary", async ({
+    page,
+  }) => {
+    await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
+
+    await expect(page.getByRole("region", { name: "Timeline", exact: true })).toBeVisible();
+    await expect(page.locator(".thread-feedback-card")).toHaveCount(0);
+    await expect(page.getByText("Keyboard shortcuts", { exact: true })).toHaveCount(0);
+    await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+    await page.getByLabel("Continue thread").fill("Please continue from the pending draft.");
+    await page.getByRole("button", { name: "Send message", exact: true }).click();
+
+    const inlineStatus = page.locator(".thread-inline-status");
+    await expect(inlineStatus).toContainText("Sending input to the current thread.");
+    await expect(inlineStatus).toHaveAttribute("role", "status");
+    await expect(inlineStatus).toHaveAttribute("aria-live", "polite");
+    await expect(page.locator(".thread-feedback-card")).toHaveCount(0);
+    await expect(
+      page.getByText("Please continue from the pending draft.", { exact: true }),
+    ).toBeVisible();
+    await expect(page.locator("#thread-composer-input")).toBeVisible();
+    expectBoundaryOrder(await readBoundaryBoxes(page));
+    await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+
+    await expect(inlineStatus).toContainText("Input accepted. Waiting for thread updates.");
+    await expect(
+      page.getByText("Please continue from the pending draft.", { exact: true }),
+    ).toBeVisible();
+    await expect(page.locator("#thread-composer-input")).toBeVisible();
+    expectBoundaryOrder(await readBoundaryBoxes(page));
+    await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+  });
+
+  test("keeps reconnecting feedback compact and visible with timeline and composer", async ({
+    page,
+  }) => {
+    await page.goto("/chat?workspaceId=ws_alpha&threadId=thread_001");
+
+    await expect(page.getByRole("region", { name: "Timeline", exact: true })).toBeVisible();
+
+    await page.evaluate(() => {
+      const instances = (
+        window as Window & {
+          __mockEventSourceInstances?: Array<{ onerror: (() => void) | null }>;
+        }
+      ).__mockEventSourceInstances;
+
+      for (const instance of instances ?? []) {
+        instance.onerror?.();
+      }
+    });
+
+    const inlineStatus = page.locator(".thread-inline-status");
+    await expect(inlineStatus).toContainText("Reconnecting live updates");
+    await expect(inlineStatus).toContainText("Refresh thread");
+    await expect(inlineStatus).toHaveAttribute("role", "status");
+    await expect(page.locator(".thread-feedback-card")).toHaveCount(0);
+    await expect(page.locator(".timeline-row").last()).toBeVisible();
+    await expect(page.locator("#thread-composer-input")).toBeVisible();
+    expectBoundaryOrder(await readBoundaryBoxes(page));
+    await expect.poll(async () => expectNoHorizontalScroll(page)).toBe(true);
+  });
+});

--- a/apps/frontend-bff/src/chat-view-composer.tsx
+++ b/apps/frontend-bff/src/chat-view-composer.tsx
@@ -4,10 +4,6 @@ import type { ComposerKeybindingMode } from "./chat-view";
 
 export interface ChatViewComposerProps {
   composerDraft: string;
-  composerFeedback: {
-    message: string;
-    tone: "info" | "success" | "warning" | "error";
-  } | null;
   composerInputLabel: string;
   composerKeybindingMode: ComposerKeybindingMode;
   composerPlaceholder: string;
@@ -23,7 +19,6 @@ export interface ChatViewComposerProps {
 
 export function ChatViewComposer({
   composerDraft,
-  composerFeedback,
   composerInputLabel,
   composerKeybindingMode,
   composerPlaceholder,
@@ -76,14 +71,9 @@ export function ChatViewComposer({
 
   return (
     <div className="chat-composer" data-composer-mode={isStartingThread ? "start" : "send"}>
-      <div className="composer-toolbar">
-        <div className="composer-toolbar-copy">
-          <p className="composer-toolbar-label">Keyboard shortcuts</p>
-          <p className="composer-toolbar-hint" id={composerShortcutHintId}>
-            {composerShortcutSummary}
-          </p>
-        </div>
-      </div>
+      <p className="sr-only" id={composerShortcutHintId}>
+        {composerShortcutSummary}
+      </p>
       <label className="composer-input-frame" htmlFor="thread-composer-input">
         <span className="sr-only">{composerInputLabel}</span>
         <textarea
@@ -101,6 +91,7 @@ export function ChatViewComposer({
         />
         <button
           aria-label={composerSubmitLabel}
+          aria-describedby={composerShortcutHintId}
           className="submit-button composer-submit-button"
           disabled={isComposerDisabled}
           onClick={onSubmitComposer}
@@ -144,17 +135,6 @@ export function ChatViewComposer({
         ) : (
           <div aria-hidden="true" className="chat-composer-status chat-composer-status-empty" />
         )}
-        <div className="chat-composer-feedback-slot">
-          {composerFeedback ? (
-            <p
-              aria-live={composerFeedback.tone === "error" ? "assertive" : "polite"}
-              className={`feedback-note composer-feedback-note ${composerFeedback.tone}`}
-              role={composerFeedback.tone === "error" ? "alert" : "status"}
-            >
-              {composerFeedback.message}
-            </p>
-          ) : null}
-        </div>
       </div>
     </div>
   );

--- a/apps/frontend-bff/src/chat-view.tsx
+++ b/apps/frontend-bff/src/chat-view.tsx
@@ -34,6 +34,14 @@ type ScopedFeedback = {
   tone: "info" | "success" | "warning" | "error";
 };
 
+type InlineStatusDescriptor = {
+  actions: ThreadFeedbackAction[];
+  message: string;
+  role: "alert" | "status";
+  title: string | null;
+  tone: ScopedFeedback["tone"];
+};
+
 const SCROLL_FOLLOW_BOTTOM_THRESHOLD_PX = 48;
 const SCROLL_FOLLOW_SUSPEND_DELTA_PX = 24;
 export const THEME_STORAGE_KEY = "codex-webui.theme";
@@ -533,6 +541,95 @@ function buildThreadFeedbackDescriptor({
   };
 }
 
+function normalizeThreadFeedbackTone(
+  tone: ThreadFeedbackDescriptor["badgeTone"],
+): ScopedFeedback["tone"] {
+  switch (tone) {
+    case "success":
+      return "success";
+    case "warning":
+      return "warning";
+    default:
+      return "info";
+  }
+}
+
+function compactInlineErrorMessage(message: string) {
+  const normalized = message.replaceAll(/\s+/g, " ").trim();
+  if (normalized.length <= 96) {
+    return normalized;
+  }
+
+  return "Thread action failed. Refresh the thread or review detail for more information.";
+}
+
+function buildInlineStatusDescriptor({
+  composerFeedback,
+  requestFeedback,
+  threadFeedback,
+  threadViewFeedback,
+}: {
+  composerFeedback: ScopedFeedback | null;
+  requestFeedback: ScopedFeedback | null;
+  threadFeedback: ThreadFeedbackDescriptor;
+  threadViewFeedback: ScopedFeedback | null;
+}): InlineStatusDescriptor | null {
+  if (threadViewFeedback) {
+    return {
+      actions:
+        threadViewFeedback.tone === "error" && threadFeedback.isVisible
+          ? threadFeedback.actions
+          : [],
+      message:
+        threadViewFeedback.tone === "error" && threadFeedback.isVisible
+          ? threadFeedback.summary
+          : threadViewFeedback.tone === "error"
+            ? compactInlineErrorMessage(threadViewFeedback.message)
+            : threadViewFeedback.message,
+      role: threadViewFeedback.tone === "error" ? "alert" : "status",
+      title:
+        threadViewFeedback.tone === "error"
+          ? threadFeedback.isVisible
+            ? threadFeedback.title
+            : "Error"
+          : null,
+      tone: threadViewFeedback.tone,
+    };
+  }
+
+  if (requestFeedback) {
+    return {
+      actions: [],
+      message: requestFeedback.message,
+      role: requestFeedback.tone === "error" ? "alert" : "status",
+      title: null,
+      tone: requestFeedback.tone,
+    };
+  }
+
+  if (composerFeedback) {
+    return {
+      actions: [],
+      message: composerFeedback.message,
+      role: composerFeedback.tone === "error" ? "alert" : "status",
+      title: null,
+      tone: composerFeedback.tone,
+    };
+  }
+
+  if (!threadFeedback.isVisible) {
+    return null;
+  }
+
+  return {
+    actions: threadFeedback.actions,
+    message: threadFeedback.summary,
+    role: "status",
+    title: threadFeedback.title,
+    tone: normalizeThreadFeedbackTone(threadFeedback.badgeTone),
+  };
+}
+
 type MatchableRequest = {
   state: "pending" | "resolved";
   request_id: string;
@@ -848,6 +945,12 @@ export function ChatView({
     (errorMessage !== null
       ? ({ message: errorMessage, tone: "error" } satisfies ScopedFeedback)
       : null);
+  const inlineStatus = buildInlineStatusDescriptor({
+    composerFeedback: effectiveComposerFeedback,
+    requestFeedback: effectiveRequestFeedback,
+    threadFeedback,
+    threadViewFeedback: effectiveThreadViewFeedback,
+  });
   const threadActivitySummary = workspaceId
     ? currentActivitySummary(selectedThreadView, isOpeningSelectedThread)
     : "Choose a workspace to enable the composer.";
@@ -1494,43 +1597,6 @@ export function ChatView({
                 </div>
               </div>
             ) : null}
-            <div className="thread-feedback-stack">
-              {threadFeedback.isVisible ? (
-                <section
-                  aria-live="polite"
-                  className={`thread-feedback-card ${feedbackToneClass(threadFeedback.badgeTone)}`}
-                  role="status"
-                >
-                  <div className="thread-feedback-copy">
-                    <strong>{threadFeedback.title}</strong>
-                    <p>{threadFeedback.summary}</p>
-                  </div>
-                  {threadFeedback.actions.length > 0 ? (
-                    <div className="workspace-actions thread-feedback-actions">
-                      {threadFeedback.actions.map((action) => renderThreadFeedbackAction(action))}
-                    </div>
-                  ) : null}
-                </section>
-              ) : null}
-              {effectiveThreadViewFeedback ? (
-                <p
-                  aria-live={effectiveThreadViewFeedback.tone === "error" ? "assertive" : "polite"}
-                  className={`feedback-note thread-surface-feedback ${feedbackToneClass(effectiveThreadViewFeedback.tone)}`}
-                  role={effectiveThreadViewFeedback.tone === "error" ? "alert" : "status"}
-                >
-                  {effectiveThreadViewFeedback.message}
-                </p>
-              ) : null}
-              {effectiveRequestFeedback ? (
-                <p
-                  aria-live={effectiveRequestFeedback.tone === "error" ? "assertive" : "polite"}
-                  className={`feedback-note request-surface-feedback ${feedbackToneClass(effectiveRequestFeedback.tone)}`}
-                  role={effectiveRequestFeedback.tone === "error" ? "alert" : "status"}
-                >
-                  {effectiveRequestFeedback.message}
-                </p>
-              ) : null}
-            </div>
           </div>
 
           <div className="thread-view-body">
@@ -1694,10 +1760,36 @@ export function ChatView({
               </button>
             </div>
 
-            <div className="thread-view-readable-column">
+            <div className="thread-view-boundary-stack thread-view-readable-column">
+              {inlineStatus ? (
+                <section
+                  aria-live={inlineStatus.role === "alert" ? "assertive" : "polite"}
+                  className={`thread-inline-status ${feedbackToneClass(inlineStatus.tone)}`}
+                  role={inlineStatus.role}
+                >
+                  <div className="thread-inline-status-copy">
+                    {inlineStatus.title ? (
+                      <strong className="thread-inline-status-title">{inlineStatus.title}</strong>
+                    ) : null}
+                    <p
+                      className={
+                        inlineStatus.title
+                          ? "thread-inline-status-message"
+                          : "thread-inline-status-message thread-inline-status-message-standalone"
+                      }
+                    >
+                      {inlineStatus.message}
+                    </p>
+                  </div>
+                  {inlineStatus.actions.length > 0 ? (
+                    <div className="workspace-actions thread-inline-status-actions">
+                      {inlineStatus.actions.map((action) => renderThreadFeedbackAction(action))}
+                    </div>
+                  ) : null}
+                </section>
+              ) : null}
               <ChatViewComposer
                 composerDraft={composerDraft}
-                composerFeedback={effectiveComposerFeedback}
                 composerInputLabel={composerInputLabel}
                 composerKeybindingMode={composerKeybindingMode}
                 composerPlaceholder={composerPlaceholder}

--- a/apps/frontend-bff/tests/chat-page-client.test.tsx
+++ b/apps/frontend-bff/tests/chat-page-client.test.tsx
@@ -441,12 +441,11 @@ describe("ChatPageClient", () => {
     expect((textarea as HTMLTextAreaElement).value).toBe("");
     expect(container.textContent).toContain("Continue with the fix.");
     expect(container.textContent).toContain("Streaming");
-    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
-      "Connecting live updates",
-    );
-    expect(container.querySelector(".composer-feedback-note")?.textContent).toContain(
+    expect(container.querySelector(".thread-inline-status")?.textContent).toContain(
       "Input accepted. Waiting for thread updates.",
     );
+    expect(container.querySelector(".thread-feedback-card")).toBeNull();
+    expect(container.querySelector(".composer-feedback-note")).toBeNull();
     expect(container.querySelector(".chat-feedback-stack")).toBeNull();
   });
 
@@ -532,7 +531,7 @@ describe("ChatPageClient", () => {
       "Continue with the fix.",
       expect.stringMatching(/^input_followup_/),
     );
-    const composerFeedback = container.querySelector(".composer-feedback-note");
+    const composerFeedback = container.querySelector(".thread-inline-status");
     expect(composerFeedback?.textContent).toContain("Sending input to the current thread.");
     expect(composerFeedback?.getAttribute("role")).toBe("status");
     expect(composerFeedback?.getAttribute("aria-live")).toBe("polite");
@@ -1357,7 +1356,7 @@ describe("ChatPageClient", () => {
       "approved",
       expect.stringMatching(/^response_/),
     );
-    expect(container.querySelector(".request-surface-feedback")?.textContent).toContain(
+    expect(container.querySelector(".thread-inline-status")?.textContent).toContain(
       "Approved req_001.",
     );
     expect(container.querySelector(".chat-feedback-stack")).toBeNull();
@@ -1500,12 +1499,13 @@ describe("ChatPageClient", () => {
     await flushUi();
 
     expect(container.textContent).toContain("Streaming");
-    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
+    expect(container.querySelector(".thread-inline-status")?.textContent).toContain(
       "Reconnecting live updates",
     );
-    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
+    expect(container.querySelector(".thread-inline-status")?.textContent).toContain(
       "Refresh thread",
     );
+    expect(container.querySelector(".thread-feedback-card")).toBeNull();
   });
 
   it("marks stream sequence gaps as inconsistent and reacquires selected thread state", async () => {

--- a/apps/frontend-bff/tests/chat-view.test.tsx
+++ b/apps/frontend-bff/tests/chat-view.test.tsx
@@ -646,7 +646,8 @@ describe("ChatView", () => {
     expect(markup).toContain("timeline-row-prominent");
     expect(markup).not.toContain("pending-request-card-fallback");
     expect(markup).toContain("Request detail");
-    expect(markup).toContain("thread-feedback-card");
+    expect(markup).toContain("thread-inline-status");
+    expect(markup).not.toContain("thread-feedback-card");
     expect(markup).not.toContain("Status update");
     expect(markup).not.toContain("timeline-row-compact");
     expect(markup).not.toContain("Inspect artifacts");
@@ -657,6 +658,8 @@ describe("ChatView", () => {
     expect(markup).toContain('id="thread-composer-input"');
     expect(markup).toContain('class="composer-input-frame"');
     expect(markup).toContain('aria-label="Send message"');
+    expect(markup).toContain('aria-describedby="thread-composer-shortcut-hint"');
+    expect(markup).not.toContain("Keyboard shortcuts");
     expect(markup).not.toContain("Send input");
     expect(markup).not.toContain('id="thread-input"');
     expect(markup).not.toContain('id="message-input"');
@@ -885,9 +888,10 @@ describe("ChatView", () => {
     });
 
     expect(container.querySelector(".thread-feedback-card-inline")).toBeNull();
-    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
+    expect(container.querySelector(".thread-inline-status")?.textContent).toContain(
       "Codex is running",
     );
+    expect(container.querySelector(".thread-feedback-card")).toBeNull();
     expect(container.textContent).toContain("Streaming");
     expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
   });
@@ -1005,9 +1009,10 @@ describe("ChatView", () => {
     });
 
     expect(container.querySelector(".thread-feedback-card-inline")).toBeNull();
-    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
+    expect(container.querySelector(".thread-inline-status")?.textContent).toContain(
       "Reconnecting live updates",
     );
+    expect(container.querySelector(".thread-feedback-card")).toBeNull();
     expect(container.querySelector(".timeline-row-live-status")).not.toBeNull();
     expect(container.textContent).toContain("Streaming");
   });
@@ -1041,7 +1046,74 @@ describe("ChatView", () => {
     expect(container.textContent).not.toContain("Submitting follow-up input");
   });
 
-  it("keeps the stronger thread feedback card for first-input submission", async () => {
+  it("renders inline composer feedback between the timeline stack and composer", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          {...buildChatViewBaseProps({
+            composerFeedback: {
+              message: "Input accepted. Waiting for thread updates.",
+              tone: "success",
+            },
+          })}
+        />,
+      );
+    });
+
+    const scrollStack = container.querySelector(".thread-view-scroll-stack");
+    const inlineStatus = container.querySelector(".thread-inline-status");
+    const composer = container.querySelector(".chat-composer");
+
+    expect(scrollStack).not.toBeNull();
+    expect(inlineStatus?.textContent).toContain("Input accepted. Waiting for thread updates.");
+    expect(composer).not.toBeNull();
+    expect(inlineStatus?.getAttribute("role")).toBe("status");
+    expect(inlineStatus?.getAttribute("aria-live")).toBe("polite");
+    if (!scrollStack || !inlineStatus || !composer) {
+      throw new Error("Expected scroll stack, inline status, and composer to be rendered.");
+    }
+    expect(
+      scrollStack.compareDocumentPosition(inlineStatus) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      inlineStatus.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("keeps send shortcut guidance in the accessible button tooltip and description", async () => {
+    await act(async () => {
+      root.render(
+        <ChatView
+          {...buildChatViewBaseProps({
+            composerDraft: "Ship the follow-up.",
+            selectedThreadView: {
+              ...buildChatViewBaseProps().selectedThreadView!,
+              current_activity: {
+                kind: "waiting_on_user_input",
+                label: "Waiting for your input",
+              },
+              composer: {
+                accepting_user_input: true,
+                interrupt_available: false,
+                blocked_by_request: false,
+                input_unavailable_reason: null,
+              },
+            },
+          })}
+        />,
+      );
+    });
+
+    const submitButton = container.querySelector(
+      'button[aria-label="Send message"]',
+    ) as HTMLButtonElement | null;
+    expect(submitButton).not.toBeNull();
+    expect(submitButton?.getAttribute("title")).toBe("Send message (Enter)");
+    expect(submitButton?.getAttribute("aria-describedby")).toBe("thread-composer-shortcut-hint");
+    expect(container.textContent).not.toContain("Keyboard shortcuts");
+  });
+
+  it("keeps first-input submission feedback inline above the composer", async () => {
     await act(async () => {
       root.render(
         <ChatView
@@ -1055,12 +1127,13 @@ describe("ChatView", () => {
       );
     });
 
-    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
+    expect(container.querySelector(".thread-inline-status")?.textContent).toContain(
       "Submitting first input",
     );
-    expect(container.querySelector(".thread-feedback-card")?.textContent).toContain(
+    expect(container.querySelector(".thread-inline-status")?.textContent).toContain(
       "new thread to open",
     );
+    expect(container.querySelector(".thread-feedback-card")).toBeNull();
   });
 
   it("shows the first running progress in the timeline before assistant content arrives", async () => {
@@ -1168,7 +1241,44 @@ describe("ChatView", () => {
     expect(container.textContent).toContain("Streaming");
   });
 
-  it("routes legacy feedback props into scoped thread and composer surfaces", () => {
+  it("keeps recovery and error guidance compact with explicit actions", async () => {
+    const verboseError =
+      "Failed to recover the thread after a long reconnect sequence. Review the latest request and timeline payload for diagnostic context before retrying the action again.";
+
+    await act(async () => {
+      root.render(
+        <ChatView
+          {...buildChatViewBaseProps({
+            errorMessage: verboseError,
+            selectedThreadView: {
+              ...buildChatViewBaseProps().selectedThreadView!,
+              current_activity: {
+                kind: "latest_turn_failed",
+                label: "Latest turn failed",
+              },
+              composer: {
+                accepting_user_input: false,
+                interrupt_available: true,
+                blocked_by_request: false,
+                input_unavailable_reason: "recovery_pending",
+              },
+            },
+          })}
+        />,
+      );
+    });
+
+    const inlineStatus = container.querySelector(".thread-inline-status");
+    expect(inlineStatus?.textContent).toContain("Latest turn failed");
+    expect(inlineStatus?.textContent).toContain("Refresh thread");
+    expect(inlineStatus?.textContent).toContain("Interrupt thread");
+    expect(inlineStatus?.getAttribute("role")).toBe("alert");
+    expect(inlineStatus?.getAttribute("aria-live")).toBe("assertive");
+    expect(inlineStatus?.textContent).not.toContain(verboseError);
+    expect(container.querySelector(".thread-feedback-card")).toBeNull();
+  });
+
+  it("routes legacy error feedback into the compact inline status surface", () => {
     const markup = renderToStaticMarkup(
       <ChatView
         backgroundPriorityNotice={null}
@@ -1207,10 +1317,11 @@ describe("ChatView", () => {
       />,
     );
 
-    expect(markup).toContain("thread-surface-feedback");
-    expect(markup).toContain("chat-composer-feedback-slot");
-    expect(markup).toContain("Thread started.");
+    expect(markup).toContain("thread-inline-status");
     expect(markup).toContain("Failed to interrupt the thread.");
+    expect(markup).not.toContain("Thread started.");
+    expect(markup).not.toContain("thread-feedback-card");
+    expect(markup).not.toContain("chat-composer-feedback-slot");
     expect(markup).not.toContain("chat-feedback-stack");
     expect(markup).not.toContain("error-banner");
   });

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-316-inline-status](./archive/issue-316-inline-status/README.md)
 - [issue-312-submit-feedback](./archive/issue-312-submit-feedback/README.md)
 - [issue-313-settings-dialog](./archive/issue-313-settings-dialog/README.md)
 - [issue-306-theme-switching](./archive/issue-306-theme-switching/README.md)

--- a/tasks/archive/issue-316-inline-status/README.md
+++ b/tasks/archive/issue-316-inline-status/README.md
@@ -1,0 +1,69 @@
+# Issue 316 Inline Status
+
+## Purpose
+
+- Redesign Thread View feedback placement so timeline content stays primary while transient, error, and recovery statuses remain discoverable inline.
+
+## Primary issue
+
+- Issue: [#316](https://github.com/tsukushibito/codex-webui/issues/316)
+
+## Source docs
+
+- `docs/specs/codex_webui_ui_layout_spec_v0_9.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `apps/frontend-bff/README.md`
+
+## Scope for this package
+
+- Move running, reconnecting, submit, accepted, error, and recovery feedback out of large Thread View cards and into compact status near the composer/timeline boundary.
+- Remove always-visible keyboard shortcut copy above the composer input while preserving tooltip and accessible guidance.
+- Add focused test coverage for placement, compact styling, and desktop/mobile layout behavior.
+
+## Exit criteria
+
+- Thread feedback no longer renders as large cards above the timeline for #316 states.
+- Compact status appears between the latest timeline content and the composer.
+- Error and recovery status stays compact while preserving short action affordances and access to longer detail.
+- Visible keyboard shortcut copy is removed from the composer toolbar.
+- Targeted unit and Playwright coverage passes, followed by the dedicated pre-push validation gate.
+
+## Work plan
+
+- Inspect current Thread View and composer feedback rendering.
+- Plan and execute one bounded sprint for the inline status layout.
+- Run targeted component and E2E validation.
+- Run the dedicated pre-push validation gate before archive or publish-oriented handoff.
+- Archive the package after local completion and validation evidence are recorded.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-28T12-57-15Z-issue-316-close/events.ndjson`
+- Sprint validation:
+  - `npm run check` passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - `node ./node_modules/vitest/vitest.mjs run tests/chat-view.test.tsx tests/chat-page-client.test.tsx` passed.
+  - `npm run test:e2e -- e2e/issue-316-inline-status.spec.ts --project=desktop-chromium --project=mobile-chromium` passed.
+- Dedicated pre-push validation:
+  - `npm run check` passed.
+  - `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` passed.
+  - `npm test` passed, 15 files / 136 tests.
+  - `npm run build` passed.
+  - `npm run test:e2e -- e2e/issue-316-inline-status.spec.ts --project=desktop-chromium --project=mobile-chromium` passed, 4 tests.
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: Inline Thread View status implementation is evaluator-approved and dedicated pre-push validation passed. Next handoff is publish-oriented PR creation/merge, parent checkout sync, worktree cleanup, Issue close, and Project `Done`.
+- Completion retrospective:
+  - Completion boundary: package archive only; Issue close remains blocked until the PR reaches `main` and local cleanup is complete.
+  - Contract check: package exit criteria satisfied by the inline status implementation, focused tests, full app validation, and focused desktop/mobile E2E coverage.
+  - What worked: using the existing #312 feedback tests as anchors kept the UI regression focused.
+  - Workflow problems: the initial worktree dependency symlink was unusable for validation and had to be corrected locally.
+  - Improvements to adopt: for worktree-local Node dependency reuse, verify symlink targets before handing the worktree to worker/validator agents.
+  - Skill candidates or skill updates: consider clarifying the work-package symlink example for nested app `node_modules`.
+  - Follow-up updates: none required before archive.
+
+## Archive conditions
+
+- Archive this package when the implementation is evaluator-approved, dedicated pre-push validation passes, and handoff notes summarize the validation evidence.


### PR DESCRIPTION
## Summary

- Move Thread View running/reconnect/error/recovery/send feedback into one compact inline status between timeline and composer
- Remove visible composer keyboard shortcut copy while preserving send tooltip and accessible shortcut description
- Add focused Vitest and Playwright coverage for inline status placement and desktop/mobile layout

Closes #316

## Validation

- `npm run check`
- `node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npm test`
- `npm run build`
- `npm run test:e2e -- e2e/issue-316-inline-status.spec.ts --project=desktop-chromium --project=mobile-chromium`
