### PR TITLE
fix: gate thread reads on native reachability

### DIFF
--- a/apps/codex-runtime/src/domain/threads/native-thread-reachability.ts
+++ b/apps/codex-runtime/src/domain/threads/native-thread-reachability.ts
@@ -1,0 +1,42 @@
+import type { RuntimeError } from "../../errors.js";
+
+function serializeErrorSignal(value: unknown) {
+  if (typeof value === "string") {
+    return value.toLowerCase();
+  }
+
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  try {
+    return JSON.stringify(value).toLowerCase();
+  } catch {
+    return String(value).toLowerCase();
+  }
+}
+
+export function indicatesMissingNativeThread(error: RuntimeError) {
+  if (
+    error.code !== "app_server_request_failed" ||
+    !["turn/start", "thread/resume"].includes(String(error.details?.rpc_method ?? ""))
+  ) {
+    return false;
+  }
+
+  const messageSignal = error.message.toLowerCase();
+  const codeSignal = serializeErrorSignal(error.details?.rpc_error_code);
+  const dataSignal = serializeErrorSignal(error.details?.rpc_error_data);
+  const signals = [messageSignal, codeSignal, dataSignal];
+
+  return (
+    signals.some((signal) => signal.includes("thread_not_found")) ||
+    (signals.some((signal) => signal.includes("not_found")) &&
+      signals.some((signal) => signal.includes("thread") || signal.includes("session"))) ||
+    signals.some(
+      (signal) =>
+        (signal.includes("thread") || signal.includes("session")) &&
+        (signal.includes("not found") || signal.includes("missing")),
+    )
+  );
+}

--- a/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
@@ -8,6 +8,7 @@ import { RuntimeError } from "../../errors.js";
 import type { NativeSessionGateway } from "../sessions/native-session-gateway.js";
 import type { SessionEventPublisher } from "../sessions/session-event-publisher.js";
 import type { MessageProjection } from "../sessions/types.js";
