### PR TITLE
Switch remote access to Tailscale sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
-NGROK_AUTHTOKEN=your-ngrok-authtoken
-NGROK_BASIC_AUTH=username:password
+TAILSCALE_AUTHKEY=tskey-client-your-tailnet-auth-key
+TAILSCALE_HOSTNAME=codex-webui-dev
+TAILSCALE_USERSPACE=false
+TAILSCALE_SERVE_CONFIG=/var/lib/tailscale/serve/frontend-bff.json
+TAILSCALE_EXTRA_ARGS=--accept-dns=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ARG VULKAN_SDK_VERSION=1.4.341.0
 ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=1000
-ARG NGROK_VERSION=3.30.0
 ARG DEVTUNNEL_DOWNLOAD_URL=https://aka.ms/TunnelsCliDownload/linux-x64
 
 ENV TZ=Asia/Tokyo
@@ -164,11 +163,6 @@ RUN mkdir -p /opt/node \
     && ln -sf /opt/node/bin/npx /usr/local/bin/npx \
     && npm install -g "npm@${NPM_VERSION}" \
     && rm -f "node-v${NODE_VERSION}-linux-x64.tar.xz"
-
-RUN curl -fsSL "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v${NGROK_VERSION}-linux-amd64.tgz" -o /tmp/ngrok.tgz \
-    && tar -xzf /tmp/ngrok.tgz -C /usr/local/bin ngrok \
-    && chmod +x /usr/local/bin/ngrok \
-    && rm -f /tmp/ngrok.tgz
 
 # Keep devtunnel installed until #154 migrates the launcher off the legacy path.
 RUN curl -fsSL "${DEVTUNNEL_DOWNLOAD_URL}" -o /usr/local/bin/devtunnel \

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Work from the app directory you are changing and use its local README for setup 
 For a repo-local development container and launcher workflow, this repository also provides:
 
 - [`Dockerfile`](./Dockerfile)
-- [`docker-compose.yml`](./docker-compose.yml)
+- [`docker-compose.yml`](./docker-compose.yml) for the dev container plus Tailscale sidecar workflow
 - [`scripts/start-tunnel.sh`](./scripts/start-tunnel.sh) for `code tunnel`
-- [`scripts/start-codex-webui.sh`](./scripts/start-codex-webui.sh) for `codex-runtime` + `frontend-bff` + `devtunnel`
+- [`scripts/start-codex-webui.sh`](./scripts/start-codex-webui.sh) for local `codex-runtime` + `frontend-bff` startup inside the shared sidecar namespace
 - [`scripts/stop-codex-webui.sh`](./scripts/stop-codex-webui.sh) for stopping local `codex-runtime` + `frontend-bff` dev processes
-- [`docs/codex_webui_dev_container_onboarding.md`](./docs/codex_webui_dev_container_onboarding.md) for the full container and tunnel workflow
+- [`docs/codex_webui_dev_container_onboarding.md`](./docs/codex_webui_dev_container_onboarding.md) for the full container, Tailscale Serve, and tunnel workflow
 
 Use the onboarding document for the full setup and usage flow instead of relying on the root README for step-by-step operational detail.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,28 @@
 name: ${COMPOSE_PROJECT_NAME:-codex-webui-dev}
 
 services:
+  tailscale:
+    image: tailscale/tailscale:stable
+    container_name: ${TAILSCALE_CONTAINER_NAME:-codex-webui-tailscale}
+    hostname: ${TAILSCALE_HOSTNAME:-codex-webui-dev}
+    init: true
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    volumes:
+      - codex_webui_tailscale_state:${TAILSCALE_STATE_DIR:-/var/lib/tailscale}
+    environment:
+      TS_AUTHKEY: ${TAILSCALE_AUTHKEY:-}
+      TS_HOSTNAME: ${TAILSCALE_HOSTNAME:-codex-webui-dev}
+      TS_USERSPACE: ${TAILSCALE_USERSPACE:-false}
+      TS_STATE_DIR: ${TAILSCALE_STATE_DIR:-/var/lib/tailscale}
+      TS_SERVE_CONFIG: ${TAILSCALE_SERVE_CONFIG:-/var/lib/tailscale/serve/frontend-bff.json}
+      TS_EXTRA_ARGS: ${TAILSCALE_EXTRA_ARGS:---accept-dns=false}
+    restart: unless-stopped
+
   dev:
-    env_file:
-      - .env
     build:
       context: .
       dockerfile: Dockerfile
@@ -23,13 +42,13 @@ services:
     stdin_open: true
     tty: true
     runtime: nvidia
+    depends_on:
+      - tailscale
+    network_mode: service:tailscale
     group_add:
       - "0"
     gpus: all
     working_dir: /workspace
-    ports:
-      - "${CODEX_WEBUI_FRONTEND_PORT:-3000}:${CODEX_WEBUI_FRONTEND_PORT:-3000}"
-      - "${CODEX_WEBUI_RUNTIME_PORT:-3001}:${CODEX_WEBUI_RUNTIME_PORT:-3001}"
     volumes:
       - ./:/workspace
       - ${DOCKER_SOCK_PATH:-/var/run/docker.sock.raw}:/var/run/docker.sock
@@ -56,10 +75,9 @@ services:
       EXPECTED_NPM_PREFIX: ${EXPECTED_NPM_PREFIX:-/home/dev/.npm-global}
       DOCTOR_REQUIRE_GPU: ${DOCTOR_REQUIRE_GPU:-true}
       DOCTOR_RUN_WINIT_SMOKE: ${DOCTOR_RUN_WINIT_SMOKE:-false}
-      CODEX_WEBUI_RUNTIME_PORT: ${CODEX_WEBUI_RUNTIME_PORT:-3001}
       CODEX_WEBUI_FRONTEND_PORT: ${CODEX_WEBUI_FRONTEND_PORT:-3000}
-      NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN:-}
-      NGROK_BASIC_AUTH: ${NGROK_BASIC_AUTH:-}
+      CODEX_WEBUI_RUNTIME_HOST: ${CODEX_WEBUI_RUNTIME_HOST:-127.0.0.1}
+      CODEX_WEBUI_FRONTEND_HOST: ${CODEX_WEBUI_FRONTEND_HOST:-127.0.0.1}
       CODEX_WEBUI_DEVTUNNEL_ID: ${CODEX_WEBUI_DEVTUNNEL_ID:-}
       CODEX_WEBUI_WORKSPACE_ROOT: ${CODEX_WEBUI_WORKSPACE_ROOT:-}
       CODEX_WEBUI_DATABASE_PATH: ${CODEX_WEBUI_DATABASE_PATH:-}
@@ -70,3 +88,4 @@ volumes:
   codex_webui_dev_codex_npm:
   codex_webui_dev_gh_auth:
   codex_webui_dev_vscode_cli:
+  codex_webui_tailscale_state:

--- a/docs/codex_webui_dev_container_onboarding.md
+++ b/docs/codex_webui_dev_container_onboarding.md
@@ -1,6 +1,6 @@
 # Codex WebUI dev container onboarding
 
-Last updated: 2026-04-27
+Last updated: 2026-04-29
 
 ## 1. Purpose
 
@@ -11,7 +11,7 @@ It covers:
 - the repo-root `Dockerfile`
 - the repo-root `docker-compose.yml`
 - the `code tunnel` helper for remote development access
-- the ngrok flow for WebUI verification
+- the supported Tailscale sidecar + Tailscale Serve flow for remote WebUI verification
 
 This is an onboarding and operational guide. It does not replace the maintained product requirements or API specifications under `docs/requirements/` and `docs/specs/`.
 
@@ -20,36 +20,55 @@ This is an onboarding and operational guide. It does not replace the maintained 
 The repository root includes the following development entrypoints:
 
 - `Dockerfile`: development image for this repository
-- `docker-compose.yml`: recommended way to run the dev container
-- `scripts/start-codex-webui.sh`: starts `codex-runtime` and `frontend-bff`, with optional interactive ngrok launch
-- `scripts/stop-codex-webui.sh`: stops local `codex-runtime` and `frontend-bff` dev processes, with optional ngrok cleanup
+- `docker-compose.yml`: recommended way to run the dev container and the Tailscale sidecar
+- `scripts/start-codex-webui.sh`: starts the local runtime service and `frontend-bff` inside the shared sidecar namespace
+- `scripts/stop-codex-webui.sh`: stops local WebUI dev processes from this checkout
 - `scripts/start-tunnel.sh`: starts `code tunnel`
-- `scripts/doctor.sh`: validates the development container toolchain
+- `scripts/doctor.sh`: validates the development container toolchain and prints user-run Tailscale verification steps
 
 The container is intended to mount this repository as `/workspace`.
 
 ## 3. Recommended workflow
 
