### PR TITLE
docs: define runtime persistence boundary

### DIFF
--- a/apps/codex-runtime/README.md
+++ b/apps/codex-runtime/README.md
@@ -10,6 +10,38 @@ This directory contains the private runtime service for the MVP implementation d
 - Thread/request projections over the native `codex app-server` thread lifecycle
 - Recovery-oriented helper state that can be rebuilt from native facts plus minimal app-owned metadata
 
+## SQLite persistence boundary
+
+The v0.9 direction is native-first: SQLite rows are candidates, helper metadata, and compatibility state for the WebUI, not proof of native thread existence, readability, sendability, status, or transcript truth. A DB-only `sessions` row must not prove that a native thread still exists or can be resumed. Persisted `messages` rows and full `session_events` history must not be treated as the authoritative native transcript or event history.
+
+Current table classification in [`src/db/schema.ts`](./src/db/schema.ts):
+
+- `workspaces`: WebUI-owned canonical data. This is app-owned workspace metadata and local directory identity.
+- `workspace_session_mappings`: WebUI-owned canonical index data. This maps local workspaces to native thread IDs, but the mapping is still an app-owned lookup and not proof that the native thread currently exists.
+- `thread_input_requests`: short-lived helper and idempotency metadata. This binds the first accepted workspace input to a generated thread ID so retries do not create duplicate native threads.
+- `sessions`: mixed table. Retain only helper metadata such as workspace association, created/updated timestamps, `app_session_overlay_state`, `current_turn_id`, `pending_assistant_message_id`, `active_approval_id`, and similar recovery/reconnect fields. Treat `title`, `status`, `started_at`, and `last_message_at` as duplicate native conversation state or compatibility cache that must eventually be read from native-backed facts instead of trusted from SQLite.
+- `messages`: duplicate native conversation state plus compatibility cache. Keep only bounded idempotency/helper fields such as the user-input replay key (`client_message_id`) while moving transcript and history reads to native-backed sources.
+- `approvals`: retained bounded request-helper retention. This is the allowed app-owned helper surface for request detail completion, request lifecycle tracking, and recovery-oriented lookup/index data when native payloads are incomplete.
+- `session_events`: rebuildable cache plus duplicate native conversation state. Keep only minimal ordering/reconnect helper metadata if needed; persisted full event payload history is not authoritative transcript/history.
+
+Retained SQLite surface for this runtime:
+
+- WebUI-owned workspace metadata in `workspaces`
+- Workspace-to-native-thread mapping and lookup/index data in `workspace_session_mappings`
+- First-input idempotency records in `thread_input_requests`
+- Bounded request-helper retention in `approvals`
+- Recovery, reconnect, and ordering helper metadata such as `app_session_overlay_state`, `current_turn_id`, `pending_assistant_message_id`, `active_approval_id`, and event sequence helpers
+- UI-only helper state where present, as long as it is explicitly treated as overlay/helper state rather than native truth
+
+Current DB-only paths that follow-up issues must replace or constrain:
+
+- Issue `#323`: replace DB-only thread/session summary reads in [`src/domain/threads/thread-service.ts`](./src/domain/threads/thread-service.ts) and [`src/domain/sessions/session-service.ts`](./src/domain/sessions/session-service.ts). This includes `listThreads`, `getThread`, `getThreadView`, `openThread`, `listSessions`, `getSession`, and the route surfaces in [`src/routes/threads.ts`](./src/routes/threads.ts) and [`src/routes/workspaces.ts`](./src/routes/workspaces.ts) that currently project `sessions` rows as if they were native-backed thread facts.
+- Issue `#323`: replace DB-only transcript/history reads in [`src/domain/sessions/session-service.ts`](./src/domain/sessions/session-service.ts) `listMessages` and in [`src/domain/threads/thread-service.ts`](./src/domain/threads/thread-service.ts) `listThreadFeed` / `listTimeline`. The affected read surfaces are `/api/v1/threads/:threadId/feed` and `/api/v1/threads/:threadId/timeline`, and any session message/event route that still reads `messages` or `session_events` as transcript truth.
+- Issue `#324`: constrain persistence writes in [`src/domain/threads/thread-input-orchestrator.ts`](./src/domain/threads/thread-input-orchestrator.ts), [`src/domain/sessions/session-event-publisher.ts`](./src/domain/sessions/session-event-publisher.ts), and [`src/domain/sessions/session-service.ts`](./src/domain/sessions/session-service.ts) so `sessions`, `messages`, and `session_events` retain only bounded helper state, idempotency data, and recovery metadata instead of growing into the canonical native conversation record.
+- Issue `#324`: keep [`src/domain/workspaces/workspace-registry.ts`](./src/domain/workspaces/workspace-registry.ts) and [`src/domain/threads/thread-request-persistence.ts`](./src/domain/threads/thread-request-persistence.ts) inside the retained surface. `workspaces`, `workspace_session_mappings`, `thread_input_requests`, and bounded `approvals` retention remain valid app-owned persistence; `approvals` should stay a helper/detail store rather than become proof of full native event history.
+
+Until those follow-ups land, read every `sessions`, `messages`, and `session_events` row as a local helper candidate. Native app-server reads and native-backed projections are the source for thread existence, sendability, current status, and transcript/history truth.
+
 Use the maintained v0.9 internal API spec and roadmap for current behavior boundaries:
 
 - `../../docs/specs/codex_webui_internal_api_v0_9.md`

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-322-persistence-boundary](./archive/issue-322-persistence-boundary/README.md)
 - [issue-318-tailscale-sidecar](./archive/issue-318-tailscale-sidecar/README.md)
 - [issue-316-inline-status](./archive/issue-316-inline-status/README.md)
 - [issue-312-submit-feedback](./archive/issue-312-submit-feedback/README.md)

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-322-persistence-boundary](./issue-322-persistence-boundary/README.md)
 - [issue-318-tailscale-sidecar](./issue-318-tailscale-sidecar/README.md)
 - [issue-218-feedback-recovery](./issue-218-feedback-recovery/README.md)
 - [issue-217-navigation-return-surface](./issue-217-navigation-return-surface/README.md)