+import { indicatesMissingNativeThread } from "./native-thread-reachability.js";
 
 type TurnStartConvergenceGateway = NativeSessionGateway & {
   acknowledgeTurnStartPersisted?: (input: { sessionId: string; turnId: string }) => Promise<void>;
@@ -19,47 +20,6 @@ function generateMessageId() {
 
 function firstRow<T>(rows: T[]) {
   return rows[0] ?? null;
-}
-
-function serializeErrorSignal(value: unknown) {
-  if (typeof value === "string") {
-    return value.toLowerCase();
-  }
-
-  if (value === null || value === undefined) {
-    return "";
-  }
-
-  try {
-    return JSON.stringify(value).toLowerCase();
-  } catch {
-    return String(value).toLowerCase();
-  }
-}
-
-function indicatesMissingNativeThread(error: RuntimeError) {
-  if (
-    error.code !== "app_server_request_failed" ||
-    !["turn/start", "thread/resume"].includes(String(error.details?.rpc_method ?? ""))
-  ) {
-    return false;
-  }
-
-  const messageSignal = error.message.toLowerCase();
-  const codeSignal = serializeErrorSignal(error.details?.rpc_error_code);
-  const dataSignal = serializeErrorSignal(error.details?.rpc_error_data);
-  const signals = [messageSignal, codeSignal, dataSignal];
-
-  return (
-    signals.some((signal) => signal.includes("thread_not_found")) ||
-    (signals.some((signal) => signal.includes("not_found")) &&
-      signals.some((signal) => signal.includes("thread") || signal.includes("session"))) ||
-    signals.some(
-      (signal) =>
-        (signal.includes("thread") || signal.includes("session")) &&
-        (signal.includes("not found") || signal.includes("missing")),
-    )
-  );
 }
 
 export class ThreadInputOrchestrator {

--- a/apps/codex-runtime/src/domain/threads/thread-service.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-service.ts
@@ -21,6 +21,7 @@ import type {
 } from "../sessions/types.js";
 import type { WorkspaceFilesystem } from "../workspaces/workspace-filesystem.js";
 import type { WorkspaceRegistry } from "../workspaces/workspace-registry.js";
+import { indicatesMissingNativeThread } from "./native-thread-reachability.js";
 import { ThreadInputOrchestrator } from "./thread-input-orchestrator.js";
 import { buildThreadRequestHelperLifecycleState } from "./thread-request-helper-lifecycle.js";
 import {
@@ -301,8 +302,12 @@ export class ThreadService {
       .orderBy(desc(sessions.updatedAt), desc(sessions.sessionId))
       .all();
 
+    const reachableItems = await Promise.all(
+      items.map((item) => this.ensureThreadReadableCandidateReachability(item)),
+    );
+
     return {
-      items: items.map((item) => toThreadSummary(item)),
+      items: reachableItems.map((item) => toThreadSummary(item)),
       next_cursor: null,
       has_more: false,
     };
@@ -324,7 +329,8 @@ export class ThreadService {
       });
     }
 
-    return toThreadSummary(thread);
+    const reachableThread = await this.ensureThreadReadableCandidateReachability(thread);
+    return toThreadSummary(reachableThread);
   }
 
   async startThreadFromInput(
@@ -906,5 +912,53 @@ export class ThreadService {
         .where(eq(workspaces.workspaceId, thread.workspaceId))
         .run();
     })();
+  }
+
+  private async ensureThreadReadableCandidateReachability(thread: SessionRow) {
+    if (
+      thread.appSessionOverlayState === "recovery_pending" ||
+      thread.appSessionOverlayState !== "open" ||
+      thread.status !== "waiting_input"
+    ) {
+      return thread;
+    }
+
+    try {
+      await this.nativeSessionGateway.resumeSession({
+        sessionId: thread.sessionId,
+      });
+      return thread;
+    } catch (error) {
+      const runtimeError = asRuntimeError(error);
+      if (!runtimeError || !indicatesMissingNativeThread(runtimeError)) {
+        throw error;
+      }
+
+      const recoveryMarkedAt = this.now().toISOString();
+      this.database.sqlite.transaction(() => {
+        this.database.db
+          .update(sessions)
+          .set({
+            updatedAt: recoveryMarkedAt,
+            appSessionOverlayState: "recovery_pending",
+          })
+          .where(eq(sessions.sessionId, thread.sessionId))
+          .run();
+
+        this.database.db
+          .update(workspaces)
+          .set({
+            updatedAt: recoveryMarkedAt,
+          })
+          .where(eq(workspaces.workspaceId, thread.workspaceId))
+          .run();
+      })();
+
+      return {
+        ...thread,
+        updatedAt: recoveryMarkedAt,
+        appSessionOverlayState: "recovery_pending",
+      };
+    }
   }
 }

--- a/apps/codex-runtime/tests/fixtures/fake-codex-app-server.mjs
+++ b/apps/codex-runtime/tests/fixtures/fake-codex-app-server.mjs
@@ -6,6 +6,8 @@ let turnCounter = 1;
 let itemCounter = 1;
 const turnStartMode =
   process.argv.find((arg) => arg.startsWith("--turn-start-mode="))?.split("=")[1] ?? "normal";
+const resumeMode =
+  process.argv.find((arg) => arg.startsWith("--resume-mode="))?.split("=")[1] ?? "normal";
 const requireResumeBeforeTurn = process.argv.includes("--require-resume-before-turn");
 const loadedThreadIds = new Set();
 