-### 3.1 Build and start the dev container
+### 3.1 Prepare environment values
 
 From the repository root:
 
 ```bash
 cp .env.example .env
-docker compose up -d --build dev
-docker compose exec dev bash
 ```
 
-The `dev` service also declares `env_file: .env`, so the same file is used as the container-side source for values such as `NGROK_AUTHTOKEN` and `NGROK_BASIC_AUTH`.
+Set at least the following before you bring up the sidecar:
+
+- `TAILSCALE_AUTHKEY`: auth key for the target tailnet
+- `TAILSCALE_HOSTNAME`: optional stable hostname for this dev node
+- `TAILSCALE_USERSPACE`: defaults to `false` for the kernel-networking sidecar path with `/dev/net/tun`
+- `TAILSCALE_SERVE_CONFIG`: optional override for the persisted Serve config path; default is `/var/lib/tailscale/serve/frontend-bff.json`
+
+The supported remote-browser path assumes tailnet membership and Tailscale ACLs are the access boundary. Public internet exposure is out of scope, and `tailscale funnel` is not a supported command for this repo workflow.
+
+### 3.2 Build and start the dev container plus sidecar
+
+From the repository root:
+
+```bash
+docker compose --env-file .env up -d --build tailscale dev
+docker compose --env-file .env exec dev bash
+```
 
 The recommended path is `docker compose`, not a direct `docker run`, because the compose file already defines:
 
 - the repo mount to `/workspace`
 - persistent auth/cache volumes
 - Docker socket access
-- expected environment defaults
+- the shared network namespace between `dev` and the Tailscale sidecar
+- the persistent Tailscale state volume used for node state and Serve configuration
 
-### 3.2 Install app dependencies
+The sidecar owns the network namespace. The local browser-facing entrypoint inside that namespace is `http://127.0.0.1:3000/`. Do not publish or expose the private runtime service directly.
+
+The supported default is kernel networking with `/dev/net/tun`, container caps, and `TS_USERSPACE=false`. Set `TAILSCALE_USERSPACE=true` only if your host cannot provide `/dev/net/tun`; that is a fallback path with different networking behavior, not the primary recommended setup.
+
+### 3.3 Install app dependencies
 
 Inside the container:
 
@@ -67,7 +86,7 @@ npm run build --prefix apps/codex-runtime
 npm run build --prefix apps/frontend-bff
 ```
 
-### 3.3 Validate the container toolchain
+### 3.4 Validate the container toolchain
 
 Inside the container:
 
@@ -75,7 +94,7 @@ Inside the container:
 scripts/doctor.sh
 ```
 
-This checks the expected CLI/toolchain installation, including `code`, `codex`, `ngrok`, Node.js, Python, Rust, and Vulkan tooling.
+This checks the expected CLI/toolchain installation, plus static prerequisites for the supported Tailscale sidecar path. It does not authenticate Tailscale or perform live tailnet verification.
 
 When you run a Vulkan workload directly inside the container, prefer the helper wrapper so an NVIDIA ICD manifest can be synthesized when the graphics libraries are mounted but the manifest is missing:
 
@@ -95,90 +114,91 @@ scripts/start-tunnel.sh
 
 This wrapper is intentionally separate from the WebUI launcher. It is for development access, not for exposing the application to a browser.
 
-## 5. WebUI verification with ngrok
+## 5. Supported remote-browser workflow
 
-Use `ngrok` when you want to verify the WebUI from a remote browser, including smartphone access.
+The supported v0.9 remote-browser path is Tailscale sidecar + Tailscale Serve. The browser-facing surface must remain `frontend-bff` on `http://127.0.0.1:3000/` inside the shared namespace. The private runtime service and App Server must stay unreachable from the browser.
 
-### 5.1 One-time tunnel setup
+### 5.1 Start the local WebUI stack
 
-Inside the container:
-
-```bash
-ngrok config add-authtoken <token>
-```
-
-Set Basic Auth credentials for the remote-browser boundary. A simple shell export is usually enough:
+Inside the dev container:
 
 ```bash
-export NGROK_BASIC_AUTH="<user>:<password>"
+scripts/start-codex-webui.sh
 ```
 
-The supported workflow does not require a fixed public URL or a reserved hostname. A free-plan ngrok URL is acceptable as long as it is available for the current verification session.
+The launcher starts only local services. It binds both processes to `127.0.0.1` by default so they remain inside the sidecar namespace. The frontend keeps its runtime base URL on the private loopback address internally, but that private address is not a supported browser target.
 
-### 5.2 Start the local WebUI stack
-
-The recommended launcher is:
-
-```bash
-scripts/start-codex-webui.sh --interactive
-```
-
-In interactive mode, the launcher can ask whether to start ngrok for the current session and lets you decide the Basic Auth and extra ngrok arguments before it launches the local stack.
-
-If you already know the intended ngrok settings and want a non-interactive run, you can start everything in one command:
-
-```bash
-scripts/start-codex-webui.sh --with-ngrok --ngrok-basic-auth="$NGROK_BASIC_AUTH"
-```
-
-The launcher still supports local-only startup when you omit ngrok flags. App-local commands from `apps/codex-runtime/README.md` and `apps/frontend-bff/README.md` remain valid when you want to run the services separately.
-
-The local browser-facing port remains `3000`, and the runtime stays on `3001`.
-
-If an earlier local WebUI run is still using the default ports, stop it before starting a fresh launcher session:
+If an earlier local WebUI run is still active, stop it before starting again:
 
 ```bash
 scripts/stop-codex-webui.sh
 ```
 
-The stop helper targets local `codex-runtime` and `frontend-bff` dev processes from this checkout. It leaves an existing ngrok tunnel running by default so a subsequent launcher run can reuse it; pass `--with-ngrok` when the tunnel should also be stopped.
+### 5.2 Publish only the frontend through Tailscale Serve
 
-### 5.3 Expose the browser entrypoint with ngrok
-
-If you used `scripts/start-codex-webui.sh --interactive` or `--with-ngrok`, the launcher starts ngrok for you and prints the public URL after the local services are ready.
-
-If an ngrok agent is already running locally for the same frontend port, the launcher reuses that tunnel instead of starting a duplicate. When a fixed ngrok URL is passed through `--ngrok-arg --url --ngrok-arg <url>` or `--ngrok-arg=--url=<url>`, the launcher probes the URL before startup and stops early if the endpoint is already online elsewhere; stop the existing endpoint first, or pass `--ngrok-arg=--pooling-enabled` only when load balancing is intentional.
-
-You can still start ngrok manually when you prefer to keep the launcher local-only:
-
-Inside the container:
+Run these commands from the host checkout or from any shell that can reach the Docker daemon:
 
 ```bash
-ngrok http 3000 --basic-auth="$NGROK_BASIC_AUTH"
+docker compose --env-file .env exec tailscale tailscale status
+docker compose --env-file .env exec tailscale tailscale serve --bg 3000
+docker compose --env-file .env exec tailscale tailscale serve status
 ```
 
-The ngrok URL is the public browser entrypoint for the active session. It fronts only `frontend-bff`; `codex-runtime` and the App Server remain private on the container network.
+Expected Serve behavior:
 
-### 5.4 Verify access
+- the active handler targets only `http://127.0.0.1:3000`
+- the exposed HTTPS URL resolves inside the tailnet only
+- the access boundary is tailnet membership plus ACLs
+- `tailscale funnel` is not used and is not supported for this repo workflow
 
-Verify both desktop and smartphone access against the ngrok URL:
+If you need to inspect the persisted Serve config path:
 
-- open the ngrok URL in a desktop browser
-- confirm the ngrok Basic Auth prompt appears before the UI
-- confirm the WebUI loads successfully after authentication
-- open the same URL from a smartphone browser
-- confirm the local `http://127.0.0.1:3000/` URL still works inside the container for debugging
-- if the ngrok session restarts, use the new public URL; no fixed public URL is required
+```bash
+docker compose --env-file .env exec tailscale sh -lc 'echo "$TS_SERVE_CONFIG" && test -f "$TS_SERVE_CONFIG" && sed -n "1,160p" "$TS_SERVE_CONFIG"'
+```
+
+### 5.3 User-run live verification
+
+Live browser verification is intentionally user-run outside this agent session.
+
+Desktop and smartphone verification steps:
+
+1. Confirm the node is online in the target tailnet:
+
+```bash
+docker compose --env-file .env exec tailscale tailscale status --json
+```
+
+2. Confirm Serve is still pointed at the frontend only:
+
+```bash
+docker compose --env-file .env exec tailscale tailscale serve status --json
+```
+
+3. Capture the tailnet-reachable HTTPS URL from `tailscale status` or the Tailscale admin UI and open it from a desktop browser that is already on the same tailnet.
+4. Confirm the WebUI loads successfully.
+5. Open the same HTTPS URL from a smartphone browser that is also on the same tailnet.
+6. Confirm the smartphone can load the same `frontend-bff` surface.
+7. Confirm the browser workflow does not require or expose a direct private runtime URL.
+
+Expected evidence:
+
+- a desktop screenshot of the WebUI over the tailnet URL
+- a smartphone screenshot of the same WebUI over the tailnet URL
+- `tailscale serve status --json` output showing the handler mapped to `http://127.0.0.1:3000`
+- no browser step, command, or screenshot that depends on direct access to the private runtime service
 
 ## 6. Useful environment variables
 