--- a/tasks/archive/issue-322-persistence-boundary/README.md
+++ b/tasks/archive/issue-322-persistence-boundary/README.md
@@ -1,0 +1,61 @@
+# Runtime Native-First Persistence Boundary
+
+## Purpose
+
+- Define the minimal SQLite persistence boundary for native-first runtime behavior so `codex-runtime` stops treating DB projections as canonical thread state.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/322
+
+## Source docs
+
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `docs/codex_webui_mvp_roadmap_v0_1.md`
+- `apps/codex-runtime/README.md`
+
+## Scope for this package
+
+- Audit `apps/codex-runtime/src/db/schema.ts` and runtime domain reads/writes.
+- Classify runtime SQLite data as WebUI-owned canonical data, short-lived helper/idempotency metadata, rebuildable cache, or duplicate native conversation state.
+- Document the retained DB surface near the runtime implementation or maintained source docs.
+- Identify code paths that currently use DB-only `sessions`, `messages`, or full `session_events` as canonical thread/status/transcript state.
+
+## Exit criteria
+
+- Runtime has a clear documented persistence boundary for Issue #321.
+- The implementation plan names which data remains persisted and which native-backed reads must replace DB reads.
+- The audit is specific enough to drive #323 and #324 without re-triage.
+- Targeted runtime validation passes for touched files.
+
+## Work plan
+
+- Review v0.9 native-first source docs and current runtime schema/service boundaries.
+- Add or update concise maintained documentation for the retained DB surface.
+- Add implementation-facing notes where they reduce ambiguity for #323/#324.
+- Run targeted formatting/check validation for the touched app or docs.
+
+## Artifacts / evidence
+
+- Planned evidence: `apps/codex-runtime` targeted validation output in handoff notes.
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: Added the runtime SQLite persistence boundary to `apps/codex-runtime/README.md`.
+- Sprint evidence: planner selected a README-only slice; worker changed only `apps/codex-runtime/README.md`; evaluator verdict was `approved`.
+- Pre-push validation: passed with `npm run check`, `npm test`, `npm run build`, and `git diff --check` in the active worktree.
+- Completion retrospective:
+  - Completion boundary: package archive only; Issue close still requires PR publication, merge to `main`, parent checkout sync, and worktree cleanup.
+  - Contract check: package scope satisfied by the README classification covering all current runtime SQLite tables and #323/#324 handoff mapping.
+  - What worked: splitting #321 first kept this slice small enough to validate cleanly.
+  - Workflow problems: the initial worktree dependency symlink was wrong and blocked validation until corrected.
+  - Improvements to adopt: verify shared `node_modules` symlink targets immediately after worktree creation when package setup creates them.
+  - Skill candidates or updates: consider tightening `codex-webui-work-packages` symlink guidance if this path issue repeats.
+  - Follow-up updates: continue with PR publication and completion tracking for #322, then resume #321 through #323/#324.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate has passed, and handoff notes are updated.


### PR DESCRIPTION
## Summary

- document the runtime SQLite persistence boundary for native-first thread state
- classify all current runtime SQLite tables by retained/helper/duplicate status
- archive the Issue #322 work package and update task indexes

## Validation

- `cd apps/codex-runtime && npm run check`
- `cd apps/codex-runtime && npm test`
- `cd apps/codex-runtime && npm run build`
- `git diff --check`

Closes #322