@@ -67,6 +69,22 @@ lineReader.on("line", (line) => {
 
   if (method === "thread/resume") {
     const threadId = String(message.params?.threadId ?? "");
+    if (resumeMode === "missing") {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: "thread_not_found",
+          message: `thread ${threadId} is missing`,
+          data: {
+            threadId,
+            reason: "persisted thread missing after restart",
+          },
+        },
+      });
+      return;
+    }
+
     loadedThreadIds.add(threadId);
     send({
       jsonrpc: "2.0",

--- a/apps/codex-runtime/tests/thread-routes.test.ts
+++ b/apps/codex-runtime/tests/thread-routes.test.ts
@@ -79,6 +79,16 @@ class FailingSendNativeSessionGateway extends StubNativeSessionGateway {
   }
 }
 
+class FailingResumeNativeSessionGateway extends StubNativeSessionGateway {
+  override async resumeSession(input: { sessionId: string }): Promise<{ sessionId: string }> {
+    this.resumeSessions.push(input);
+    throw new RuntimeError(502, "app_server_request_failed", "resume request rejected", {
+      rpc_method: "thread/resume",
+      rpc_error_code: "invalid_state",
+    });
+  }
+}
+
 class MissingThreadNativeSessionGateway extends StubNativeSessionGateway {
   override async sendUserMessage(_input: {
     sessionId: string;
@@ -90,6 +100,20 @@ class MissingThreadNativeSessionGateway extends StubNativeSessionGateway {
       rpc_error_code: "not_found",
       rpc_error_data: {
         threadId: _input.sessionId,
+        reason: "persisted thread missing after restart",
+      },
+    });
+  }
+}
+
+class MissingThreadOnResumeNativeSessionGateway extends StubNativeSessionGateway {
+  override async resumeSession(input: { sessionId: string }): Promise<{ sessionId: string }> {
+    this.resumeSessions.push(input);
+    throw new RuntimeError(502, "app_server_request_failed", "thread not found in app server", {
+      rpc_method: "thread/resume",
+      rpc_error_code: "not_found",
+      rpc_error_data: {
+        threadId: input.sessionId,
         reason: "persisted thread missing after restart",
       },
     });
@@ -354,6 +378,81 @@ describe("thread routes", () => {
         },
       },
     });
+
+    await app.close();
+  });
+
+  it("surfaces non-missing native thread/resume failures on thread reads", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway: new FailingResumeNativeSessionGateway(),
+      },
+    });
+
+    database.db
+      .insert(workspaces)
+      .values({
+        workspaceId: "ws_alpha",
+        workspaceName: "alpha",
+        directoryName: "alpha",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:00:00.000Z",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: "thread_001",
+        workspaceId: "ws_alpha",
+        title: "Existing thread",
+        status: "waiting_input",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:01:00.000Z",
+        startedAt: "2026-04-09T00:00:00.000Z",
+        lastMessageAt: null,
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001",
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(response.json()).toEqual({
+      error: {
+        code: "app_server_request_failed",
+        message: "resume request rejected",
+        details: {
+          rpc_method: "thread/resume",
+          rpc_error_code: "invalid_state",
+        },
+      },
+    });
+
+    const persistedSession = database.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.sessionId, "thread_001"))
+      .get();
+    expect(persistedSession?.appSessionOverlayState).toBe("open");
 
     await app.close();
   });
@@ -1491,6 +1590,151 @@ describe("thread routes", () => {
     await app.close();
   });
 