-- `NGROK_AUTHTOKEN`: optional shell-side convenience variable for the ngrok auth token
-- `NGROK_BASIC_AUTH`: optional shell-side convenience variable for the ngrok Basic Auth credential pair
-- `CODEX_WEBUI_RUNTIME_PORT`: defaults to `3001`
+- `TAILSCALE_AUTHKEY`: auth key used by the sidecar container
+- `TAILSCALE_HOSTNAME`: optional tailnet hostname override for the sidecar container
+- `TAILSCALE_USERSPACE`: defaults to `false`; set `true` only as a fallback when the host cannot provide `/dev/net/tun`
+- `TAILSCALE_SERVE_CONFIG`: persisted Serve config path inside the sidecar state volume
+- `TAILSCALE_EXTRA_ARGS`: optional extra `tailscale up` flags; the documented default disables Tailscale-managed DNS rewrites
 - `CODEX_WEBUI_FRONTEND_PORT`: defaults to `3000`
 - `CODEX_WEBUI_WORKSPACE_ROOT`: optional override for the runtime workspace root
 - `CODEX_WEBUI_DATABASE_PATH`: optional override for the runtime SQLite path
-- `CODEX_WEBUI_RUNTIME_BASE_URL`: optional override for the BFF runtime base URL
+- `CODEX_WEBUI_RUNTIME_BASE_URL`: optional override for the internal BFF runtime base URL
 - `CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED`: optional override for the runtime bridge flag; defaults to enabled, set it to `false` only when you intentionally want the synthetic gateway path
 
 ## 7. Direct Docker usage
@@ -189,60 +209,48 @@ The repo-root `Dockerfile` can also be built directly:
 docker build -t codex-webui/dev .
 ```
 
-However, direct `docker run` is not the primary documented workflow because you would need to recreate the compose-managed volume mounts and runtime options yourself.
+However, direct `docker run` is not the primary documented workflow because you would need to recreate the compose-managed volume mounts, GPU options, and the shared Tailscale sidecar namespace yourself.
 
 Use `docker-compose.yml` unless you have a specific reason not to.
 
 ## 8. Troubleshooting
 
-### 8.1 `ngrok` command not found
+### 8.1 Tailscale sidecar does not authenticate
 
-Rebuild the image:
-
-```bash
-docker compose up -d --build dev
-```
-
-### 8.2 ngrok authentication is missing
-
-Export `NGROK_AUTHTOKEN` or run `ngrok config add-authtoken <token>` before starting the tunnel.
-
-### 8.3 ngrok cannot reach port `3000`
-
-Run:
+Confirm that `.env` contains a valid `TAILSCALE_AUTHKEY`, then recreate the sidecar:
 
 ```bash
-ngrok http 3000 --basic-auth="$NGROK_BASIC_AUTH"
+docker compose --env-file .env up -d --build tailscale dev
+docker compose --env-file .env logs tailscale
 ```
 
-Or rerun the launcher in interactive mode:
+If your host cannot provide `/dev/net/tun`, set `TAILSCALE_USERSPACE=true` and recreate the sidecar. This is a fallback, not the preferred path, because the documented default assumes kernel networking with tun plus the required caps.
+
+### 8.2 Tailscale Serve does not point at the frontend
+
+Reapply the supported Serve command:
 
 ```bash
-scripts/start-codex-webui.sh --interactive
+docker compose --env-file .env exec tailscale tailscale serve --bg 3000
+docker compose --env-file .env exec tailscale tailscale serve status
 ```
 
-If the browser still cannot load the UI, confirm the frontend is listening on `127.0.0.1:3000` inside the container.
+The supported Serve target is only `http://127.0.0.1:3000`.
 
-### 8.4 Port `3000` is already in use
+### 8.3 Port `3000` is already in use inside the shared namespace
 
-If the launcher reports `EADDRINUSE` for `0.0.0.0:3000`, an earlier `frontend-bff` process is still bound to the browser-facing port. Stop the local WebUI processes and start again:
+If the launcher reports `EADDRINUSE` for `127.0.0.1:3000`, an earlier `frontend-bff` process is still active in this checkout. Stop local WebUI processes and start again:
 
 ```bash
 scripts/stop-codex-webui.sh
-scripts/start-codex-webui.sh --interactive
+scripts/start-codex-webui.sh
 ```
 
-Use `scripts/stop-codex-webui.sh --with-ngrok` when you also want to stop the local ngrok agent for the frontend port.
-
-### 8.5 ngrok endpoint is already online
-
-For fixed ngrok URLs, `ERR_NGROK_334` means another endpoint with the same URL is already online. Stop the existing ngrok process or dashboard endpoint, then rerun the launcher. If the existing process is a local ngrok agent for the same frontend port, the launcher should detect and reuse it automatically.
-
-### 8.6 The runtime fails because the workspace root does not exist
+### 8.4 The runtime fails because the workspace root does not exist
 
 The local startup process creates the default workspace root for you. If you override `CODEX_WEBUI_WORKSPACE_ROOT`, make sure the target path is valid and writable inside the container.
 
-### 8.7 `vulkaninfo` only shows `llvmpipe`
+### 8.5 `vulkaninfo` only shows `llvmpipe`
 
 If `nvidia-smi` works but `vulkaninfo --summary` still falls back to `llvmpipe`, the container runtime is exposing compute/NVML but not the NVIDIA graphics stack or Vulkan ICD.
 
@@ -250,7 +258,7 @@ This repository now ships `scripts/with-vulkan-driver.sh`, which can repair the 
 
 If the helper still cannot surface an NVIDIA Vulkan device, the host runtime is not providing the required graphics libraries. Native Linux Docker Engine with NVIDIA Container Toolkit is the recommended path for containerized Vulkan validation. Docker Desktop on Windows with the WSL2 backend is reliable for GPU compute, but may not expose the full graphics/Vulkan stack needed for Vulkan app development inside containers.
 
-### 8.8 Vulkan SDK download 404s during image build
+### 8.6 Vulkan SDK download 404s during image build
 
 The Dockerfile uses LunarG's automated download API with the generic Linux file name, `vulkan_sdk.tar.xz`, instead of constructing the embedded-version tarball name directly.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Codex WebUI LLM Wiki Index
 
-Last updated: 2026-04-27
+Last updated: 2026-04-29
 
 ## Purpose
 
@@ -40,7 +40,7 @@ Read this file first when you need to locate maintained knowledge across source-
 
 - [AGENTS.md](../AGENTS.md): repo-wide workflow rules, including wiki promotion and update triggers
 - [docs/codex_webui_mvp_roadmap_v0_1.md](./codex_webui_mvp_roadmap_v0_1.md): phase breakdown and delivery order; for UX questions, treat it as sequencing guidance and use the v0.9 UI layout spec plus v0.9 requirements/specs as the current UX source of truth
-- [docs/codex_webui_dev_container_onboarding.md](./codex_webui_dev_container_onboarding.md): development container and tunnel workflow
+- [docs/codex_webui_dev_container_onboarding.md](./codex_webui_dev_container_onboarding.md): development container, Tailscale sidecar, Tailscale Serve, and tunnel workflow
 - [docs/README.md](./README.md): wiki maintenance workflow and category-specific placement rules
 
 ## Update expectations

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,6 +1,6 @@
 # Codex WebUI LLM Wiki Log
 
-Last updated: 2026-04-27
+Last updated: 2026-04-29
 
 ## Purpose
 
@@ -28,6 +28,42 @@ After the heading, keep the body concise:
 - short note on what changed or remains deferred
 
 ## Entries
