### PR TITLE
fix(runtime): quarantine stale transcript cache

### DIFF
--- a/apps/codex-runtime/src/domain/sessions/session-service.ts
+++ b/apps/codex-runtime/src/domain/sessions/session-service.ts
@@ -574,7 +574,14 @@ export class SessionService {
       sort?: "created_at" | "-created_at";
     } = {},
   ) {
-    await this.getSession(sessionId);
+    const session = await this.getSession(sessionId);
+    if (session.app_session_overlay_state === "recovery_pending") {
+      return {
+        items: [],
+        next_cursor: null,
+        has_more: false,
+      };
+    }
 
     const limit = Math.max(1, Math.min(options.limit ?? 100, 100));
     const sort = options.sort ?? "created_at";
@@ -605,7 +612,14 @@ export class SessionService {
       sort?: "occurred_at" | "-occurred_at";
     } = {},
   ) {
-    await this.getSession(sessionId);
+    const session = await this.getSession(sessionId);
+    if (session.app_session_overlay_state === "recovery_pending") {
+      return {
+        items: [],
+        next_cursor: null,
+        has_more: false,
+      };
+    }
 
     const limit = Math.max(1, Math.min(options.limit ?? 100, 100));
     const sort = options.sort ?? "occurred_at";

--- a/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-input-orchestrator.ts
@@ -37,6 +37,34 @@ export class ThreadInputOrchestrator {
       content: string;
     },
   ): Promise<MessageProjection> {
+    const session = firstRow(
+      this.database.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.sessionId, threadId))
+        .limit(1)
+        .all(),
+    );
+
+    if (!session) {
+      throw new RuntimeError(404, "session_not_found", "session was not found", {
+        session_id: threadId,
+      });
+    }
+
+    if (session.appSessionOverlayState === "recovery_pending") {
+      throw new RuntimeError(
+        409,
+        "thread_recovery_pending",
+        "thread requires recovery before accepting input",
+        {
+          thread_id: threadId,
+          status: session.status,
+          app_session_overlay_state: session.appSessionOverlayState,
+        },
+      );
+    }
+
     const existingMessage = firstRow(
       this.database.db
         .select()
@@ -72,34 +100,6 @@ export class ThreadInputOrchestrator {
         created_at: existingMessage.createdAt,
         source_item_type: existingMessage.sourceItemType as MessageProjection["source_item_type"],
       };
-    }
-
-    const session = firstRow(
-      this.database.db
-        .select()
-        .from(sessions)
-        .where(eq(sessions.sessionId, threadId))
-        .limit(1)
-        .all(),
-    );
-
-    if (!session) {
-      throw new RuntimeError(404, "session_not_found", "session was not found", {
-        session_id: threadId,
-      });
-    }
-
-    if (session.appSessionOverlayState === "recovery_pending") {
-      throw new RuntimeError(
-        409,
-        "thread_recovery_pending",
-        "thread requires recovery before accepting input",
-        {
-          thread_id: threadId,
-          status: session.status,
-          app_session_overlay_state: session.appSessionOverlayState,
-        },
-      );
     }
 
     if (session.status !== "waiting_input") {

--- a/apps/codex-runtime/src/domain/threads/thread-service.ts
+++ b/apps/codex-runtime/src/domain/threads/thread-service.ts
@@ -443,7 +443,15 @@ export class ThreadService {
   }
 
   async listThreadFeed(threadId: string) {
-    await this.getThread(threadId);
+    const thread = await this.getThread(threadId);
+    if (thread.derived_hints.blocked_reason === "thread_recovery_pending") {
+      return {
+        items: [],
+        next_cursor: null,
+        has_more: false,
+      };
+    }
+
     const events = this.database.db
       .select()
       .from(sessionEvents)
@@ -466,7 +474,15 @@ export class ThreadService {
   }
 
   async listTimeline(threadId: string) {
-    await this.getThread(threadId);
+    const thread = await this.getThread(threadId);
+    if (thread.derived_hints.blocked_reason === "thread_recovery_pending") {
+      return {
+        items: [],
+        next_cursor: null,
+        has_more: false,
+      };
+    }
+
     const events = this.database.db
       .select()
       .from(sessionEvents)

--- a/apps/codex-runtime/tests/thread-routes.test.ts
+++ b/apps/codex-runtime/tests/thread-routes.test.ts
@@ -1735,6 +1735,182 @@ describe("thread routes", () => {
     await app.close();
   });
 
+  it("quarantines persisted transcript cache rows after native reachability marks a thread recovery_pending", async () => {
+    const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
+    const database = await createTempDatabase("thread-routes-db");
+    const nativeSessionGateway = new MissingThreadOnResumeNativeSessionGateway();
+    cleanupPaths.push(workspaceRoot, path.dirname(database.sqlite.name));
+
+    const app = await buildApp({
+      config: {
+        workspaceRoot,
+        databasePath: database.sqlite.name,
+        appServerBridgeEnabled: false,
+        appServerCommand: process.execPath,
+        appServerArgs: ["-e", "process.exit(0)"],
+      },
+      database,
+      services: {
+        nativeSessionGateway,
+      },
+    });
+
+    database.db
+      .insert(workspaces)
+      .values({
+        workspaceId: "ws_alpha",
+        workspaceName: "alpha",
+        directoryName: "alpha",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:00:00.000Z",
+      })
+      .run();
+
+    database.db
+      .insert(sessions)
+      .values({
+        sessionId: "thread_001",
+        workspaceId: "ws_alpha",
+        title: "Recovered thread",
+        status: "waiting_input",
+        createdAt: "2026-04-09T00:00:00.000Z",
+        updatedAt: "2026-04-09T00:01:00.000Z",
+        startedAt: "2026-04-09T00:00:00.000Z",
+        lastMessageAt: "2026-04-09T00:00:30.000Z",
+        activeApprovalId: null,
+        currentTurnId: null,
+        pendingAssistantMessageId: null,
+        appSessionOverlayState: "open",
+      })
+      .run();
+
+    database.db
+      .insert(messages)
+      .values({
+        messageId: "msg_user_cached_001",
+        sessionId: "thread_001",
+        role: "user",
+        content: "Retry after runtime restart",
+        createdAt: "2026-04-09T00:00:30.000Z",
+        sourceItemType: "user_message",
+        clientMessageId: "req_followup_missing_cached_001",
+      })
+      .run();
+
+    database.db
+      .insert(sessionEvents)
+      .values({
+        eventId: "evt_cached_001",
+        sessionId: "thread_001",
+        eventType: "message.user",
+        sequence: 1,
+        occurredAt: "2026-04-09T00:00:30.000Z",
+        payload: JSON.stringify({
+          message_id: "msg_user_cached_001",
+          content: "Retry after runtime restart",
+        }),
+        nativeEventName: null,
+      })
+      .run();
+
+    const threadResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001",
+    });
+
+    expect(threadResponse.statusCode).toBe(200);
+    expect(threadResponse.json()).toMatchObject({
+      thread_id: "thread_001",
+      derived_hints: {
+        accepting_user_input: false,
+        blocked_reason: "thread_recovery_pending",
+      },
+    });
+
+    const messagesBeforeRetry = database.db
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, "thread_001"))
+      .all();
+    const eventsBeforeRetry = database.db
+      .select()
+      .from(sessionEvents)
+      .where(eq(sessionEvents.sessionId, "thread_001"))
+      .all();
+
+    const retryResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/threads/thread_001/inputs",
+      payload: {
+        client_request_id: "req_followup_missing_cached_001",
+        content: "Retry after runtime restart",
+      },
+    });
+
+    expect(retryResponse.statusCode).toBe(409);
+    expect(retryResponse.json()).toMatchObject({
+      error: {
+        code: "thread_recovery_pending",
+        details: {
+          thread_id: "thread_001",
+        },
+      },
+    });
+    expect(retryResponse.json()).not.toHaveProperty("accepted_input");
+    expect(nativeSessionGateway.sendUserMessages).toHaveLength(0);
+    expect(nativeSessionGateway.resumeSessions).toEqual([{ sessionId: "thread_001" }]);
+
+    const messagesAfterRetry = database.db
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, "thread_001"))
+      .all();
+    const eventsAfterRetry = database.db
+      .select()
+      .from(sessionEvents)
+      .where(eq(sessionEvents.sessionId, "thread_001"))
+      .all();
+    expect(messagesAfterRetry).toEqual(messagesBeforeRetry);
+    expect(eventsAfterRetry).toEqual(eventsBeforeRetry);
+
+    const feedResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001/feed",
+    });
+    expect(feedResponse.statusCode).toBe(200);
+    expect(feedResponse.json()).toEqual({
+      items: [],
+      next_cursor: null,
+      has_more: false,
+    });
+
+    const timelineResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/threads/thread_001/timeline",
+    });
+    expect(timelineResponse.statusCode).toBe(200);
+    expect(timelineResponse.json()).toEqual({
+      items: [],
+      next_cursor: null,
+      has_more: false,
+    });
+
+    await expect(app.runtimeServices.sessionService.listMessages("thread_001")).resolves.toEqual({
+      items: [],
+      next_cursor: null,
+      has_more: false,
+    });
+    await expect(
+      app.runtimeServices.sessionService.listSessionEvents("thread_001"),
+    ).resolves.toEqual({
+      items: [],
+      next_cursor: null,
+      has_more: false,
+    });
+
+    await app.close();
+  });
+
   it("accepts existing-thread input even when another thread is currently active", async () => {
     const workspaceRoot = await createTempWorkspaceRoot("thread-routes-root");
     const database = await createTempDatabase("thread-routes-db");

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Archived Task Packages
 
+- [issue-324-thin-transcript-persistence](./archive/issue-324-thin-transcript-persistence/README.md)
 - [issue-323-native-reachability](./archive/issue-323-native-reachability/README.md)
 - [issue-322-persistence-boundary](./archive/issue-322-persistence-boundary/README.md)
 - [issue-318-tailscale-sidecar](./archive/issue-318-tailscale-sidecar/README.md)

--- a/tasks/archive/README.md
+++ b/tasks/archive/README.md
@@ -12,6 +12,7 @@ Archive entries preserve the work instructions that were used at the time, while
 
 ## Packages
 
+- [issue-324-thin-transcript-persistence](./issue-324-thin-transcript-persistence/README.md)
 - [issue-323-native-reachability](./issue-323-native-reachability/README.md)
 - [issue-322-persistence-boundary](./issue-322-persistence-boundary/README.md)
 - [issue-318-tailscale-sidecar](./issue-318-tailscale-sidecar/README.md)

--- a/tasks/archive/issue-324-thin-transcript-persistence/README.md
+++ b/tasks/archive/issue-324-thin-transcript-persistence/README.md
@@ -1,0 +1,53 @@
+# Issue 324 thin transcript persistence
+
+## Purpose
+
+- Execute the final child slice for Issue #321 by thinning DB-owned transcript and timeline persistence so `codex app-server` remains the source of truth for native conversation state.
+
+## Primary issue
+
+- Issue: [#324 Runtime: thin duplicate transcript and timeline persistence](https://github.com/tsukushibito/codex-webui/issues/324)
+
+## Source docs
+
+- [Runtime README SQLite persistence boundary](../../../apps/codex-runtime/README.md#sqlite-persistence-boundary)
+- [Internal API spec v0.9](../../../docs/specs/codex_webui_internal_api_v0_9.md)
+- [MVP roadmap v0.1](../../../docs/codex_webui_mvp_roadmap_v0_1.md)
+
+## Scope for this package
+
+- Constrain follow-up persistence so stale DB-only transcript rows cannot make a thread sendable.
+- Stop treating persisted `messages` and `session_events` rows as authoritative native transcript or timeline truth on thread read surfaces.
+- Keep bounded helper metadata, idempotency records, and compatibility cache behavior explicit.
+- Extend runtime tests around missing native rollout behavior and DB transcript rows.
+
+## Exit criteria
+
+- Follow-up input for a missing native rollout is blocked before appending new DB transcript data.
+- Thread feed and timeline behavior does not use DB-only transcript rows as proof of valid native history.
+- Runtime tests cover the missing-rollout path with pre-existing DB `messages` / `session_events` rows.
+- `apps/codex-runtime` validation passes for `npm run check`, targeted runtime tests, and `npm run build`.
+
+## Work plan
+
+- Inspect the current #323 reachability helper and thread feed/timeline read paths.
+- Plan a bounded implementation slice with `codex-webui-sprint-cycle`.
+- Apply the implementation in this worktree only.
+- Run targeted and standard runtime validations.
+- Use the pre-push validation gate before archive, push, PR, and merge handoff.
+
+## Artifacts / evidence
+
+- Orchestration log: `artifacts/execution_orchestrator/runs/2026-04-30T13-42-56Z-issue-321-close/events.ndjson`
+- Sprint validation: `npm run check`, `npm test -- tests/thread-routes.test.ts`, and `npm run build` passed in `apps/codex-runtime`.
+- Pre-push validation: `npm run check`, `npm test -- tests/thread-routes.test.ts`, `npm run build`, and `git diff --check` passed.
+
+## Status / handoff notes
+
+- Status: `archived`
+- Notes: Implemented DB transcript cache quarantine for recovery-pending native threads. Follow-up input now checks recovery state before replaying cached `messages.client_message_id` rows, thread feed/timeline return empty pages for `thread_recovery_pending`, and session message/event list helpers return empty pages for `app_session_overlay_state=recovery_pending`.
+- Completion retrospective: package archive boundary is satisfied. The Issue remains open until the branch is committed, published, merged to `main`, the worktree is removed, and GitHub tracking is finalized. No new repo skill is needed; the only workflow issue was temporary GitHub GraphQL rate limiting for Project field updates, already logged in the orchestration run.
+
+## Archive conditions
+
+- Archived after the exit criteria were met, pre-push validation passed, and retrospective notes were recorded.


### PR DESCRIPTION
## Summary

- quarantine recovery-pending thread transcript cache reads so stale DB `messages` / `session_events` rows are not exposed as native history
- block follow-up idempotency replay after native reachability marks a thread `recovery_pending`
- archive the Issue #324 task package

## Root cause

SQLite transcript and event cache rows could still shape read and idempotency behavior after native app-server reachability had already proven the thread missing. That let DB-owned projections look more authoritative than the native app-server state.

## Validation

- `cd apps/codex-runtime && npm run check`
- `cd apps/codex-runtime && npm test -- tests/thread-routes.test.ts`
- `cd apps/codex-runtime && npm run build`
- `git diff --check`

Closes #324