+  it("marks stale db-only waiting-input threads recovery_pending on list/read/view when native resume reports missing", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    const nativeSessionGateway = new MissingThreadOnResumeNativeSessionGateway();
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    database.db
+      .insert(workspaces)
+      .values({
+        workspaceId: "ws_alpha",
+        workspaceName: "alpha",
+        directoryName: "alpha",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:00:00.000Z",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: "thread_001",
+        workspaceId: "ws_alpha",
+        title: "Recovered thread",
+        status: "waiting_input",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:01:00.000Z",
+        startedAt: "2026-04-09T00:00:00.000Z",
+        lastMessageAt: "2026-04-09T00:00:30.000Z",
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    const initialWorkspace = database.db
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.workspaceId, "ws_alpha"))
+      .get();
+    expect(initialWorkspace).not.toBeUndefined();
+
+    const threadResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001",
+    });
+    expect(threadResponse.statusCode).toBe(200);
+    expect(threadResponse.json()).toMatchObject({
+      thread_id: "thread_001",
+      derived_hints: {
+        accepting_user_input: false,
+        blocked_reason: "thread_recovery_pending",
+      },
+    });
+
+    const persistedSession = database.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.sessionId, "thread_001"))
+      .get();
+    expect(persistedSession).toMatchObject({
+      sessionId: "thread_001",
+      appSessionOverlayState: "recovery_pending",
+    });
+    expect(persistedSession?.updatedAt).not.toBe("2026-04-09T00:01:00.000Z");
+
+    const persistedWorkspace = database.db
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.workspaceId, "ws_alpha"))
+      .get();
+    expect(persistedWorkspace?.updatedAt).toBe(persistedSession?.updatedAt);
+
+    const viewResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001/view",
+    });
+    expect(viewResponse.statusCode).toBe(200);
+    expect(viewResponse.json()).toMatchObject({
+      thread: {
+        thread_id: "thread_001",
+        derived_hints: {
+          accepting_user_input: false,
+          blocked_reason: "thread_recovery_pending",
+        },
+      },
+    });
+
+    const listResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/workspaces/ws_alpha/threads",
+    });
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.json()).toMatchObject({
+      items: [
+        expect.objectContaining({
+          thread_id: "thread_001",
+          derived_hints: expect.objectContaining({
+            accepting_user_input: false,
+            blocked_reason: "thread_recovery_pending",
+          }),
+        }),
+      ],
+    });
+
+    expect(nativeSessionGateway.resumeSessions).toEqual([{ sessionId: "thread_001" }]);
+
+    const retryResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/threads/thread_001/inputs",
+      payload: {
+        client_request_id: "req_followup_missing_002",
+        content: "Retry after runtime restart",
+      },
+    });
+
+    expect(retryResponse.statusCode).toBe(409);
+    expect(retryResponse.json()).toMatchObject({
+      error: {
+        code: "thread_recovery_pending",
+        details: {
+          thread_id: "thread_001",
+        },
+      },
+    });
+    expect(nativeSessionGateway.sendUserMessages).toHaveLength(0);
+    expect(nativeSessionGateway.resumeSessions).toEqual([{ sessionId: "thread_001" }]);
+
+    await app.close();
+  });
+
   it("accepts existing-thread input even when another thread is currently active", async () => {
     const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
     const database = await createTempDatabase("thread-routes-db");
@@ -2275,6 +2519,79 @@ describe("thread routes", () => {
         ]),
       );
     });
+
+    await app.close();
+  });
+
+  it("maps real app-server thread/resume missing-thread errors to recovery_pending on thread reads", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+    await fs.mkdir(path.join(workspaceRoot, "alpha"), { recursive: true });
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: true,
+        appServerCommand: process.execPath,
+        appServerArgs: [
+          fileURLToPath(new URL("./fixtures/fake-codex-app-server.mjs", import.meta.url)),
+          "--resume-mode=missing",
+        ],
+      },
+      database,
+    });
+
+    database.db
+      .insert(workspaces)
+      .values({
+        workspaceId: "ws_alpha",
+        workspaceName: "alpha",
+        directoryName: "alpha",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:00:00.000Z",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: "thread_persisted_001",
+        workspaceId: "ws_alpha",
+        title: "Persisted thread",
+        status: "waiting_input",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:01:00.000Z",
+        startedAt: "2026-04-09T00:00:00.000Z",
+        lastMessageAt: "2026-04-09T00:00:30.000Z",
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_persisted_001",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      thread_id: "thread_persisted_001",
+      derived_hints: {
+        accepting_user_input: false,
+        blocked_reason: "thread_recovery_pending",
+      },
+    });
+
+    const persistedSession = database.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.sessionId, "thread_persisted_001"))
+      .get();
+    expect(persistedSession?.appSessionOverlayState).toBe("recovery_pending");
 
     await app.close();
   });

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-323-native-reachability](./archive/issue-323-native-reachability/README.md)
 - [issue-322-persistence-boundary](./archive/issue-322-persistence-boundary/README.md)
 - [issue-318-tailscale-sidecar](./archive/issue-318-tailscale-sidecar/README.md)
 - [issue-316-inline-status](./archive/issue-316-inline-status/README.md)

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-323-native-reachability](./issue-323-native-reachability/README.md)
 - [issue-322-persistence-boundary](./issue-322-persistence-boundary/README.md)
 - [issue-318-tailscale-sidecar](./issue-318-tailscale-sidecar/README.md)
 - [issue-218-feedback-recovery](./issue-218-feedback-recovery/README.md)