+
+## [2026-04-29] ingest | Issue #318 Tailscale sidecar remote-browser path
+
+Source:
+
+- approved sprint slice for Issue `#318`
+- `docker-compose.yml`
+- `.env.example`
+- `Dockerfile`
+- `scripts/start-codex-webui.sh`
+- `scripts/stop-codex-webui.sh`
+- `scripts/doctor.sh`
+- `docs/codex_webui_dev_container_onboarding.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+
+Updated:
+
+- `README.md`
+- `docker-compose.yml`
+- `.env.example`
+- `Dockerfile`
+- `scripts/start-codex-webui.sh`
+- `scripts/stop-codex-webui.sh`
+- `scripts/doctor.sh`
+- `docs/codex_webui_dev_container_onboarding.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/index.md`
+- `docs/log.md`
+
+Notes:
+
+- replaced the supported ngrok browser path with a Tailscale Docker sidecar plus Tailscale Serve
+- kept `frontend-bff` as the only browser-facing entrypoint and documented that Serve must target only `http://127.0.0.1:3000`
+- removed supported ngrok launcher, stop-helper, env-example, and image-installation guidance
+- documented that tailnet membership plus ACLs are the access boundary and that Tailscale Funnel is not supported
+- left live Docker/Tailscale desktop and smartphone verification as an explicit user-run step
 
 ## [2026-04-27] query | desktop thread view composer and header refinement
 

--- a/docs/requirements/codex_webui_mvp_requirements_v0_9.md
+++ b/docs/requirements/codex_webui_mvp_requirements_v0_9.md
@@ -4,7 +4,7 @@
 
 This document defines the requirements for CodexWebUI v0.9, reorganized around the **public contract of Codex App Server**.
 
-The supported remote-browser path for v0.9 is ngrok. ngrok Basic Auth is the access-control boundary for browser access, while OAuth / SSO / app-owned accounts remain out of scope for MVP.
+The supported remote-browser path for v0.9 is a Tailscale Docker sidecar plus Tailscale Serve. Tailnet membership and Tailscale ACLs are the access-control boundary for browser access, while OAuth / SSO / app-owned accounts remain out of scope for MVP. Public internet exposure through Tailscale Funnel is out of scope.
 
 The primary goal of v0.9 is to provide a natural UX, close to Codex CLI / TUI, in PC and smartphone web browsers.  
 To achieve that, WebUI must not introduce a thick, independent conversation state machine. Instead, it must treat the **native conversation model exposed by Codex App Server as the primary domain**, and keep WebUI-specific concepts limited to workspace handling and the minimum browser-facing facade concepts required.
@@ -65,7 +65,7 @@ WebUI must not foreground its own `thread create / start` as a primary concept.
 - support for both PC and smartphone
 - conversation, execution, approval, and confirmation flows backed by Codex App Server
 - workspace operations limited to directories under `/workspaces`
-- browser access through ngrok
+- browser access through Tailscale Serve on a tailnet-reachable `frontend-bff` endpoint
 
 ### 3.2 Out of scope
 - turning the product into a general-purpose IDE
@@ -81,10 +81,11 @@ WebUI must not foreground its own `thread create / start` as a primary concept.
 ### 3.3 System and operational boundaries
 - the only externally exposed entry point must be `frontend-bff` or an equivalent facade backend
 - `codex-runtime` must not be exposed externally
-- authentication is delegated to ngrok Basic Auth, and WebUI-specific authentication / authorization is out of scope for MVP
+- authentication is delegated to tailnet membership and Tailscale ACLs, and WebUI-specific authentication / authorization is out of scope for MVP
 - the product assumes a single user and does not handle consistency or access control for concurrent multi-user actions
-- the security boundary is ngrok Basic Auth and host-side operations; fine-grained in-app authorization is not an MVP requirement
-- the supported remote-browser path does not require a fixed public URL; free-plan ngrok endpoints may change between sessions, and the workflow only assumes the currently assigned public URL is usable for the active session
+- the security boundary is tailnet membership, Tailscale ACLs, and host-side operations; fine-grained in-app authorization is not an MVP requirement
+- the supported remote-browser path exposes only `frontend-bff` through Tailscale Serve, which must target `http://127.0.0.1:3000` inside the shared sidecar namespace
+- Tailscale Funnel or any public-internet exposure is not supported for the maintained workflow
 - OAuth, SSO, and app-owned account management are out of scope for MVP
 - although this document is UX-focused, the public boundary, authentication responsibility, and single-user assumption are treated as fixed conditions
 
@@ -126,7 +127,7 @@ Concrete field names, response shapes, and transport-level representations may b
 - WebUI does not replace the App Server source of truth
 - the WebUI backend handles only operational concepts not present in App Server and browser-facing reshaping
 - App Server may allow multiple active threads, and WebUI must not restrict that unnecessarily
-- the only external entry point is the WebUI behind ngrok; runtime and App Server are not exposed directly
+- the only external entry point is the WebUI behind Tailscale Serve; runtime and App Server are not exposed directly
 - MVP assumes a single user and does not handle concurrent editing / approval coordination across multiple users
 
 ---
@@ -353,7 +354,7 @@ The priority is that users can return directly to the necessary thread from the 
 - ensures client request idempotency
 - detects and assists convergence of partial failures
 - stores or derives thread-scoped ordering metadata
-- provides the minimum public boundary as the ngrok-facing entry point
+- provides the minimum public boundary as the Tailscale-Serve-facing entry point
 
 #### Frontend
 - constructs thread view
@@ -365,7 +366,7 @@ The priority is that users can return directly to the necessary thread from the 
 ### 10.3 Public boundary
 - only `frontend-bff` or an equivalent facade backend may be exposed externally
 - `codex-runtime` and App Server are for internal communication only
-- MVP does not add app-specific authentication; authentication is delegated to ngrok Basic Auth
+- MVP does not add app-specific authentication; authentication is delegated to tailnet membership and Tailscale ACLs
 
 ---
 
@@ -781,7 +782,7 @@ The backend must satisfy at least the following:
 - only the browser-facing facade may be exposed externally
 - runtime and App Server must not be exposed directly to the browser
 - MVP assumes a single user and does not handle conflict resolution for multi-user usage
-- authentication assumes ngrok Basic Auth, and additional in-app authentication is not part of the mandatory requirements
+- authentication assumes tailnet membership and Tailscale ACLs, and additional in-app authentication is not part of the mandatory requirements
 
 ---
 
@@ -828,7 +829,7 @@ v0.9 MVP is considered established when the following are satisfied:
 - browser UX based on REST + SSE
 - minimum app-owned metadata for idempotency and reconnect convergence
 - thread-scoped ordering foundation
-- ngrok-based public boundary
+- Tailscale-Serve-based public boundary
 
 ### 22.2 Should
 - stronger thread list UX
@@ -890,6 +891,6 @@ The following are not goals in v0.9:
 - a canonical-feed-like helper projection may be retained, but it must not become a substitute source of truth for App Server full history
 - the system must have a thread-scoped stable ordering foundation, and REST reacquisition is authoritative after reconnect
 - request helpers are assumed to remain reachable from thread context for pending requests and just-resolved requests
-- the facade backend is the only public entry point, and authentication is delegated to ngrok Basic Auth
+- the facade backend is the only public entry point, and authentication is delegated to tailnet membership and Tailscale ACLs
 - the single-user assumption is a fixed condition in v0.9
 - `App Server Contract Matrix v0.9` is a prerequisite artifact before implementation starts

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -13,8 +13,10 @@ DOCTOR_RUN_WINIT_SMOKE="${DOCTOR_RUN_WINIT_SMOKE:-false}"
 DOCTOR_DEBUG="${DOCTOR_DEBUG:-false}"
 DOCTOR_DEBUG_LINES="${DOCTOR_DEBUG_LINES:-120}"
 EXPECTED_CARGO_VERSION_PREFIX="${EXPECTED_CARGO_VERSION_PREFIX:-${EXPECTED_RUST_VERSION%.*}}"
-NGROK_AUTHTOKEN="${NGROK_AUTHTOKEN:-}"
-NGROK_BASIC_AUTH="${NGROK_BASIC_AUTH:-}"
+TAILSCALE_AUTHKEY="${TAILSCALE_AUTHKEY:-}"
+TAILSCALE_HOSTNAME="${TAILSCALE_HOSTNAME:-}"
+TAILSCALE_USERSPACE="${TAILSCALE_USERSPACE:-false}"
+TAILSCALE_SERVE_CONFIG="${TAILSCALE_SERVE_CONFIG:-/var/lib/tailscale/serve/frontend-bff.json}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 failures=0
@@ -106,15 +108,15 @@ check_command() {
   fi
 }
 
-check_required_env() {
+print_env_state() {
   local label="$1"
   local value="$2"
+  local missing_message="$3"
 
   if [[ -n "${value}" ]]; then
     echo "[ok] ${label}: set"
   else
-    echo "[ng] ${label}: required for the supported ngrok remote-browser path"
-    failures=$((failures + 1))
+    echo "[info] ${label}: ${missing_message}"
   fi
 }
 
@@ -131,7 +133,6 @@ fi
 echo "== command checks =="
 check_command "VS Code CLI" "code"
 check_command "Codex CLI" "codex"
-check_command "ngrok CLI" "ngrok"
 check_command "Python" "python"
 check_command "uv" "uv"
 check_command "Node.js" "node"
@@ -139,6 +140,7 @@ check_command "npm" "npm"
 check_command "rustc" "rustc"
 check_command "cargo" "cargo"
 check_command "vulkaninfo" "vulkaninfo"
+check_command "Docker CLI" "docker"
 
 echo
 echo "== version checks =="
@@ -152,17 +154,29 @@ check_contains "vulkan sdk path" "${VULKAN_SDK:-unset}" "${EXPECTED_VULKAN_SDK_V
 check_contains "npm prefix" "$(npm config get prefix || true)" "${EXPECTED_NPM_PREFIX}"
 
 echo
-echo "== ngrok prerequisites =="
-check_required_env "NGROK_AUTHTOKEN" "${NGROK_AUTHTOKEN}"
-check_required_env "NGROK_BASIC_AUTH" "${NGROK_BASIC_AUTH}"
+echo "== Tailscale sidecar prerequisites =="
+print_env_state "TAILSCALE_AUTHKEY" "${TAILSCALE_AUTHKEY}" "set it in .env before user-run tailnet verification"
+print_env_state "TAILSCALE_HOSTNAME" "${TAILSCALE_HOSTNAME}" "optional; defaults to codex-webui-dev when omitted"
+echo "[info] TAILSCALE_USERSPACE: ${TAILSCALE_USERSPACE} (recommended default: false for /dev/net/tun kernel networking)"
+echo "[info] TAILSCALE_SERVE_CONFIG expected path: ${TAILSCALE_SERVE_CONFIG}"
+echo "[info] Set TAILSCALE_USERSPACE=true only if the host cannot provide /dev/net/tun; that is a fallback with different networking behavior."
+
+echo
+echo "== Tailscale sidecar live checks (user-run, not validated here) =="
+echo "[info] docker compose up -d --build tailscale dev"
+echo "[info] docker compose exec dev bash -lc 'scripts/start-codex-webui.sh'"
+echo "[info] docker compose exec tailscale tailscale status"
+echo "[info] docker compose exec tailscale tailscale serve --bg 3000"
+echo "[info] docker compose exec tailscale tailscale serve status"
+echo "[info] Expected live evidence: Serve targets only http://127.0.0.1:3000 and the MagicDNS / tailnet URL loads frontend-bff from desktop and smartphone."
 
 echo
 echo "== legacy launcher note =="
 if command -v devtunnel >/dev/null 2>&1; then
-  echo "[info] devtunnel is still installed as temporary legacy tooling for scripts/start-codex-webui.sh; cleanup is deferred to #154."
+  echo "[info] devtunnel is still installed as temporary legacy tooling for scripts/start-tunnel.sh; cleanup is deferred to its legacy follow-up."
   echo "[info] devtunnel --version: $(devtunnel --version || true)"
 else
-  echo "[info] devtunnel is not required for the supported ngrok path; launcher migration/removal is deferred to #154."
+  echo "[info] devtunnel is optional legacy tooling and is not required for the supported Tailscale sidecar path."
 fi
 
 echo

--- a/scripts/start-codex-webui.sh
+++ b/scripts/start-codex-webui.sh
@@ -6,9 +6,9 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 RUNTIME_DIR="${REPO_ROOT}/apps/codex-runtime"
 FRONTEND_DIR="${REPO_ROOT}/apps/frontend-bff"
 
-RUNTIME_HOST="${CODEX_WEBUI_RUNTIME_HOST:-0.0.0.0}"
+RUNTIME_HOST="${CODEX_WEBUI_RUNTIME_HOST:-127.0.0.1}"
 RUNTIME_PORT="${CODEX_WEBUI_RUNTIME_PORT:-3001}"
-FRONTEND_HOST="${CODEX_WEBUI_FRONTEND_HOST:-0.0.0.0}"
+FRONTEND_HOST="${CODEX_WEBUI_FRONTEND_HOST:-127.0.0.1}"
 FRONTEND_PORT="${CODEX_WEBUI_FRONTEND_PORT:-3000}"
 WORKSPACE_ROOT="${CODEX_WEBUI_WORKSPACE_ROOT:-${RUNTIME_DIR}/var/workspaces}"
 DATABASE_PATH="${CODEX_WEBUI_DATABASE_PATH:-${RUNTIME_DIR}/var/data/codex-runtime.sqlite}"
@@ -16,39 +16,21 @@ RUNTIME_BASE_URL="${CODEX_WEBUI_RUNTIME_BASE_URL:-http://127.0.0.1:${RUNTIME_POR
 STARTUP_TIMEOUT_SECONDS="${CODEX_WEBUI_STARTUP_TIMEOUT_SECONDS:-180}"
 APP_SERVER_BRIDGE_ENABLED="${CODEX_WEBUI_APP_SERVER_BRIDGE_ENABLED:-1}"
 LOG_FILE="${CODEX_WEBUI_LOG_FILE:-}"
-NGROK_PORT="${CODEX_WEBUI_NGROK_PORT:-${FRONTEND_PORT}}"
-NGROK_API_URL="${CODEX_WEBUI_NGROK_API_URL:-http://127.0.0.1:4040/api/tunnels}"
-NGROK_AUTHTOKEN_VALUE="${NGROK_AUTHTOKEN:-}"
-NGROK_BASIC_AUTH_VALUE="${NGROK_BASIC_AUTH:-}"
 DEBUG_LIVE_CHAT=false
-INTERACTIVE=false
-START_NGROK=false
-NGROK_STARTED_BY_LAUNCHER=false
-NGROK_REUSED_EXISTING=false
-NGROK_PUBLIC_URL=""
-NGROK_EXTRA_ARGS=()
 
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/start-codex-webui.sh [--debug-live-chat] [--interactive] [--with-ngrok] [--log-file PATH] [--ngrok-basic-auth VALUE] [--ngrok-authtoken VALUE] [--ngrok-arg ARG] [--help]
+  scripts/start-codex-webui.sh [--debug-live-chat] [--log-file PATH] [--help]
 
 Options:
   --debug-live-chat  Enable live-chat debug logs for runtime and frontend
-  --interactive      Prompt for optional ngrok launch and config before startup
   --log-file         Append combined launcher, runtime, and frontend output to PATH
-  --with-ngrok       Start ngrok automatically after local startup succeeds
-  --ngrok-basic-auth Set ngrok Basic Auth as user:pass for this run
-  --ngrok-authtoken  Configure ngrok authtoken for this run before launch
-  --ngrok-arg        Append one extra argument to the ngrok command; repeat as needed
   --help             Show this help text
 
-Environment:
-  NGROK_AUTHTOKEN=<token>                 Optional ngrok authtoken for interactive or --with-ngrok runs
-  NGROK_BASIC_AUTH=user:pass              Optional Basic Auth pair for ngrok runs
-
-Without --with-ngrok, start remote browser access separately with:
-  ngrok http 3000 --basic-auth="$NGROK_BASIC_AUTH"
+This launcher starts only the local runtime and frontend inside the current namespace.
+For remote browser access, run Tailscale sidecar and Tailscale Serve separately as documented in
+docs/codex_webui_dev_container_onboarding.md.
 EOF
 }
 
@@ -57,9 +39,6 @@ parse_args() {
     case "$1" in
       --debug-live-chat)
         DEBUG_LIVE_CHAT=true
-        ;;
-      --interactive)
-        INTERACTIVE=true
         ;;
       --log-file)
         shift
@@ -73,45 +52,6 @@ parse_args() {
         if [[ -z "${LOG_FILE}" ]]; then
           fail "--log-file requires a path"
         fi
-        ;;
-      --with-ngrok)
-        START_NGROK=true
-        ;;
-      --ngrok-basic-auth)
-        shift
-        if (($# == 0)); then
-          fail "--ngrok-basic-auth requires a value"
-        fi
-        NGROK_BASIC_AUTH_VALUE="$1"
-        ;;
-      --ngrok-basic-auth=*)
-        NGROK_BASIC_AUTH_VALUE="${1#*=}"
-        if [[ -z "${NGROK_BASIC_AUTH_VALUE}" ]]; then
-          fail "--ngrok-basic-auth requires a value"
-        fi
-        ;;
-      --ngrok-authtoken)
-        shift
-        if (($# == 0)); then
-          fail "--ngrok-authtoken requires a value"
-        fi
-        NGROK_AUTHTOKEN_VALUE="$1"
-        ;;
-      --ngrok-authtoken=*)
-        NGROK_AUTHTOKEN_VALUE="${1#*=}"
-        if [[ -z "${NGROK_AUTHTOKEN_VALUE}" ]]; then
-          fail "--ngrok-authtoken requires a value"
-        fi
-        ;;
-      --ngrok-arg)
-        shift
-        if (($# == 0)); then
-          fail "--ngrok-arg requires a value"
-        fi
-        NGROK_EXTRA_ARGS+=("$1")
-        ;;
-      --ngrok-arg=*)
-        NGROK_EXTRA_ARGS+=("${1#*=}")
         ;;
       --help|-h)
         usage