--- a/tasks/archive/issue-323-native-reachability/README.md
+++ b/tasks/archive/issue-323-native-reachability/README.md
@@ -1,0 +1,60 @@
+# Runtime Native Thread Reachability
+
+## Purpose
+
+- Make runtime thread read/list/view sendability depend on native app-server reachability instead of SQLite-only `sessions` rows.
+
+## Primary issue
+
+- Issue: https://github.com/tsukushibito/codex-webui/issues/323
+
+## Source docs
+
+- `docs/specs/codex_webui_common_spec_v0_9.md`
+- `docs/specs/codex_webui_app_server_contract_matrix_v0_9.md`
+- `docs/specs/codex_webui_internal_api_v0_9.md`
+- `apps/codex-runtime/README.md`
+- `apps/codex-runtime/src/domain/threads/thread-service.ts`
+- `apps/codex-runtime/src/domain/app-server/codex-app-server-gateway.ts`
+
+## Scope for this package
+
+- Add or extend the native app-server gateway boundary needed to read, resume, or check a thread by native `thread.id`.
+- Update runtime thread list/read/view paths so SQLite mappings are candidates, not proof of native thread existence.
+- Ensure missing-rollout or native thread-not-found responses become explicit WebUI unavailable/not-found/recovery states.
+- Cover stale DB-only threads that exist in SQLite but cannot be loaded by app-server.
+
+## Exit criteria
+
+- `GET /api/v1/workspaces/{workspace_id}/threads`, `GET /api/v1/threads/{thread_id}`, and `GET /api/v1/threads/{thread_id}/view` do not present stale DB-only threads as normally sendable.
+- Runtime tests cover SQLite-containing/native-missing thread read or view behavior.
+- Behavior remains aligned with #321 and the runtime README persistence boundary.
+
+## Work plan
+
+- Inspect native gateway capabilities and fake app-server fixtures.
+- Plan and implement one bounded native reachability slice through the sprint workflow.
+- Run targeted runtime tests and app-local validation.
+
+## Artifacts / evidence
+
+- Planned evidence: runtime test output and app-local validation in handoff notes.
+
+## Status / handoff notes
+
+- Status: `locally complete`
+- Notes: Implemented read-side native reachability checks for waiting-input/open thread summaries.
+- Sprint evidence: planner selected the read-side reachability gate; worker updated runtime thread service/input helper/tests; evaluator verdict was `approved`.
+- Pre-push validation: passed with `npm run check`, focused `tests/thread-routes.test.ts`, `npm run build`, and `git diff --check`.
+- Completion retrospective:
+  - Completion boundary: package archive only; Issue close still requires PR publication, merge to `main`, parent checkout sync, and worktree cleanup.
+  - Contract check: package scope satisfied by list/read/view stale DB-only coverage and missing `thread/resume` recovery mapping.
+  - What worked: reusing the shared missing-native-thread classifier kept input and read-side behavior aligned.
+  - Workflow problems: none beyond the still-active GitHub GraphQL quota pressure during broad Project reads.
+  - Improvements to adopt: keep using narrow Issue/API reads while Project GraphQL quota is constrained.
+  - Skill candidates or updates: none.
+  - Follow-up updates: continue with PR publication and completion tracking for #323, then resume #321 through #324.
+
+## Archive conditions
+
+- Archive this package when the exit criteria are met, the dedicated pre-push validation gate has passed, and handoff notes are updated.


### PR DESCRIPTION
## Summary

- add a shared missing-native-thread classifier for runtime thread operations
- gate waiting-input/open thread reads on native `thread/resume` reachability
- mark stale DB-only threads `recovery_pending` and add route coverage for list/read/view and follow-up input
- archive the Issue #323 work package and update task indexes

## Validation

- `cd apps/codex-runtime && npm run check`
- `cd apps/codex-runtime && node ./node_modules/vitest/vitest.mjs run tests/thread-routes.test.ts`
- `cd apps/codex-runtime && npm run build`
- `git diff --check`

Closes #323