@@ -149,22 +89,6 @@ fail() {
   exit 1
 }
 
-mask_secret() {
-  local value="$1"
-
-  if [[ -z "${value}" ]]; then
-    printf '%s' "unset"
-    return 0
-  fi
-
-  if [[ "${value}" == *:* ]]; then
-    printf '%s' "${value%%:*}:********"
-    return 0
-  fi
-
-  printf '%s' "********"
-}
-
 setup_logging() {
   if [[ -z "${LOG_FILE}" ]]; then
     return 0
@@ -197,137 +121,6 @@ require_file() {
 
   if [[ ! -f "${path}" ]]; then
     fail "required file not found: ${path}"
-  fi
-}
-
-prompt_yes_no() {
-  local prompt="$1"
-  local default_answer="$2"
-  local suffix="[y/N]"
-  local reply=""
-
-  if [[ "${default_answer}" == "yes" ]]; then
-    suffix="[Y/n]"
-  fi
-
-  while true; do
-    read -r -p "[codex-webui] ${prompt} ${suffix} " reply || fail "interactive prompt aborted"
-    reply="${reply,,}"
-
-    if [[ -z "${reply}" ]]; then
-      reply="${default_answer}"
-    fi
-
-    case "${reply}" in
-      y|yes)
-        return 0
-        ;;
-      n|no)
-        return 1
-        ;;
-      *)
-        log "please answer yes or no"
-        ;;
-    esac
-  done
-}
-
-prompt_value() {
-  local prompt="$1"
-  local hidden="${2:-false}"
-  local value=""
-
-  if [[ "${hidden}" == "true" ]]; then
-    read -r -s -p "[codex-webui] ${prompt} " value || fail "interactive prompt aborted"
-    echo
-  else
-    read -r -p "[codex-webui] ${prompt} " value || fail "interactive prompt aborted"
-  fi
-
-  printf '%s' "${value}"
-}
-
-configure_ngrok_interactive() {
-  local entered_value=""
-  local extra_args_input=""
-
-  if [[ ! -t 0 || ! -t 1 ]]; then
-    fail "--interactive requires a TTY"
-  fi
-
-  if [[ "${START_NGROK}" != "true" ]]; then
-    if prompt_yes_no "Expose frontend-bff through ngrok after local startup?" "no"; then
-      START_NGROK=true
-    fi
-  fi
-
-  if [[ "${START_NGROK}" != "true" ]]; then
-    return 0
-  fi
-
-  prepare_existing_ngrok
-  if [[ "${NGROK_REUSED_EXISTING}" == "true" ]]; then
-    return 0
-  fi
-
-  if [[ -n "${NGROK_AUTHTOKEN_VALUE}" ]]; then
-    if ! prompt_yes_no "Use configured ngrok authtoken ($(mask_secret "${NGROK_AUTHTOKEN_VALUE}"))?" "yes"; then
-      entered_value="$(prompt_value "Enter ngrok authtoken now, or leave blank to skip:" true)"
-      NGROK_AUTHTOKEN_VALUE="${entered_value}"
-    fi
-  else
-    entered_value="$(prompt_value "Enter ngrok authtoken now, or leave blank to skip:" true)"
-    NGROK_AUTHTOKEN_VALUE="${entered_value}"
-  fi
-
-  if [[ -n "${NGROK_BASIC_AUTH_VALUE}" ]]; then
-    if ! prompt_yes_no "Use configured ngrok Basic Auth ($(mask_secret "${NGROK_BASIC_AUTH_VALUE}"))?" "yes"; then
-      NGROK_BASIC_AUTH_VALUE=""
-    fi
-  fi
-
-  while [[ -z "${NGROK_BASIC_AUTH_VALUE}" ]]; do
-    entered_value="$(prompt_value "Enter ngrok Basic Auth as user:pass, or leave blank to skip:" true)"
-    if [[ -n "${entered_value}" ]]; then
-      NGROK_BASIC_AUTH_VALUE="${entered_value}"
-      break
-    fi
-
-    if prompt_yes_no "Start ngrok without Basic Auth? This is not the supported browser path." "no"; then
-      break
-    fi
-  done
-
-  if ((${#NGROK_EXTRA_ARGS[@]} == 0)); then
-    extra_args_input="$(prompt_value "Extra ngrok args (optional, space-separated, leave blank for none):")"
-    if [[ -n "${extra_args_input}" ]]; then
-      read -r -a NGROK_EXTRA_ARGS <<< "${extra_args_input}"
-    fi
-  fi
-}
-
-prepare_ngrok() {
-  if [[ "${INTERACTIVE}" == "true" ]]; then
-    configure_ngrok_interactive
-  fi
-
-  if [[ "${NGROK_REUSED_EXISTING}" == "true" ]]; then
-    return 0
-  fi
-
-  if [[ "${START_NGROK}" != "true" ]]; then
-    return 0
-  fi
-
-  require_command ngrok
-
-  if [[ -n "${NGROK_AUTHTOKEN_VALUE}" ]]; then
-    log "configuring ngrok authtoken for this environment"
-    ngrok config add-authtoken "${NGROK_AUTHTOKEN_VALUE}" >/dev/null
-  fi
-
-  if [[ "${INTERACTIVE}" != "true" && -z "${NGROK_BASIC_AUTH_VALUE}" ]]; then
-    fail "--with-ngrok requires NGROK_BASIC_AUTH or --ngrok-basic-auth; use --interactive if you want to decide at launch time"
   fi
 }
 
@@ -368,153 +161,6 @@ wait_for_http() {
   fail "timed out waiting for ${label} at ${url}"
 }
 
-get_ngrok_public_url() {
-  curl --silent --fail "${NGROK_API_URL}" | node -e '
-let input = "";
-process.stdin.on("data", (chunk) => {
-  input += chunk;
-});
-process.stdin.on("end", () => {
-  try {
-    const payload = JSON.parse(input);
-    const tunnels = Array.isArray(payload.tunnels) ? payload.tunnels : [];
-    const preferred =
-      tunnels.find((entry) => typeof entry.public_url === "string" && entry.public_url.startsWith("https://")) ??
-      tunnels.find((entry) => typeof entry.public_url === "string");
-    if (!preferred) {
-      process.exit(1);
-    }
-    process.stdout.write(preferred.public_url);
-  } catch {
-    process.exit(1);
-  }
-});
-'
-}
-
-get_ngrok_public_url_for_port() {
-  local port="$1"
-
-  curl --silent --fail "${NGROK_API_URL}" | node -e '
-const port = process.argv[1];
-let input = "";
-process.stdin.on("data", (chunk) => {
-  input += chunk;
-});
-process.stdin.on("end", () => {
-  try {
-    const payload = JSON.parse(input);
-    const tunnels = Array.isArray(payload.tunnels) ? payload.tunnels : [];
-    const candidates = tunnels.filter((entry) => {
-      if (typeof entry.public_url !== "string") {
-        return false;
-      }
-
-      const address = typeof entry.config?.addr === "string" ? entry.config.addr : "";
-      return address === port || address.endsWith(`:${port}`) || address.includes(`:${port}/`);
-    });
-    const preferred =
-      candidates.find((entry) => entry.public_url.startsWith("https://")) ??
-      candidates.find((entry) => typeof entry.public_url === "string");
-    if (!preferred) {
-      process.exit(1);
-    }
-    process.stdout.write(preferred.public_url);
-  } catch {
-    process.exit(1);
-  }
-});
-' "${port}"
-}
-
-get_configured_ngrok_url() {
-  local index=0
-  local arg=""
-
-  while (( index < ${#NGROK_EXTRA_ARGS[@]} )); do
-    arg="${NGROK_EXTRA_ARGS[${index}]}"
-
-    case "${arg}" in
-      --url=*)
-        printf '%s' "${arg#*=}"
-        return 0
-        ;;
-      --url)
-        index=$((index + 1))
-        if (( index < ${#NGROK_EXTRA_ARGS[@]} )); then
-          printf '%s' "${NGROK_EXTRA_ARGS[${index}]}"
-          return 0
-        fi
-        ;;
-    esac
-
-    index=$((index + 1))
-  done
-
-  return 1
-}
-
-probe_ngrok_url_online() {
-  local url="$1"
-  local status=""
-
-  status="$(curl --silent --output /dev/null --write-out "%{http_code}" --max-time 5 "${url}" || true)"
-  case "${status}" in
-    2*|3*|401|403)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
-prepare_existing_ngrok() {
-  local existing_url=""
-  local configured_url=""
-
-  if [[ "${START_NGROK}" != "true" ]]; then
-    return 0
-  fi
-
-  existing_url="$(get_ngrok_public_url_for_port "${NGROK_PORT}" 2>/dev/null || true)"
-  if [[ -n "${existing_url}" ]]; then
-    NGROK_PUBLIC_URL="${existing_url}"
-    NGROK_REUSED_EXISTING=true
-    log "reusing existing local ngrok tunnel for port ${NGROK_PORT}: ${NGROK_PUBLIC_URL}"
-    return 0
-  fi
-
-  configured_url="$(get_configured_ngrok_url || true)"
-  if [[ -n "${configured_url}" ]] && probe_ngrok_url_online "${configured_url}"; then
-    fail "ngrok endpoint is already online: ${configured_url}; stop the existing endpoint first, or add --ngrok-arg=--pooling-enabled when load balancing is intentional"
-  fi
-}
-
-wait_for_ngrok_url() {
-  local pid="$1"
-  local attempts=0
-  local url=""
-
-  while (( attempts < STARTUP_TIMEOUT_SECONDS )); do
-    if ! kill -0 "${pid}" 2>/dev/null; then
-      fail "ngrok exited before a public URL became available"
-    fi
-
-    url="$(get_ngrok_public_url 2>/dev/null || true)"
-    if [[ -n "${url}" ]]; then
-      NGROK_PUBLIC_URL="${url}"
-      log "ngrok is ready at ${NGROK_PUBLIC_URL}"
-      return 0
-    fi
-
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-
-  fail "timed out waiting for ngrok to publish a tunnel URL"
-}
-
 start_runtime() {
   log "starting codex-runtime on ${RUNTIME_HOST}:${RUNTIME_PORT}"
   (
@@ -545,26 +191,6 @@ start_frontend() {
   PIDS+=("$!")
 }
 
-start_ngrok() {
-  local command=(ngrok http "${NGROK_PORT}")
-
-  if [[ -n "${NGROK_BASIC_AUTH_VALUE}" ]]; then
-    command+=("--basic-auth=${NGROK_BASIC_AUTH_VALUE}")
-  fi
-
-  if ((${#NGROK_EXTRA_ARGS[@]} > 0)); then
-    command+=("${NGROK_EXTRA_ARGS[@]}")
-  fi
-
-  log "starting ngrok on port ${NGROK_PORT}"
-  (
-    cd "${REPO_ROOT}"
-    exec "${command[@]}"
-  ) > >(sed -u 's/^/[ngrok] /') 2> >(sed -u 's/^/[ngrok] /' >&2) &
-  PIDS+=("$!")
-  NGROK_STARTED_BY_LAUNCHER=true
-}
-
 trap cleanup EXIT INT TERM
 parse_args "$@"
 setup_logging
@@ -577,12 +203,8 @@ require_file "${FRONTEND_DIR}/package.json"
 require_file "${RUNTIME_DIR}/node_modules/.package-lock.json"
 require_file "${FRONTEND_DIR}/node_modules/.package-lock.json"
 require_command curl
-require_command node
 require_command npm
 require_command codex
-prepare_ngrok
-
-prepare_existing_ngrok
 
 mkdir -p "${WORKSPACE_ROOT}" "$(dirname "${DATABASE_PATH}")"
 
@@ -592,41 +214,11 @@ wait_for_http "http://127.0.0.1:${RUNTIME_PORT}/api/v1/workspaces" "codex-runtim
 start_frontend
 wait_for_http "http://127.0.0.1:${FRONTEND_PORT}/" "frontend-bff" "${PIDS[1]}"
 
-if [[ "${START_NGROK}" == "true" ]]; then
-  if [[ "${NGROK_REUSED_EXISTING}" != "true" ]]; then
-    start_ngrok
-    wait_for_ngrok_url "${PIDS[2]}"
-  fi
-fi
-
 log "local UI: http://127.0.0.1:${FRONTEND_PORT}/"
 log "runtime API: http://127.0.0.1:${RUNTIME_PORT}/api/v1/"
-if [[ "${INTERACTIVE}" == "true" ]]; then
-  log "launcher mode: interactive startup"
-else
-  log "launcher mode: non-interactive startup"
-fi
-if [[ "${START_NGROK}" == "true" ]]; then
-  log "ngrok browser entrypoint: ${NGROK_PUBLIC_URL}"
-  if [[ "${NGROK_REUSED_EXISTING}" == "true" ]]; then
-    log "ngrok launch: reused existing local tunnel"
-  else
-    log "ngrok launch: started by this launcher"
-  fi
-  if [[ -n "${NGROK_BASIC_AUTH_VALUE}" ]]; then
-    log "ngrok Basic Auth: enabled ($(mask_secret "${NGROK_BASIC_AUTH_VALUE}"))"
-  else
-    log "ngrok Basic Auth: disabled"
-  fi
-else
-  log 'for remote browser access, run separately: ngrok http 3000 --basic-auth="$NGROK_BASIC_AUTH"'
-  log "the launcher did not start ngrok in this run"
-fi
-if [[ "${NGROK_STARTED_BY_LAUNCHER}" == "true" ]]; then
-  log "press Ctrl-C to stop runtime, frontend, and ngrok"
-else
-  log "press Ctrl-C to stop runtime and frontend"
-fi
+log "browser-facing entrypoint inside the shared Tailscale namespace: http://127.0.0.1:${FRONTEND_PORT}/"
+log "remote browser access is provided separately by the Tailscale sidecar and Tailscale Serve"
+log "press Ctrl-C to stop runtime and frontend"
 
 wait -n "${PIDS[@]}"
 exit $?

--- a/scripts/stop-codex-webui.sh
+++ b/scripts/stop-codex-webui.sh
@@ -6,29 +6,18 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 RUNTIME_DIR="${REPO_ROOT}/apps/codex-runtime"
 FRONTEND_DIR="${REPO_ROOT}/apps/frontend-bff"
 
-RUNTIME_PORT="${CODEX_WEBUI_RUNTIME_PORT:-3001}"
-FRONTEND_PORT="${CODEX_WEBUI_FRONTEND_PORT:-3000}"
-NGROK_PORT="${CODEX_WEBUI_NGROK_PORT:-${FRONTEND_PORT}}"
-
 DRY_RUN=false
 FORCE=false
-STOP_NGROK=false
 
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/stop-codex-webui.sh [--with-ngrok] [--force] [--dry-run] [--help]
+  scripts/stop-codex-webui.sh [--force] [--dry-run] [--help]
 
 Options:
-  --with-ngrok  Also stop a local ngrok process for CODEX_WEBUI_NGROK_PORT
   --force       Send SIGKILL to processes that do not exit after SIGTERM
   --dry-run     Print matching processes without stopping them
   --help        Show this help text
-
-Environment:
-  CODEX_WEBUI_RUNTIME_PORT=<port>    Runtime port to target; default: 3001
-  CODEX_WEBUI_FRONTEND_PORT=<port>   Frontend port to target; default: 3000
-  CODEX_WEBUI_NGROK_PORT=<port>      ngrok port to target; default: frontend port
 EOF
 }
 
@@ -44,9 +33,6 @@ fail() {
 parse_args() {
   while (($# > 0)); do
     case "$1" in
-      --with-ngrok)
-        STOP_NGROK=true
-        ;;
       --force)
         FORCE=true
         ;;
@@ -123,27 +109,6 @@ find_app_processes() {
   done
 }
 
-find_ngrok_processes() {
-  local proc=""
-  local pid=""
-  local cmd=""
-
-  for proc in /proc/[0-9]*; do
-    [[ -d "${proc}" ]] || continue
-    pid="${proc##*/}"
-    [[ "${pid}" != "$$" && "${pid}" != "${BASHPID}" ]] || continue
-
-    cmd="$(read_cmdline "${pid}")"
-    [[ -n "${cmd}" ]] || continue
-
-    case "${cmd}" in
-      ngrok\ http\ "${NGROK_PORT}"*|*/ngrok\ http\ "${NGROK_PORT}"*)
-        add_pid "${pid}"
-        ;;
-    esac
-  done
-}
-
 print_matches() {
   local pid=""
   local cmd=""
@@ -188,10 +153,6 @@ PIDS=()
 
 parse_args "$@"
 find_app_processes
-
-if [[ "${STOP_NGROK}" == "true" ]]; then
-  find_ngrok_processes
-fi
 
 if (( ${#PIDS[@]} == 0 )); then
   log "no matching codex-webui processes found"

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-318-tailscale-sidecar](./archive/issue-318-tailscale-sidecar/README.md)
 - [issue-316-inline-status](./archive/issue-316-inline-status/README.md)
 - [issue-312-submit-feedback](./archive/issue-312-submit-feedback/README.md)
 - [issue-313-settings-dialog](./archive/issue-313-settings-dialog/README.md)

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-318-tailscale-sidecar](./issue-318-tailscale-sidecar/README.md)
 - [issue-218-feedback-recovery](./issue-218-feedback-recovery/README.md)
 - [issue-217-navigation-return-surface](./issue-217-navigation-return-surface/README.md)
 - [issue-216-timeline-chronology](./issue-216-timeline-chronology/README.md)

--- a/tasks/archive/issue-318-tailscale-sidecar/README.md
+++ b/tasks/archive/issue-318-tailscale-sidecar/README.md
@@ -1,0 +1,102 @@
+# Issue #318 Tailscale sidecar migration
+
+## Purpose
+
+Migrate the supported remote-browser access path from ngrok to a Tailscale Docker sidecar workflow while preserving the repo boundary that only `frontend-bff` is browser-facing and `codex-runtime` remains private.
+
+## Primary issue
+
+- [#318 Infra: migrate remote WebUI access from ngrok to Tailscale sidecar](https://github.com/tsukushibito/codex-webui/issues/318)
+
+## Source docs
+
+- `README.md`
+- `docs/README.md`
+- `tasks/README.md`
+- `docs/codex_webui_dev_container_onboarding.md`
+- `docs/requirements/codex_webui_mvp_requirements_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `docker-compose.yml`
+- `scripts/start-codex-webui.sh`
+- `scripts/stop-codex-webui.sh`
+- `scripts/doctor.sh`
+
+## Scope for this package
+
+- Replace maintained ngrok remote-browser guidance with Tailscale VPN / Tailscale Serve guidance.
+- Add or adjust Docker Compose sidecar configuration for `tailscale/tailscale`, persistent Tailscale state, and Serve config.
+- Update environment examples from `NGROK_*` to Tailscale auth/hostname/config variables.
+- Remove ngrok startup responsibility from the WebUI launcher and stop helper for the supported path.
+- Update doctor checks so the supported remote-browser prerequisite is Tailscale sidecar state, not ngrok credentials.
+- Keep live Docker/Tailscale verification as a user-run step and document the exact commands/evidence expected.
+
+## Exit criteria
+
+- `frontend-bff` remains the only browser-facing entrypoint in the documented Tailscale path.
+- `codex-runtime` is not directly exposed through the tailnet browser path.
+- Maintained docs no longer describe ngrok as the supported v0.9 remote-browser path.
+- Repo scripts and environment examples no longer require `NGROK_*` values for the supported path.
+- Docker/Tailscale verification steps are explicit and marked as user-run for this package.
+- Static validation and targeted shell syntax checks pass locally where they do not require live Tailscale networking.
+
+## Work plan
+
+1. Inspect existing ngrok references and decide which are source-of-truth versus archived history.
+2. Update Compose, environment examples, and launcher/doctor scripts for Tailscale sidecar operation.
+3. Update maintained docs and wiki index/log entries for the remote-browser path change.
+4. Add static checks for changed shell/YAML/documentation surfaces where available.
+5. Record user-run Docker/Tailscale validation instructions and any known unverified live-networking boundary.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-29T13-40-28Z-tailscale-migration/events.ndjson`
+- Static validation results:
+  - `git status --short --branch`
+    - result: modified files limited to the approved sprint slice plus the active task package directory
+  - `bash -n scripts/start-codex-webui.sh scripts/stop-codex-webui.sh scripts/doctor.sh`
+    - result: pass
+  - `docker compose --env-file .env.example config`
+    - result: pass; rendered `tailscale` sidecar, `dev` `network_mode: service:tailscale`, persistent Tailscale state volume, and no host port publication for frontend/runtime
+  - `rg -n "NGROK|ngrok|--with-ngrok|ngrok-basic-auth|ngrok-authtoken|CODEX_WEBUI_NGROK" README.md docs/codex_webui_dev_container_onboarding.md docs/requirements/codex_webui_mvp_requirements_v0_9.md docker-compose.yml Dockerfile scripts .env.example`
+    - result: no matches
+  - `rg -n "tailscale funnel|TS_FUNNEL|--funnel" docker-compose.yml Dockerfile scripts .env.example`
+    - result: no matches
+  - `rg -n "3001|CODEX_WEBUI_RUNTIME_PORT|codex-runtime" docs/codex_webui_dev_container_onboarding.md docker-compose.yml`
+    - result: three intentional onboarding matches for `apps/codex-runtime` dependency and test/build commands only; no `3001` or `CODEX_WEBUI_RUNTIME_PORT` matches
+- Pre-push validation re-run before merge:
+  - `bash -n scripts/start-codex-webui.sh scripts/stop-codex-webui.sh scripts/doctor.sh`
+    - result: pass
+  - `docker compose --env-file .env.example config`
+    - result: pass; rendered the `tailscale` sidecar, `dev` `network_mode: service:tailscale`, `TS_USERSPACE: "false"`, and no direct host port publication
+  - `rg -n "NGROK|ngrok|--with-ngrok|ngrok-basic-auth|ngrok-authtoken|CODEX_WEBUI_NGROK" README.md docs/codex_webui_dev_container_onboarding.md docs/requirements/codex_webui_mvp_requirements_v0_9.md docker-compose.yml Dockerfile scripts .env.example`
+    - result: no matches
+  - `rg -n "tailscale funnel|TS_FUNNEL|--funnel" docker-compose.yml Dockerfile scripts .env.example`
+    - result: no matches
+  - `rg -n "3001|CODEX_WEBUI_RUNTIME_PORT|codex-runtime" docs/codex_webui_dev_container_onboarding.md docker-compose.yml`
+    - result: three intentional onboarding matches for `apps/codex-runtime` dependency and test/build commands only; no `3001` or `CODEX_WEBUI_RUNTIME_PORT` matches
+- User-run live Docker/Tailscale verification: moved to follow-up issue #319.
+
+## Status / handoff notes
+
+- Active branch: `issue-318-tailscale-sidecar`
+- Active worktree: `.worktrees/issue-318-tailscale-sidecar`
+- User stated that live Docker/Tailscale verification will be tracked separately from this migration slice.
+- Follow-up issue: [#319 Validation: verify Tailscale sidecar browser access](https://github.com/tsukushibito/codex-webui/issues/319)
+- Supported ngrok workflow replaced in Compose, env example, Dockerfile, launcher, stop helper, doctor, and maintained docs.
+- Local static validation completed; live Docker/Tailscale browser verification remains pending under #319.
+- Completion retrospective:
+  - Completion boundary: package archive and Issue #318 close after merge to `main`.
+  - Contract check: #318 scope is satisfied by repo configuration/docs/scripts plus explicit user-run validation commands; live environment proof is intentionally split to #319.
+  - What worked: sidecar topology, Serve boundary, and ngrok removal could be validated without requiring live tailnet access.
+  - Workflow problems: the original issue mixed implementation migration with live environment verification, which made completion ambiguous.
+  - Improvements to adopt: split infrastructure implementation and environment-specific live verification when the user owns the runtime environment.
+  - Skill candidates or skill updates: none.
+  - Follow-up updates: complete #319 after user-run Docker/Tailscale verification.
+
+## Archive conditions
+
+- Package exit criteria are satisfied.
+- Dedicated pre-push validation has passed.
+- Completion retrospective has been recorded.
+- Package is moved to `tasks/archive/issue-318-tailscale-sidecar/`.
+- Issue #318 `Execution` section links the archived package while PR/merge state remains visible until the work reaches `main`.


### PR DESCRIPTION
## Summary

- replace the supported ngrok remote-browser workflow with a Tailscale Docker sidecar plus Tailscale Serve path
- bind runtime/frontend services to localhost in the shared sidecar namespace and remove direct host port publication
- update env examples, launcher/stop/doctor scripts, maintained docs, and task archive notes
- split live Docker/Tailscale environment verification to follow-up issue #319

## Validation

- `git diff --check`
- `bash -n scripts/start-codex-webui.sh scripts/stop-codex-webui.sh scripts/doctor.sh`
- `docker compose --env-file .env.example config`
- `rg -n "NGROK|ngrok|--with-ngrok|ngrok-basic-auth|ngrok-authtoken|CODEX_WEBUI_NGROK" README.md docs/codex_webui_dev_container_onboarding.md docs/requirements/codex_webui_mvp_requirements_v0_9.md docker-compose.yml Dockerfile scripts .env.example` returned no matches
- `rg -n "tailscale funnel|TS_FUNNEL|--funnel" docker-compose.yml Dockerfile scripts .env.example` returned no matches
- `rg -n "3001|CODEX_WEBUI_RUNTIME_PORT|codex-runtime" docs/codex_webui_dev_container_onboarding.md docker-compose.yml` returned only intentional `apps/codex-runtime` dependency/test/build references

Closes #318.